### PR TITLE
Compiler V1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +369,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +419,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,7 +449,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -482,6 +516,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-common"
@@ -695,6 +754,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,9 +919,26 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -872,6 +954,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hexplay"
@@ -975,6 +1063,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1001,7 +1098,7 @@ dependencies = [
 [[package]]
 name = "kaspa-addresses"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#d0c5196a906b921fffe2aacdc7c113b60ef153c6"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#c9f21362b70b12fee07992c13240bc5b0cf4cef0"
 dependencies = [
  "borsh",
  "js-sys",
@@ -1016,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "kaspa-consensus-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#d0c5196a906b921fffe2aacdc7c113b60ef153c6"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#c9f21362b70b12fee07992c13240bc5b0cf4cef0"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1053,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "kaspa-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#d0c5196a906b921fffe2aacdc7c113b60ef153c6"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#c9f21362b70b12fee07992c13240bc5b0cf4cef0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1084,7 +1181,7 @@ dependencies = [
 [[package]]
 name = "kaspa-hashes"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#d0c5196a906b921fffe2aacdc7c113b60ef153c6"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#c9f21362b70b12fee07992c13240bc5b0cf4cef0"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -1104,7 +1201,7 @@ dependencies = [
 [[package]]
 name = "kaspa-math"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#d0c5196a906b921fffe2aacdc7c113b60ef153c6"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#c9f21362b70b12fee07992c13240bc5b0cf4cef0"
 dependencies = [
  "borsh",
  "faster-hex",
@@ -1124,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "kaspa-merkle"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#d0c5196a906b921fffe2aacdc7c113b60ef153c6"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#c9f21362b70b12fee07992c13240bc5b0cf4cef0"
 dependencies = [
  "kaspa-hashes",
 ]
@@ -1132,7 +1229,7 @@ dependencies = [
 [[package]]
 name = "kaspa-muhash"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#d0c5196a906b921fffe2aacdc7c113b60ef153c6"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#c9f21362b70b12fee07992c13240bc5b0cf4cef0"
 dependencies = [
  "kaspa-hashes",
  "kaspa-math",
@@ -1143,7 +1240,7 @@ dependencies = [
 [[package]]
 name = "kaspa-txscript"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#d0c5196a906b921fffe2aacdc7c113b60ef153c6"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#c9f21362b70b12fee07992c13240bc5b0cf4cef0"
 dependencies = [
  "blake2b_simd",
  "borsh",
@@ -1175,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "kaspa-txscript-errors"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#d0c5196a906b921fffe2aacdc7c113b60ef153c6"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#c9f21362b70b12fee07992c13240bc5b0cf4cef0"
 dependencies = [
  "kaspa-hashes",
  "secp256k1",
@@ -1185,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "kaspa-utils"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#d0c5196a906b921fffe2aacdc7c113b60ef153c6"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#c9f21362b70b12fee07992c13240bc5b0cf4cef0"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -1215,7 +1312,7 @@ dependencies = [
 [[package]]
 name = "kaspa-wasm-core"
 version = "1.1.0-rc.2"
-source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#d0c5196a906b921fffe2aacdc7c113b60ef153c6"
+source = "git+https://github.com/kaspanet/rusty-kaspa?branch=covpp-reset1#c9f21362b70b12fee07992c13240bc5b0cf4cef0"
 dependencies = [
  "faster-hex",
  "hexplay",
@@ -1352,6 +1449,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1513,18 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1577,6 +1695,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pest"
@@ -1786,6 +1910,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "itertools 0.12.1",
+ "lru",
+ "paste",
+ "stability",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2063,6 +2207,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2078,12 +2233,15 @@ version = "0.1.0"
 dependencies = [
  "blake2b_simd",
  "chrono",
+ "crossterm",
+ "hex",
  "kaspa-consensus-core",
  "kaspa-txscript",
  "kaspa-txscript-errors",
  "pest",
  "pest_derive",
  "rand 0.8.5",
+ "ratatui",
  "secp256k1",
  "serde",
  "serde_json",
@@ -2109,6 +2267,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "stability"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2344,6 +2540,23 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 authors = ["Kaspa developers"]
 repository = ""
 rust-version = "1.85.0"
+include = ["**/*"]
 
 [workspace.dependencies]
 kaspa-consensus-core = { git = "https://github.com/kaspanet/rusty-kaspa", branch = "covpp-reset1" }

--- a/README.md
+++ b/README.md
@@ -1,23 +1,503 @@
+# SilverScript
 
-# Silverscript
+SilverScript is a CashScript-inspired smart contract language that compiles to Kaspa script bytecode. It provides a readable, type-safe DSL for writing covenant-style contracts without dealing with raw opcodes.
 
-Silverscript is a CashScript-inspired language and compiler that targets Kaspa script.
+**Why it exists**
 
-## Workspace
+- Type-safe contract development with explicit types
+- Familiar, C-like syntax
+- Built-in transaction introspection for covenants
+- Compile-time validation and error reporting
 
-This repository is a Rust workspace. The main crate is `silverscript-lang`.
+## Project Structure
 
-## Build & Test
+This is a Rust workspace with the following components:
 
-```bash
-cargo test -p silverscript-lang
+```
+silverscript/
+├── silverscript-lang/          # Language, compiler, debugger
+│   ├── src/
+│   │   ├── ast.rs              # AST definitions
+│   │   ├── parser.rs           # Parser interface (Pest)
+│   │   ├── silverscript.pest   # Grammar definition
+│   │   ├── compiler.rs         # Bytecode compiler
+│   │   ├── debug/              # Debug engine/session
+│   │   └── bin/                # Debugger binaries
+│   └── tests/                  # Parser/compiler/debugger tests
+├── covenants/
+│   └── sdk/                    # Kaspa covenant SDK utilities
+└── analysis/                   # Design notes
 ```
 
-## Layout
+## How It Works
 
-- `silverscript-lang/` – compiler, parser, and tests
-- `silverscript-lang/tests/examples/` – example contracts (`.silver`)
+The Silverscript compiler follows a standard multi-stage compilation pipeline:
+
+### 1. Parsing (Parser → AST)
+
+The compiler uses [Pest](https://pest.rs/) parser generator with a PEG grammar defined in `silverscript.pest`:
+
+```
+Source Code (.sil) → Parser → Pairs (parse tree) → AST
+```
+
+**Location:** `silverscript-lang/src/parser.rs` and `silverscript-lang/src/silverscript.pest`
+
+The grammar defines:
+- Contract structure (pragma, parameters, functions)
+- Type system (int, bool, bytes, pubkey, sig, datasig)
+- Expressions with operator precedence
+- Statements (require, if/else, for loops, assignments)
+- Transaction introspection syntax
+
+### 2. Abstract Syntax Tree (AST)
+
+The parse tree is converted to a typed AST representation:
+
+**Location:** `silverscript-lang/src/ast.rs`
+
+**Key AST Types:**
+- `ContractAst` - Represents the entire contract (name, parameters, functions, constants)
+- `FunctionAst` - Function definitions with typed parameters and statement body
+- `Statement` - Control flow and validation statements
+- `Expr` - Type-safe expressions (literals, operations, function calls, introspection)
+
+### 3. Compilation (AST → Bytecode)
+
+The compiler translates AST nodes to Kaspa script opcodes:
+
+**Location:** `silverscript-lang/src/compiler.rs`
+
+**Compilation Process:**
+
+1. **Parameter Binding**: Contract constructor parameters are bound to provided values
+2. **Constant Evaluation**: Compile-time constants are evaluated
+3. **Code Generation**: Statements and expressions are converted to opcodes
+4. **Stack Management**: The compiler tracks stack depth for proper execution
+5. **Introspection**: Transaction field access compiles to covenant opcodes
+
+**Key Functions:**
+- `compile_contract()` - Main entry point, parses and compiles source
+- `compile_contract_ast()` - Compiles AST to bytecode
+- `compile_statement()` - Generates opcodes for each statement type
+- `compile_expression()` - Handles expression evaluation on the stack
+
+**Compilation Options:**
+```rust
+CompileOptions {
+    covenants_enabled: bool,    // Enable transaction introspection
+    without_selector: bool,     // Omit function selector for single-function contracts
+    record_debug_spans: bool,   // Record source spans for debugging (optional)
+}
+```
+
+### 4. Output
+
+The compiler produces:
+```rust
+CompiledContract {
+    contract_name: String,      // Name of the contract
+    script: Vec<u8>,            // Executable bytecode (includes dispatcher unless without_selector)
+    ast: ContractAst,           // Parsed AST
+    abi: FunctionAbi,           // Function input types for building sigscripts
+    without_selector: bool,     // Whether selector dispatch was omitted
+    debug_info: Option<DebugInfo>, // Optional statement spans + variable updates
+}
+```
+
+This bytecode can be used as:
+- Locking scripts in Kaspa transaction outputs
+- Spending conditions that must be satisfied to unlock funds
+- Covenant constraints on how funds can be spent
+
+## Debugger
+
+The debugger runs compiled bytecode in a debug session that tracks the current program counter and source spans. When `record_debug_spans` is enabled, the compiler emits debug metadata so the debugger can reconstruct variable values even though the VM only has a stack.
+
+At a glance:
+
+- **Compile time**: record `DebugVariableUpdate`, `DebugParamMapping`, and `DebugMapping` tied to bytecode offsets.
+- **Debug time**: select the latest update for each variable at the current PC and evaluate the stored AST expression tree.
+
+This bridges source-level variables to a stack-based VM and enables stepping, breakpoints, and variable inspection.
+
+## Language Features
+
+### Contract Structure
+
+Every Silverscript file starts with a pragma and defines a single contract:
+
+```silverscript
+pragma silverscript ^0.1.0;
+
+contract ContractName(type1 param1, type2 param2) {
+    // Constants (compile-time evaluated)
+    int constant MAX_VALUE = 1000;
+
+    // Functions
+    function functionName(type3 arg1) {
+        // Contract logic
+    }
+}
+```
+
+### Type System
+
+**Primitive Types:**
+- `int` - 64-bit signed integers
+- `bool` - Boolean values (true/false)
+- `string` - String literals
+- `bytes`, `bytes4`, `bytes20`, etc. - Fixed or variable length byte arrays
+- `pubkey` - Public keys (33 bytes)
+- `sig` - ECDSA signatures
+- `datasig` - Data signatures for oracle messages
+
+### Operators
+
+**Arithmetic:** `+`, `-`, `*`, `/`, `%`
+**Comparison:** `==`, `!=`, `<`, `>`, `<=`, `>=`
+**Logical:** `&&`, `||`, `!`
+**Bitwise:** `&`, `|`, `^`
+
+### Control Flow
+
+```silverscript
+// If-else
+if (condition) {
+    // ...
+} else {
+    // ...
+}
+
+// For loops
+for (i, 0, 10) {
+    // Loop body
+}
+```
+
+### Require Statements
+
+Validation is done through `require()` statements. If the condition fails, the script fails:
+
+```silverscript
+require(checkSig(sig, pubkey));
+require(tx.time >= minBlock, "Timelock not expired");
+```
+
+### Transaction Introspection
+
+Access transaction data during script execution:
+
+```silverscript
+// Transaction-level data
+tx.version
+tx.locktime
+tx.time
+tx.inputs.length
+tx.outputs.length
+
+// Input inspection
+tx.inputs[0].value
+tx.inputs[i].lockingBytecode
+tx.inputs[i].outpointTransactionHash
+tx.inputs[i].sequenceNumber
+
+// Output inspection
+tx.outputs[0].value
+tx.outputs[i].lockingBytecode
+tx.outputs[i].tokenCategory
+tx.outputs[i].tokenAmount
+
+// Contract introspection
+this.activeInputIndex
+this.activeBytecode
+this.age
+```
+
+### Built-in Functions
+
+```silverscript
+// Cryptographic
+checkSig(sig, pubkey)           // Verify signature
+checkDataSig(sig, msg, pubkey)  // Verify data signature
+blake2b(data)                   // Hash function
+
+// Byte manipulation
+data.length                     // Get byte length
+data.reverse()                  // Reverse bytes
+data.split(index)              // Split at index
+data.slice(start, end)         // Extract substring
+
+// Type conversion
+int(bytes)                     // Convert bytes to integer
+bytes(int)                     // Convert integer to bytes
+```
+
+### Functions (Inlining + Returns)
+
+Silverscript supports calling user-defined functions. Calls are inlined at compile-time (the compiler currently enforces that a function may only call earlier-defined functions).
+
+Return values require an explicit return signature and a `return(...)` statement:
+
+```silverscript
+contract Math() {
+    function addMul(int a, int b) : (int, int) {
+        return(a + b, a * b);
+    }
+
+    function main() {
+        (int sum, int prod) = addMul(2, 3);
+        require(sum == 5);
+        require(prod == 6);
+    }
+}
+```
+
+### Arrays
+
+Dynamic arrays are supported for element types with known sizes (e.g. `int[]`, `byte[]`, `bytes20[]`). Key operations:
+
+- `arr.push(x)` appends an element
+- `arr.length` yields the element count
+- `arr[i]` indexes an element
+
+Example (end-to-end covered by tests):
+
+```silverscript
+contract Sum() {
+    int constant MAX_ARRAY_SIZE = 5;
+
+    function sumArray(int[] arr) : (int) {
+        require(arr.length <= MAX_ARRAY_SIZE);
+        int sum = 0;
+        for (i, 0, MAX_ARRAY_SIZE) {
+            if (i < arr.length) {
+                sum = sum + arr[i];
+            }
+        }
+        return(sum);
+    }
+
+    function main() {
+        int[] x;
+        x.push(1);
+        x.push(2);
+        x.push(3);
+        (int total) = sumArray(x);
+        require(total == 6);
+    }
+}
+```
+
+### Units and Literals
+
+```silverscript
+// Amount units
+1 satoshis, 1 sats
+1 bitcoin
+
+// Time units
+30 seconds
+60 minutes
+24 hours
+7 days
+
+// Hex literals
+0xdeadbeef
+
+// Date literals
+date("2024-12-31")
+```
+
+## Getting Started
+
+### Prerequisites
+
+- Rust 1.85.0 or later
+- Cargo (comes with Rust)
+
+### Building
+
+```bash
+cargo build --release
+```
+
+### Running Tests
+
+```bash
+# Test the entire workspace
+cargo test
+
+# Test only the language compiler
+cargo test -p silverscript-lang
+
+# Run a specific test
+cargo test -p silverscript-lang parser_tests
+```
+
+### Compiling a Contract
+
+```rust
+use silverscript_lang::{compiler::compile_contract, ast::Expr, compiler::CompileOptions};
+
+let source = r#"
+    pragma silverscript ^0.1.0;
+
+    contract P2PKH(bytes20 pkh) {
+        function spend(pubkey pk, sig s) {
+            require(blake2b(pk) == pkh);
+            require(checkSig(s, pk));
+        }
+    }
+"#;
+
+// Provide constructor arguments
+let pkh = vec![0u8; 20]; // Example public key hash
+let constructor_args = vec![Expr::Bytes(pkh)];
+
+// Compile with default options
+let compiled = compile_contract(source, &constructor_args, CompileOptions::default())?;
+
+// Use the bytecode
+let script_bytes = compiled.script;
+```
+
+## Example Contracts
+
+### P2PKH (Pay-to-Public-Key-Hash)
+
+Basic signature check contract:
+
+```silverscript
+pragma silverscript ^0.1.0;
+
+contract P2PKH(bytes20 pkh) {
+    function spend(pubkey pk, sig s) {
+        require(blake2b(pk) == pkh);
+        require(checkSig(s, pk));
+    }
+}
+```
+
+**Location:** `silverscript-lang/tests/examples/p2pkh.sil`
+
+### HODL Vault
+
+Time and price oracle-based release contract:
+
+```silverscript
+pragma silverscript ^0.1.0;
+
+contract HodlVault(
+    pubkey ownerPk,
+    pubkey oraclePk,
+    int minBlock,
+    int priceTarget
+) {
+    function spend(sig ownerSig, datasig oracleSig, bytes oracleMessage) {
+        // Parse oracle message
+        bytes4 blockHeightBin, bytes4 priceBin = oracleMessage.split(4);
+        int blockHeight = int(blockHeightBin);
+        int price = int(priceBin);
+
+        // Validate conditions
+        require(blockHeight >= minBlock);
+        require(tx.time >= blockHeight);
+        require(price >= priceTarget);
+
+        // Verify signatures
+        require(checkDataSig(oracleSig, oracleMessage, oraclePk));
+        require(checkSig(ownerSig, ownerPk));
+    }
+}
+```
+
+**Location:** `silverscript-lang/tests/examples/hodl_vault.sil`
+
+### More Examples
+
+The `silverscript-lang/tests/examples/` directory contains many more examples:
+
+- **announcement.sil** - On-chain data announcement
+- **covenant_escrow.sil** - Multi-party escrow with arbitration
+- **covenant_mecenas.sil** - Recurring payment covenant
+- **transfer_with_timeout.sil** - Time-bounded transfer
+- **token.sil** - Token covenant example
+
+## Development
+
+### Project Dependencies
+
+**Core Dependencies:**
+- `pest` - Parser generator
+- `kaspa-txscript` - Kaspa script opcodes and execution
+- `kaspa-consensus-core` - Kaspa consensus primitives
+- `secp256k1` - Cryptographic operations
+- `blake2b_simd` - Blake2b hashing
+
+**Source:** Dependencies are pulled from the `rusty-kaspa` repository, branch `covpp-reset1`.
+
+### Code Organization
+
+**Parser (`parser.rs`):**
+- Thin wrapper around Pest parser
+- Exposes `parse_source_file()` and `parse_expression()`
+
+**AST (`ast.rs`):**
+- Defines all AST node types
+- Implements parsing from Pest pairs to AST
+- Includes `Serialize`/`Deserialize` for JSON export
+
+**Compiler (`compiler.rs`):**
+- Core compilation logic
+- Stack-based code generation
+- Error types and validation
+- Handles covenant introspection opcodes
+
+### Testing
+
+The test suite includes:
+
+- **parser_tests.rs** - Parsing validation
+- **compiler_tests.rs** - Compilation correctness
+- **examples_tests.rs** - All example contracts compile successfully
+- **ast_json_tests.rs** - AST serialization tests
+
+### Contributing
+
+When working on the compiler:
+
+1. Add test cases for new features
+2. Update the grammar in `silverscript.pest`
+3. Extend AST types in `ast.rs`
+4. Implement compilation logic in `compiler.rs`
+5. Run `cargo clippy` to check for issues
+6. Run the full test suite
+
+### Formatting
+
+The project uses custom Rust formatting defined in `.rustfmt.toml`:
+
+```bash
+cargo fmt
+```
+
+### Linting
+
+```bash
+cargo clippy --all-targets --all-features
+```
 
 ## Notes
 
-- Kaspa dependencies are pulled from https://github.com/kaspanet/rusty-kaspa (branch `covpp-reset1`).
+- Kaspa dependencies are pulled from https://github.com/kaspanet/rusty-kaspa (branch `covpp-reset1`)
+- The language is inspired by CashScript but targets Kaspa's scripting system
+- Covenant support is experimental and requires `covenants_enabled: true`
+
+## License
+
+MIT License - See LICENSE file for details
+
+## Authors
+
+Kaspa developers

--- a/silverscript-lang/Cargo.toml
+++ b/silverscript-lang/Cargo.toml
@@ -23,6 +23,9 @@ rand.workspace = true
 secp256k1.workspace = true
 thiserror.workspace = true
 serde = { version = "1.0", features = ["derive"] }
+hex = "0.4"
+ratatui = "0.26"
+crossterm = "0.27"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/silverscript-lang/src/bin/sil-debug-tui.rs
+++ b/silverscript-lang/src/bin/sil-debug-tui.rs
@@ -1,0 +1,695 @@
+//! # SilverScript Debugger (sil-debug-tui)
+//!
+//! A TUI front-end for the SilverScript debug session engine.
+
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io::{self};
+use std::time::Duration;
+
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::terminal::{Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode};
+use crossterm::{cursor, execute};
+use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
+use kaspa_txscript::caches::Cache;
+use kaspa_txscript::{EngineCtx, EngineFlags};
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+
+use silverscript_lang::ast::{Expr, parse_contract_ast};
+use silverscript_lang::compiler::{CompileOptions, compile_contract};
+use silverscript_lang::debug::session::{DebugEngine, DebugSession};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Theme colors - elegant dark theme with accent colors
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ACCENT_PRIMARY: Color = Color::Rgb(138, 180, 248); // Soft blue
+const ACCENT_SECONDARY: Color = Color::Rgb(129, 199, 132); // Soft green
+const ACCENT_WARNING: Color = Color::Rgb(255, 183, 77); // Amber
+const ACCENT_ERROR: Color = Color::Rgb(239, 83, 80); // Red
+const ACCENT_MUTED: Color = Color::Rgb(144, 144, 144); // Gray
+const BORDER_COLOR: Color = Color::Rgb(68, 68, 68); // Dark gray border
+const BORDER_FOCUSED: Color = Color::Rgb(100, 100, 100); // Lighter border for focus
+const BG_HIGHLIGHT: Color = Color::Rgb(38, 38, 38); // Subtle highlight
+const TEXT_DIM: Color = Color::Rgb(120, 120, 120); // Dimmed text
+
+struct App<'a> {
+    session: DebugSession<'a>,
+    status: String,
+    status_type: StatusType,
+    done: bool,
+    contract_name: String,
+    function_name: String,
+    opcode_count: usize,
+    result: Option<RunResult>,
+    source_lines: Vec<String>,
+    selected_line: u32,
+    scroll_offset: usize,
+}
+
+#[derive(Clone, Copy)]
+enum StatusType {
+    Info,
+    Success,
+    Warning,
+}
+
+#[derive(Clone)]
+enum RunResult {
+    Success,
+    Error(String),
+}
+
+impl<'a> App<'a> {
+    fn new(session: DebugSession<'a>, contract_name: String, function_name: String, source: &str) -> Self {
+        let source_lines: Vec<String> = source.lines().map(|s| s.to_string()).collect();
+        let initial_line = session.current_span().map(|s| s.line).unwrap_or(1);
+        Self {
+            session,
+            status: "Ready — ↑/↓ select line, 'n' step, 'b' breakpoint, '?' help".to_string(),
+            status_type: StatusType::Info,
+            done: false,
+            contract_name,
+            function_name,
+            opcode_count: 0,
+            result: None,
+            source_lines,
+            selected_line: initial_line,
+            scroll_offset: 0,
+        }
+    }
+
+    fn set_status(&mut self, msg: impl Into<String>, status_type: StatusType) {
+        self.status = msg.into();
+        self.status_type = status_type;
+    }
+
+    fn set_result(&mut self, result: RunResult) {
+        self.result = Some(result);
+    }
+
+    fn select_up(&mut self) {
+        if self.selected_line > 1 {
+            self.selected_line -= 1;
+        }
+    }
+
+    fn select_down(&mut self) {
+        if (self.selected_line as usize) < self.source_lines.len() {
+            self.selected_line += 1;
+        }
+    }
+
+    fn sync_selection_to_active(&mut self) {
+        if let Some(span) = self.session.current_span() {
+            self.selected_line = span.line;
+        }
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        "Usage: sil-debug-tui <contract.sil> [--no-selector] [--function <name>] [--ctor-arg <value> ...] [--arg <value> ...]\n\n  --ctor-arg is typed by the contract constructor params.\n  --arg is typed by the selected function ABI.\n\nExamples:\n  # constructor (int x, int y), function hello(int a, int b)\n  sil-debug-tui if_statement.sil --function hello --ctor-arg 3 --ctor-arg 10 --arg 1 --arg 2\n\nValue formats:\n  int:        123 (or 0x7b)\n  bool:       true|false\n  string:     hello (shell quoting handles spaces)\n  bytes*:     0xdeadbeef\n"
+    );
+}
+
+fn parse_int_arg(raw: &str) -> Result<i64, Box<dyn Error>> {
+    let cleaned = raw.replace('_', "");
+    if let Some(hex) = cleaned.strip_prefix("0x").or_else(|| cleaned.strip_prefix("0X")) {
+        return Ok(i64::from_str_radix(hex, 16)?);
+    }
+    Ok(cleaned.parse::<i64>()?)
+}
+
+fn parse_hex_bytes(raw: &str) -> Result<Vec<u8>, Box<dyn Error>> {
+    let trimmed = raw.trim();
+    let hex_str = trimmed.strip_prefix("0x").or_else(|| trimmed.strip_prefix("0X")).unwrap_or(trimmed);
+    if hex_str.is_empty() {
+        return Ok(vec![]);
+    }
+    let normalized = if hex_str.len() % 2 != 0 { format!("0{hex_str}") } else { hex_str.to_string() };
+    Ok(hex::decode(normalized)?)
+}
+
+fn parse_typed_arg(type_name: &str, raw: &str) -> Result<Expr, Box<dyn Error>> {
+    match type_name {
+        "int" => Ok(Expr::Int(parse_int_arg(raw)?)),
+        "bool" => match raw {
+            "true" => Ok(Expr::Bool(true)),
+            "false" => Ok(Expr::Bool(false)),
+            _ => Err(format!("invalid bool '{raw}' (expected true/false)").into()),
+        },
+        "string" => Ok(Expr::String(raw.to_string())),
+        "bytes" | "byte" | "pubkey" | "sig" | "datasig" => Ok(Expr::Bytes(parse_hex_bytes(raw)?)),
+        other => {
+            if let Some(size) = other.strip_prefix("bytes").and_then(|v| v.parse::<usize>().ok()) {
+                let bytes = parse_hex_bytes(raw)?;
+                if bytes.len() != size {
+                    return Err(format!("{other} expects {size} bytes, got {}", bytes.len()).into());
+                }
+                Ok(Expr::Bytes(bytes))
+            } else {
+                Err(format!("unsupported arg type '{other}'").into())
+            }
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut script_path: Option<String> = None;
+    let mut without_selector = false;
+    let mut function_name: Option<String> = None;
+    let mut raw_ctor_args: Vec<String> = Vec::new();
+    let mut raw_args: Vec<String> = Vec::new();
+
+    let mut args = env::args().skip(1).peekable();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--no-selector" => without_selector = true,
+            "--function" | "-f" => {
+                function_name = args.next();
+                if function_name.is_none() {
+                    print_usage();
+                    return Err("missing function name".into());
+                }
+            }
+            "--ctor-arg" => {
+                let value = args.next();
+                if value.is_none() {
+                    print_usage();
+                    return Err("missing --ctor-arg value".into());
+                }
+                raw_ctor_args.push(value.expect("checked"));
+            }
+            "--arg" | "-a" => {
+                let value = args.next();
+                if value.is_none() {
+                    print_usage();
+                    return Err("missing --arg value".into());
+                }
+                raw_args.push(value.expect("checked"));
+            }
+            "-h" | "--help" => {
+                print_usage();
+                return Ok(());
+            }
+            _ => {
+                if script_path.is_some() {
+                    print_usage();
+                    return Err("unexpected extra argument".into());
+                }
+                script_path = Some(arg);
+            }
+        }
+    }
+
+    let script_path = match script_path {
+        Some(path) => path,
+        None => {
+            print_usage();
+            return Err("missing contract path".into());
+        }
+    };
+
+    let source = fs::read_to_string(&script_path)?;
+    let parsed_contract = parse_contract_ast(&source)?;
+
+    if parsed_contract.params.len() != raw_ctor_args.len() {
+        return Err(format!("constructor expects {} arguments, got {}", parsed_contract.params.len(), raw_ctor_args.len()).into());
+    }
+
+    let mut ctor_args = Vec::with_capacity(raw_ctor_args.len());
+    for (param, raw) in parsed_contract.params.iter().zip(raw_ctor_args.iter()) {
+        ctor_args.push(parse_typed_arg(&param.type_name, raw)?);
+    }
+
+    let compile_opts = CompileOptions { covenants_enabled: true, without_selector, record_debug_spans: true };
+    let compiled = compile_contract(&source, &ctor_args, compile_opts)?;
+    let debug_info = compiled.debug_info.clone();
+
+    let sig_cache = Cache::new(10_000);
+    let reused_values = SigHashReusedValuesUnsync::new();
+    let ctx = EngineCtx::new(&sig_cache).with_reused(&reused_values);
+
+    let flags = EngineFlags { covenants_enabled: compile_opts.covenants_enabled };
+    let engine = DebugEngine::new(ctx, flags);
+
+    let default_name = compiled.abi.first().map(|entry| entry.name.clone()).ok_or("contract has no functions")?;
+    let selected_name = function_name.unwrap_or(default_name);
+    let entry = compiled
+        .abi
+        .iter()
+        .find(|entry| entry.name == selected_name)
+        .ok_or_else(|| format!("function '{selected_name}' not found"))?;
+
+    if entry.inputs.len() != raw_args.len() {
+        return Err(format!("function '{selected_name}' expects {} arguments, got {}", entry.inputs.len(), raw_args.len()).into());
+    }
+
+    let mut typed_args = Vec::with_capacity(raw_args.len());
+    for (input, raw) in entry.inputs.iter().zip(raw_args.iter()) {
+        typed_args.push(parse_typed_arg(&input.type_name, raw)?);
+    }
+
+    let sigscript = compiled.build_sig_script(&selected_name, typed_args)?;
+    let mut session = DebugSession::full(&sigscript, &compiled.script, &source, debug_info, engine)?;
+    session.run_to_first_executed_statement()?;
+
+    // Extract contract name from filename
+    let contract_name = std::path::Path::new(&script_path).file_stem().and_then(|s| s.to_str()).unwrap_or("unknown").to_string();
+
+    run_tui(App::new(session, contract_name, selected_name, &source))
+}
+
+fn run_tui(mut app: App<'_>) -> Result<(), Box<dyn Error>> {
+    // Clean up terminal and enter TUI mode
+    let mut stdout = io::stdout();
+    execute!(stdout, cursor::Hide, Clear(ClearType::All), cursor::MoveTo(0, 0), EnterAlternateScreen)?;
+    enable_raw_mode()?;
+
+    let backend = ratatui::backend::CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    terminal.clear()?;
+
+    loop {
+        terminal.draw(|frame| draw_ui(frame, &mut app))?;
+
+        if event::poll(Duration::from_millis(100))? {
+            match event::read()? {
+                Event::Key(key) => {
+                    if handle_key(&mut app, key)? {
+                        break;
+                    }
+                }
+                Event::Resize(_, _) => {
+                    terminal.clear()?;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Restore terminal state cleanly
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen, cursor::Show, Clear(ClearType::All), cursor::MoveTo(0, 0))?;
+    terminal.show_cursor()?;
+
+    // Print exit message
+    println!("\n  {} Debugger session ended.\n", "✓");
+
+    Ok(())
+}
+
+fn handle_key(app: &mut App<'_>, key: KeyEvent) -> Result<bool, Box<dyn Error>> {
+    // Handle Ctrl+C for clean exit
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        return Ok(true);
+    }
+
+    match key.code {
+        KeyCode::Char('q') => {
+            return Ok(true);
+        }
+        KeyCode::Esc => {
+            return Ok(true);
+        }
+        KeyCode::Up => {
+            app.select_up();
+            app.set_status(format!("Line {} selected", app.selected_line), StatusType::Info);
+        }
+        KeyCode::Down => {
+            app.select_down();
+            app.set_status(format!("Line {} selected", app.selected_line), StatusType::Info);
+        }
+        KeyCode::Char('n') => {
+            if app.done {
+                app.set_status("Execution complete — press 'q' to quit", StatusType::Warning);
+            } else {
+                match app.session.step_statement() {
+                    Ok(Some(_)) => {
+                        app.opcode_count += 1;
+                        app.sync_selection_to_active();
+                        if let Some(span) = app.session.current_span() {
+                            app.set_status(format!("Stepped to line {} (statement)", span.line), StatusType::Success);
+                        } else {
+                            app.set_status("Stepped (statement)", StatusType::Success);
+                        }
+                    }
+                    Ok(None) => {
+                        app.set_status("✓ Execution complete", StatusType::Success);
+                        app.done = true;
+                        app.set_result(RunResult::Success);
+                    }
+                    Err(err) => {
+                        app.set_status("Execution failed", StatusType::Warning);
+                        app.done = true;
+                        app.set_result(RunResult::Error(err.to_string()));
+                    }
+                }
+            }
+        }
+        KeyCode::Char('s') => {
+            if app.done {
+                app.set_status("Execution complete — press 'q' to quit", StatusType::Warning);
+            } else {
+                match app.session.step_opcode() {
+                    Ok(Some(_)) => {
+                        app.opcode_count += 1;
+                        app.sync_selection_to_active();
+                        app.set_status("Stepped (opcode)", StatusType::Info);
+                    }
+                    Ok(None) => {
+                        app.set_status("✓ Execution complete", StatusType::Success);
+                        app.done = true;
+                        app.set_result(RunResult::Success);
+                    }
+                    Err(err) => {
+                        app.set_status("Execution failed", StatusType::Warning);
+                        app.done = true;
+                        app.set_result(RunResult::Error(err.to_string()));
+                    }
+                }
+            }
+        }
+        KeyCode::Char('c') => {
+            if app.done {
+                app.set_status("Execution complete — press 'q' to quit", StatusType::Warning);
+            } else {
+                match app.session.continue_to_breakpoint() {
+                    Ok(Some(_)) => {
+                        app.sync_selection_to_active();
+                        if let Some(span) = app.session.current_span() {
+                            app.set_status(format!("⏸ Paused at breakpoint (line {})", span.line), StatusType::Warning);
+                        } else {
+                            app.set_status("⏸ Paused at breakpoint", StatusType::Warning);
+                        }
+                    }
+                    Ok(None) => {
+                        app.set_status("✓ Execution complete", StatusType::Success);
+                        app.done = true;
+                        app.set_result(RunResult::Success);
+                    }
+                    Err(err) => {
+                        app.set_status("Execution failed", StatusType::Warning);
+                        app.done = true;
+                        app.set_result(RunResult::Error(err.to_string()));
+                    }
+                }
+            }
+        }
+        KeyCode::Char('b') => {
+            toggle_breakpoint(app, app.selected_line);
+        }
+        KeyCode::Char('?') | KeyCode::F(1) => {
+            app.set_status("↑/↓=select │ n=step │ s=opcode │ c=continue │ b=breakpoint │ q/Esc=quit", StatusType::Info);
+        }
+        _ => {}
+    }
+
+    Ok(false)
+}
+
+fn draw_ui(frame: &mut Frame<'_>, app: &mut App<'_>) {
+    let area = frame.size();
+
+    // Main layout: header, content, footer
+    let main_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3), // Header
+            Constraint::Min(10),   // Content
+            Constraint::Length(3), // Status bar
+        ])
+        .split(area);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Header
+    // ─────────────────────────────────────────────────────────────────────────
+    let header_text = vec![Line::from(vec![
+        Span::styled("  SilverScript Debugger", Style::default().fg(ACCENT_PRIMARY).bold()),
+        Span::styled("  │  ", Style::default().fg(BORDER_COLOR)),
+        Span::styled(&app.contract_name, Style::default().fg(ACCENT_SECONDARY)),
+        Span::styled("::", Style::default().fg(TEXT_DIM)),
+        Span::styled(&app.function_name, Style::default().fg(ACCENT_SECONDARY)),
+        Span::styled("()", Style::default().fg(TEXT_DIM)),
+    ])];
+
+    let header = Paragraph::new(header_text)
+        .block(
+            Block::default()
+                .borders(Borders::BOTTOM)
+                .border_style(Style::default().fg(BORDER_COLOR))
+                .border_set(symbols::border::PLAIN),
+        )
+        .alignment(Alignment::Left);
+    frame.render_widget(header, main_layout[0]);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Content area: Source (left) | Variables + Stack (right)
+    // ─────────────────────────────────────────────────────────────────────────
+    let content_layout = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
+        .split(main_layout[1]);
+
+    // Source panel
+    draw_source_panel(frame, app, content_layout[0]);
+
+    // Right panel: Variables + Stack
+    let right_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(content_layout[1]);
+
+    draw_variables_panel(frame, app, right_layout[0]);
+    draw_stack_panel(frame, app, right_layout[1]);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Status bar
+    // ─────────────────────────────────────────────────────────────────────────
+    draw_status_bar(frame, app, main_layout[2]);
+}
+
+fn styled_block(title: &str, focused: bool) -> Block<'_> {
+    let border_color = if focused { BORDER_FOCUSED } else { BORDER_COLOR };
+    Block::default()
+        .title(Span::styled(format!(" {title} "), Style::default().fg(ACCENT_PRIMARY).bold()))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color))
+        .border_set(symbols::border::ROUNDED)
+}
+
+const BG_SELECTION: Color = Color::Rgb(50, 50, 70); // Selection highlight (blue-ish)
+
+fn draw_source_panel(frame: &mut Frame<'_>, app: &mut App<'_>, area: Rect) {
+    let block = styled_block("Source", true);
+    let inner_area = block.inner(area);
+    let visible_lines = inner_area.height as usize;
+
+    // Get active line from session
+    let active_line = app.session.current_span().map(|s| s.line);
+    let breakpoints = app.session.breakpoints();
+
+    // Calculate scroll offset to keep selected line visible
+    let selected_idx = app.selected_line.saturating_sub(1) as usize;
+    if selected_idx < app.scroll_offset {
+        app.scroll_offset = selected_idx;
+    } else if selected_idx >= app.scroll_offset + visible_lines {
+        app.scroll_offset = selected_idx.saturating_sub(visible_lines - 1);
+    }
+
+    // Build all source lines
+    let source_lines: Vec<Line<'_>> = app
+        .source_lines
+        .iter()
+        .enumerate()
+        .skip(app.scroll_offset)
+        .take(visible_lines)
+        .map(|(idx, line_text)| {
+            let line_num = (idx + 1) as u32;
+            let is_breakpoint = breakpoints.contains(&line_num);
+            let is_active = active_line == Some(line_num);
+            let is_selected = app.selected_line == line_num;
+
+            // Line number
+            let line_num_span = Span::styled(format!("{:>4} ", line_num), Style::default().fg(TEXT_DIM));
+
+            // Breakpoint indicator
+            let bp_indicator = if is_breakpoint {
+                Span::styled("● ", Style::default().fg(ACCENT_ERROR))
+            } else {
+                Span::styled("  ", Style::default())
+            };
+
+            // Active line marker (execution pointer)
+            let marker = if is_active {
+                Span::styled("→ ", Style::default().fg(ACCENT_SECONDARY).bold())
+            } else {
+                Span::styled("  ", Style::default())
+            };
+
+            // Source text styling
+            let text_style = if is_active {
+                Style::default().fg(Color::White).bold()
+            } else if is_selected {
+                Style::default().fg(Color::White)
+            } else {
+                Style::default().fg(ACCENT_MUTED)
+            };
+            let text = Span::styled(line_text.clone(), text_style);
+
+            // Background: active takes precedence, then selected
+            let bg = if is_active {
+                BG_HIGHLIGHT
+            } else if is_selected {
+                BG_SELECTION
+            } else {
+                Color::Reset
+            };
+
+            Line::from(vec![line_num_span, bp_indicator, marker, text]).style(Style::default().bg(bg))
+        })
+        .collect();
+
+    let source = Paragraph::new(source_lines).block(block);
+    frame.render_widget(source, area);
+}
+
+fn draw_variables_panel(frame: &mut Frame<'_>, app: &mut App<'_>, area: Rect) {
+    let block = styled_block("Variables", false);
+
+    let vars = match app.session.list_variables() {
+        Ok(items) if items.is_empty() => {
+            vec![ListItem::new(Line::from(Span::styled("  No variables in scope", Style::default().fg(TEXT_DIM).italic())))]
+        }
+        Ok(items) => items
+            .into_iter()
+            .map(|var| {
+                let value = app.session.format_value(&var.type_name, &var.value);
+                let name = var.name.clone();
+                let type_name = var.type_name.clone();
+                ListItem::new(Line::from(vec![
+                    Span::styled("  ", Style::default()),
+                    Span::styled(name, Style::default().fg(ACCENT_SECONDARY)),
+                    Span::styled(": ", Style::default().fg(TEXT_DIM)),
+                    Span::styled(type_name, Style::default().fg(ACCENT_PRIMARY)),
+                    Span::styled(" = ", Style::default().fg(TEXT_DIM)),
+                    Span::styled(value, Style::default().fg(Color::White)),
+                ]))
+            })
+            .collect::<Vec<_>>(),
+        Err(err) if err.contains("No function context") => {
+            vec![
+                ListItem::new(Line::from(Span::styled("  ⚠ No function selected", Style::default().fg(ACCENT_WARNING)))),
+                ListItem::new(Line::from(Span::styled("  Use --function <name>", Style::default().fg(TEXT_DIM).italic()))),
+            ]
+        }
+        Err(err) => vec![ListItem::new(Line::from(Span::styled(format!("  Error: {err}"), Style::default().fg(ACCENT_ERROR))))],
+    };
+
+    let vars_list = List::new(vars).block(block);
+    frame.render_widget(vars_list, area);
+}
+
+fn draw_stack_panel(frame: &mut Frame<'_>, app: &mut App<'_>, area: Rect) {
+    let stack = app.session.stack();
+    let title = format!("Stack ({})", stack.len());
+    let block = styled_block(&title, false);
+
+    let stack_items: Vec<ListItem<'_>> = if stack.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled("  <empty>", Style::default().fg(TEXT_DIM).italic())))]
+    } else {
+        stack
+            .iter()
+            .enumerate()
+            .rev()
+            .map(|(i, item)| {
+                let index_style = if i == stack.len() - 1 {
+                    Style::default().fg(ACCENT_WARNING) // Top of stack
+                } else {
+                    Style::default().fg(TEXT_DIM)
+                };
+
+                ListItem::new(Line::from(vec![
+                    Span::styled(format!("  [{i}] "), index_style),
+                    Span::styled(item.to_string(), Style::default().fg(ACCENT_MUTED)),
+                ]))
+            })
+            .collect()
+    };
+
+    let stack_list = List::new(stack_items).block(block);
+    frame.render_widget(stack_list, area);
+}
+
+fn draw_status_bar(frame: &mut Frame<'_>, app: &mut App<'_>, area: Rect) {
+    let status_color = match app.status_type {
+        StatusType::Info => ACCENT_PRIMARY,
+        StatusType::Success => ACCENT_SECONDARY,
+        StatusType::Warning => ACCENT_WARNING,
+    };
+
+    let status_indicator = match app.status_type {
+        StatusType::Info => "ℹ",
+        StatusType::Success => "✓",
+        StatusType::Warning => "⚠",
+    };
+
+    let state_indicator = if app.done {
+        Span::styled(" DONE ", Style::default().fg(Color::Black).bg(ACCENT_SECONDARY).bold())
+    } else {
+        Span::styled(" RUNNING ", Style::default().fg(Color::Black).bg(ACCENT_PRIMARY).bold())
+    };
+
+    let result_span = render_result_span(app);
+
+    let status_line = Line::from(vec![
+        Span::styled("  ", Style::default()),
+        state_indicator,
+        Span::styled("  ", Style::default()),
+        Span::styled(status_indicator, Style::default().fg(status_color)),
+        Span::styled(" ", Style::default()),
+        Span::styled(&app.status, Style::default().fg(status_color)),
+        result_span,
+    ]);
+
+    let help_line = Line::from(vec![Span::styled(
+        "  ↑/↓ select  │  n step  │  s opcode  │  c continue  │  b breakpoint  │  ? help  │  q quit",
+        Style::default().fg(TEXT_DIM),
+    )]);
+
+    let status = Paragraph::new(vec![status_line, help_line]).block(
+        Block::default().borders(Borders::TOP).border_style(Style::default().fg(BORDER_COLOR)).border_set(symbols::border::PLAIN),
+    );
+    frame.render_widget(status, area);
+}
+
+fn toggle_breakpoint(app: &mut App<'_>, line: u32) {
+    let breakpoints = app.session.breakpoints();
+    if breakpoints.contains(&line) {
+        app.session.clear_breakpoint(line);
+        app.set_status(format!("○ Cleared breakpoint at line {line}"), StatusType::Info);
+    } else {
+        app.session.add_breakpoint(line);
+        app.set_status(format!("● Set breakpoint at line {line}"), StatusType::Warning);
+    }
+}
+
+fn render_result_span(app: &App<'_>) -> Span<'static> {
+    let Some(result) = &app.result else {
+        return Span::styled("", Style::default());
+    };
+
+    match result {
+        RunResult::Success => Span::styled("  RESULT: OK", Style::default().fg(ACCENT_SECONDARY).bold()),
+        RunResult::Error(message) => {
+            let mut truncated: String = message.chars().take(60).collect();
+            if message.chars().count() > 60 {
+                truncated.push('…');
+            }
+            Span::styled(format!("  RESULT: {truncated}"), Style::default().fg(ACCENT_ERROR).bold())
+        }
+    }
+}

--- a/silverscript-lang/src/bin/sil-debug.rs
+++ b/silverscript-lang/src/bin/sil-debug.rs
@@ -1,0 +1,307 @@
+use std::env;
+use std::fs;
+use std::io::{self, BufRead, Write};
+
+use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
+use kaspa_txscript::caches::Cache;
+use kaspa_txscript::{EngineCtx, EngineFlags};
+
+use silverscript_lang::ast::{Expr, parse_contract_ast};
+use silverscript_lang::compiler::{CompileOptions, compile_contract};
+use silverscript_lang::debug::MappingKind;
+use silverscript_lang::debug::session::{DebugEngine, DebugSession};
+
+const PROMPT: &str = "(sdb) ";
+
+fn print_usage() {
+    eprintln!(
+        "Usage: sil-debug <contract.sil> [--no-selector] [--function <name>] [--ctor-arg <value> ...] [--arg <value> ...]\n\n  --ctor-arg is typed by the contract constructor params.\n  --arg is typed by the selected function ABI.\n\nExamples:\n  # constructor (int x, int y), function hello(int a, int b)\n  sil-debug if_statement.sil --function hello --ctor-arg 3 --ctor-arg 10 --arg 1 --arg 2\n\nValue formats:\n  int:        123 (or 0x7b)\n  bool:       true|false\n  string:     hello (shell quoting handles spaces)\n  bytes*:     0xdeadbeef\n"
+    );
+}
+
+fn parse_int_arg(raw: &str) -> Result<i64, Box<dyn std::error::Error>> {
+    let cleaned = raw.replace('_', "");
+    if let Some(hex) = cleaned.strip_prefix("0x").or_else(|| cleaned.strip_prefix("0X")) {
+        return Ok(i64::from_str_radix(hex, 16)?);
+    }
+    Ok(cleaned.parse::<i64>()?)
+}
+
+fn parse_hex_bytes(raw: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let trimmed = raw.trim();
+    let hex_str = trimmed.strip_prefix("0x").or_else(|| trimmed.strip_prefix("0X")).unwrap_or(trimmed);
+    if hex_str.is_empty() {
+        return Ok(vec![]);
+    }
+    // Allow odd length by implicitly left-padding with 0
+    let normalized = if hex_str.len() % 2 != 0 { format!("0{hex_str}") } else { hex_str.to_string() };
+    Ok(hex::decode(normalized)?)
+}
+
+fn parse_typed_arg(type_name: &str, raw: &str) -> Result<Expr, Box<dyn std::error::Error>> {
+    match type_name {
+        "int" => Ok(Expr::Int(parse_int_arg(raw)?)),
+        "bool" => match raw {
+            "true" => Ok(Expr::Bool(true)),
+            "false" => Ok(Expr::Bool(false)),
+            _ => Err(format!("invalid bool '{raw}' (expected true/false)").into()),
+        },
+        "string" => Ok(Expr::String(raw.to_string())),
+        "bytes" | "byte" | "pubkey" | "sig" | "datasig" => Ok(Expr::Bytes(parse_hex_bytes(raw)?)),
+        other => {
+            if let Some(size) = other.strip_prefix("bytes").and_then(|v| v.parse::<usize>().ok()) {
+                let bytes = parse_hex_bytes(raw)?;
+                if bytes.len() != size {
+                    return Err(format!("{other} expects {size} bytes, got {}", bytes.len()).into());
+                }
+                Ok(Expr::Bytes(bytes))
+            } else {
+                Err(format!("unsupported arg type '{other}'").into())
+            }
+        }
+    }
+}
+
+fn show_state(session: &DebugSession<'_>) {
+    let state = session.state();
+    if let Some(op) = state.opcode {
+        println!("[{}/{}] {op}", state.pc, session.opcode_count());
+    }
+    if let Some(mapping) = state.mapping {
+        match &mapping.kind {
+            MappingKind::Statement { stmt_type } => {
+                if let Some(span) = mapping.span {
+                    println!("Line {} ({})", span.line, stmt_type);
+                } else {
+                    println!("Statement ({})", stmt_type);
+                }
+            }
+            MappingKind::Synthetic { label } => println!("Synthetic ({label})"),
+        }
+    }
+    println!("Stack: {:?}", state.stack);
+}
+
+fn show_stack(session: &DebugSession<'_>) {
+    let stack = session.stack();
+    for (i, item) in stack.iter().enumerate().rev() {
+        println!("[{i}] {item}");
+    }
+}
+
+fn show_source_context(session: &DebugSession<'_>) {
+    let Some(context) = session.source_context() else {
+        println!("No source context available.");
+        return;
+    };
+
+    for line in context.lines {
+        let marker = if line.is_active { "→" } else { " " };
+        println!("{marker} {:>4} | {}", line.line, line.text);
+    }
+}
+
+fn run_repl(session: &mut DebugSession<'_>) -> Result<(), kaspa_txscript_errors::TxScriptError> {
+    let stdin = io::stdin();
+    loop {
+        print!("{PROMPT}");
+        io::stdout().flush().ok();
+
+        let mut cmd = String::new();
+        if stdin.lock().read_line(&mut cmd).is_err() {
+            println!("Failed to read input.");
+            continue;
+        }
+
+        let cmd = cmd.trim();
+        if cmd.is_empty() || cmd == "n" || cmd == "next" {
+            match session.step_statement()? {
+                Some(_) => show_state(session),
+                None => {
+                    println!("Done.");
+                    break;
+                }
+            }
+            continue;
+        }
+
+        let mut parts = cmd.split_whitespace();
+        match parts.next().unwrap_or("") {
+            "si" | "step" | "s" => match session.step_opcode()? {
+                Some(_) => show_state(session),
+                None => {
+                    println!("Done.");
+                    break;
+                }
+            },
+            "c" | "continue" => match session.continue_to_breakpoint()? {
+                Some(_) => show_state(session),
+                None => {
+                    println!("Done.");
+                    break;
+                }
+            },
+            "b" | "break" => {
+                if let Some(arg) = parts.next() {
+                    match arg.parse::<u32>() {
+                        Ok(line) => {
+                            session.add_breakpoint(line);
+                            println!("Breakpoint set at line {line}");
+                        }
+                        Err(_) => println!("Invalid line number."),
+                    }
+                } else {
+                    let lines = session.breakpoints();
+                    if lines.is_empty() {
+                        println!("No breakpoints set.");
+                    } else {
+                        println!("Breakpoints: {}", lines.iter().map(|line| line.to_string()).collect::<Vec<_>>().join(", "));
+                    }
+                }
+            }
+            "l" | "list" => show_source_context(session),
+            "vars" => match session.list_variables() {
+                Ok(variables) => {
+                    if variables.is_empty() {
+                        println!("No variables in scope.");
+                    } else {
+                        for var in variables {
+                            println!("{} ({}) = {}", var.name, var.type_name, session.format_value(&var.type_name, &var.value));
+                        }
+                    }
+                }
+                Err(err) => println!("ERROR: {err}"),
+            },
+            "print" | "p" => {
+                if let Some(name) = parts.next() {
+                    match session.variable_by_name(name) {
+                        Ok(var) => println!("{} ({}) = {}", var.name, var.type_name, session.format_value(&var.type_name, &var.value)),
+                        Err(err) => println!("ERROR: {err}"),
+                    }
+                } else {
+                    println!("Usage: print <name>");
+                }
+            }
+            "stack" => show_stack(session),
+            "q" | "quit" => break,
+            "help" | "h" | "?" => {
+                println!(
+                    "Commands: next (n), step opcode (si), continue (c), break (b <line>), list (l), vars, print <name>, stack, quit (q)"
+                )
+            }
+            _ => println!(
+                "Commands: next (n), step opcode (si), continue (c), break (b <line>), list (l), vars, print <name>, stack, quit (q)"
+            ),
+        }
+    }
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut script_path: Option<String> = None;
+    let mut without_selector = false;
+    let mut function_name: Option<String> = None;
+    let mut raw_ctor_args: Vec<String> = Vec::new();
+    let mut raw_args: Vec<String> = Vec::new();
+
+    let mut args = env::args().skip(1).peekable();
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--no-selector" => without_selector = true,
+            "--function" | "-f" => {
+                function_name = args.next();
+                if function_name.is_none() {
+                    print_usage();
+                    return Err("missing function name".into());
+                }
+            }
+            "--ctor-arg" => {
+                let value = args.next();
+                if value.is_none() {
+                    print_usage();
+                    return Err("missing --ctor-arg value".into());
+                }
+                raw_ctor_args.push(value.expect("checked"));
+            }
+            "--arg" | "-a" => {
+                let value = args.next();
+                if value.is_none() {
+                    print_usage();
+                    return Err("missing --arg value".into());
+                }
+                raw_args.push(value.expect("checked"));
+            }
+            "-h" | "--help" => {
+                print_usage();
+                return Ok(());
+            }
+            _ => {
+                if script_path.is_some() {
+                    print_usage();
+                    return Err("unexpected extra argument".into());
+                }
+                script_path = Some(arg);
+            }
+        }
+    }
+
+    let script_path = match script_path {
+        Some(path) => path,
+        None => {
+            print_usage();
+            return Err("missing contract path".into());
+        }
+    };
+
+    let source = fs::read_to_string(&script_path)?;
+    let parsed_contract = parse_contract_ast(&source)?;
+
+    if parsed_contract.params.len() != raw_ctor_args.len() {
+        return Err(format!("constructor expects {} arguments, got {}", parsed_contract.params.len(), raw_ctor_args.len()).into());
+    }
+
+    let mut ctor_args = Vec::with_capacity(raw_ctor_args.len());
+    for (param, raw) in parsed_contract.params.iter().zip(raw_ctor_args.iter()) {
+        ctor_args.push(parse_typed_arg(&param.type_name, raw)?);
+    }
+
+    let compile_opts = CompileOptions { covenants_enabled: true, without_selector, record_debug_spans: true };
+    let compiled = compile_contract(&source, &ctor_args, compile_opts)?;
+    let debug_info = compiled.debug_info.clone();
+
+    let sig_cache = Cache::new(10_000);
+    let reused_values = SigHashReusedValuesUnsync::new();
+    let ctx = EngineCtx::new(&sig_cache).with_reused(&reused_values);
+
+    let flags = EngineFlags { covenants_enabled: compile_opts.covenants_enabled };
+    let engine = DebugEngine::new(ctx, flags);
+
+    // Seed the stack like a real spend: run sigscript pushes before locking script.
+    let default_name = compiled.abi.first().map(|entry| entry.name.clone()).ok_or("contract has no functions")?;
+    let selected_name = function_name.unwrap_or(default_name);
+    let entry = compiled
+        .abi
+        .iter()
+        .find(|entry| entry.name == selected_name)
+        .ok_or_else(|| format!("function '{selected_name}' not found"))?;
+
+    if entry.inputs.len() != raw_args.len() {
+        return Err(format!("function '{selected_name}' expects {} arguments, got {}", entry.inputs.len(), raw_args.len()).into());
+    }
+
+    let mut typed_args = Vec::with_capacity(raw_args.len());
+    for (input, raw) in entry.inputs.iter().zip(raw_args.iter()) {
+        typed_args.push(parse_typed_arg(&input.type_name, raw)?);
+    }
+
+    // Always seed: even in --no-selector mode the function params must be pushed.
+    let sigscript = compiled.build_sig_script(&selected_name, typed_args)?;
+    let mut session = DebugSession::full(&sigscript, &compiled.script, &source, debug_info, engine)?;
+
+    println!("Stepping through {} bytes of script", compiled.script.len());
+    session.run_to_first_executed_statement()?;
+    show_source_context(&session);
+    run_repl(&mut session)?;
+
+    Ok(())
+}

--- a/silverscript-lang/src/debug.rs
+++ b/silverscript-lang/src/debug.rs
@@ -1,0 +1,139 @@
+use crate::ast::{Expr, SourceSpan};
+
+pub mod session;
+
+#[derive(Debug, Clone)]
+pub enum DebugEventKind {
+    Statement { stmt_type: String },
+    Synthetic { label: String },
+}
+
+#[derive(Debug, Clone)]
+pub struct DebugEvent {
+    pub bytecode_start: usize,
+    pub bytecode_end: usize,
+    pub span: Option<SourceSpan>,
+    pub kind: DebugEventKind,
+}
+
+#[derive(Debug, Default)]
+pub struct DebugRecorder {
+    events: Vec<DebugEvent>,
+    variable_updates: Vec<DebugVariableUpdate>,
+    params: Vec<DebugParamMapping>,
+    functions: Vec<DebugFunctionRange>,
+    constants: Vec<DebugConstantMapping>,
+}
+
+impl DebugRecorder {
+    pub fn record(&mut self, event: DebugEvent) {
+        self.events.push(event);
+    }
+
+    pub fn record_variable_update(&mut self, update: DebugVariableUpdate) {
+        self.variable_updates.push(update);
+    }
+
+    pub fn record_param(&mut self, param: DebugParamMapping) {
+        self.params.push(param);
+    }
+
+    pub fn record_function(&mut self, function: DebugFunctionRange) {
+        self.functions.push(function);
+    }
+
+    pub fn record_constant(&mut self, constant: DebugConstantMapping) {
+        self.constants.push(constant);
+    }
+
+    pub fn into_events(self) -> Vec<DebugEvent> {
+        self.events
+    }
+
+    pub fn into_debug_info(self, source: String) -> DebugInfo {
+        DebugInfo {
+            source,
+            mappings: self.events.into_iter().map(DebugMapping::from).collect(),
+            variable_updates: self.variable_updates,
+            params: self.params,
+            functions: self.functions,
+            constants: self.constants,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DebugInfo {
+    pub source: String,
+    pub mappings: Vec<DebugMapping>,
+    pub variable_updates: Vec<DebugVariableUpdate>,
+    pub params: Vec<DebugParamMapping>,
+    pub functions: Vec<DebugFunctionRange>,
+    pub constants: Vec<DebugConstantMapping>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DebugVariableUpdate {
+    pub name: String,
+    pub type_name: String,
+    pub expr: Expr,
+    pub bytecode_offset: usize,
+    pub span: Option<SourceSpan>,
+    pub function: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DebugParamMapping {
+    pub name: String,
+    pub type_name: String,
+    pub stack_index: i64,
+    pub function: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DebugFunctionRange {
+    pub name: String,
+    pub bytecode_start: usize,
+    pub bytecode_end: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct DebugConstantMapping {
+    pub name: String,
+    pub type_name: String,
+    pub value: Expr,
+}
+
+#[derive(Debug, Clone)]
+pub struct DebugMapping {
+    pub bytecode_start: usize,
+    pub bytecode_end: usize,
+    pub span: Option<SourceSpan>,
+    pub kind: MappingKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum MappingKind {
+    Statement { stmt_type: String },
+    Synthetic { label: String },
+}
+
+impl From<DebugEventKind> for MappingKind {
+    fn from(kind: DebugEventKind) -> Self {
+        match kind {
+            DebugEventKind::Statement { stmt_type } => MappingKind::Statement { stmt_type },
+            DebugEventKind::Synthetic { label } => MappingKind::Synthetic { label },
+        }
+    }
+}
+
+impl From<DebugEvent> for DebugMapping {
+    fn from(event: DebugEvent) -> Self {
+        DebugMapping {
+            bytecode_start: event.bytecode_start,
+            bytecode_end: event.bytecode_end,
+            span: event.span,
+            kind: event.kind.into(),
+        }
+    }
+}

--- a/silverscript-lang/src/debug/session.rs
+++ b/silverscript-lang/src/debug/session.rs
@@ -1,0 +1,781 @@
+use std::collections::{HashMap, HashSet};
+
+use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
+use kaspa_consensus_core::tx::PopulatedTransaction;
+use kaspa_txscript::{DynOpcodeImplementation, TxScriptEngine, parse_script};
+
+use crate::ast::{BinaryOp, Expr, SourceSpan, SplitPart, UnaryOp};
+use crate::debug::{DebugFunctionRange, DebugInfo, DebugMapping, DebugParamMapping, DebugVariableUpdate, MappingKind};
+
+pub type DebugTx<'a> = PopulatedTransaction<'a>;
+pub type DebugReused = SigHashReusedValuesUnsync;
+pub type DebugOpcode<'a> = DynOpcodeImplementation<DebugTx<'a>, DebugReused>;
+pub type DebugEngine<'a> = TxScriptEngine<'a, DebugTx<'a>, DebugReused>;
+
+#[derive(Debug, Clone)]
+pub enum DebugValue {
+    Int(i64),
+    Bool(bool),
+    Bytes(Vec<u8>),
+    String(String),
+    Array(Vec<DebugValue>),
+    /// Value could not be evaluated (e.g., from inline function return)
+    Unknown(std::string::String),
+}
+
+#[derive(Debug, Clone)]
+pub struct Variable {
+    pub name: String,
+    pub type_name: String,
+    pub value: DebugValue,
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceContextLine {
+    pub line: u32,
+    pub text: String,
+    pub is_active: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct SourceContext {
+    pub lines: Vec<SourceContextLine>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionState {
+    pub pc: usize,
+    pub opcode: Option<String>,
+    pub mapping: Option<DebugMapping>,
+    pub stack: Vec<String>,
+}
+
+pub struct DebugSession<'a> {
+    engine: DebugEngine<'a>,
+    opcodes: Vec<Option<DebugOpcode<'a>>>,
+    op_displays: Vec<String>,
+    opcode_offsets: Vec<usize>,
+    script_len: usize,
+    pc: usize,
+    debug_info: Option<DebugInfo>,
+    statement_mappings: Vec<DebugMapping>,
+    source_lines: Vec<String>,
+    breakpoints: HashSet<u32>,
+}
+
+impl<'a> DebugSession<'a> {
+    pub fn lockscript_only(
+        script: &[u8],
+        source: &str,
+        debug_info: Option<DebugInfo>,
+        engine: DebugEngine<'a>,
+    ) -> Result<Self, kaspa_txscript_errors::TxScriptError> {
+        Self::from_scripts(script, source, debug_info, engine)
+    }
+
+    pub fn full(
+        sigscript: &[u8],
+        lockscript: &[u8],
+        source: &str,
+        debug_info: Option<DebugInfo>,
+        mut engine: DebugEngine<'a>,
+    ) -> Result<Self, kaspa_txscript_errors::TxScriptError> {
+        seed_engine_with_sigscript(&mut engine, sigscript)?;
+        Self::from_scripts(lockscript, source, debug_info, engine)
+    }
+
+    pub fn from_scripts(
+        script: &[u8],
+        source: &str,
+        debug_info: Option<DebugInfo>,
+        engine: DebugEngine<'a>,
+    ) -> Result<Self, kaspa_txscript_errors::TxScriptError> {
+        let opcodes = parse_script::<DebugTx<'a>, DebugReused>(script).collect::<Result<Vec<_>, _>>()?;
+        let op_displays = opcodes.iter().map(|op| format!("{op:?}")).collect();
+        let opcodes: Vec<Option<DebugOpcode<'a>>> = opcodes.into_iter().map(Some).collect();
+        let source_lines: Vec<String> = source.lines().map(String::from).collect();
+        let (opcode_offsets, script_len) = build_opcode_offsets(&opcodes);
+
+        let statement_mappings = debug_info
+            .as_ref()
+            .map(|info| {
+                let mut mappings = info
+                    .mappings
+                    .iter()
+                    .filter(|mapping| matches!(&mapping.kind, MappingKind::Statement { .. }))
+                    .cloned()
+                    .collect::<Vec<_>>();
+                mappings.sort_by_key(|mapping| (mapping.bytecode_start, mapping.bytecode_end));
+                mappings
+            })
+            .unwrap_or_default();
+
+        Ok(Self {
+            engine,
+            opcodes,
+            op_displays,
+            opcode_offsets,
+            script_len,
+            pc: 0,
+            debug_info,
+            statement_mappings,
+            source_lines,
+            breakpoints: HashSet::new(),
+        })
+    }
+
+    pub fn step_opcode(&mut self) -> Result<Option<SessionState>, kaspa_txscript_errors::TxScriptError> {
+        if self.pc >= self.opcodes.len() {
+            return Ok(None);
+        }
+
+        let opcode = self.opcodes[self.pc].take().expect("opcode already executed");
+        self.engine.execute_opcode(opcode)?;
+        self.pc += 1;
+        Ok(Some(self.state()))
+    }
+
+    pub fn step_statement(&mut self) -> Result<Option<SessionState>, kaspa_txscript_errors::TxScriptError> {
+        if self.statement_mappings.is_empty() {
+            return self.step_opcode();
+        }
+
+        let start_offset = self.current_byte_offset();
+        let start_stmt =
+            self.statement_for_offset(start_offset).filter(|_| self.engine.is_executing()).map(|stmt| stmt.bytecode_start);
+
+        let mut progressed = false;
+        loop {
+            if self.pc >= self.opcodes.len() {
+                return Ok(if progressed { Some(self.state()) } else { None });
+            }
+
+            if self.step_opcode()?.is_none() {
+                return Ok(if progressed { Some(self.state()) } else { None });
+            }
+            progressed = true;
+
+            let offset = self.current_byte_offset();
+            if let Some(stmt) = self.statement_for_offset(offset) {
+                if self.engine.is_executing() {
+                    let stmt_start = stmt.bytecode_start;
+                    if start_stmt.map(|s| s != stmt_start).unwrap_or(true) {
+                        return Ok(Some(self.state()));
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn run_to_first_executed_statement(&mut self) -> Result<(), kaspa_txscript_errors::TxScriptError> {
+        if self.statement_mappings.is_empty() {
+            return Ok(());
+        }
+        loop {
+            if self.pc >= self.opcodes.len() {
+                return Ok(());
+            }
+            let offset = self.current_byte_offset();
+            if self.statement_for_offset(offset).is_some() {
+                if self.engine.is_executing() {
+                    return Ok(());
+                }
+            }
+            if self.step_opcode()?.is_none() {
+                return Ok(());
+            }
+        }
+    }
+
+    pub fn continue_to_breakpoint(&mut self) -> Result<Option<SessionState>, kaspa_txscript_errors::TxScriptError> {
+        if self.breakpoints.is_empty() {
+            while self.step_opcode()?.is_some() {}
+            return Ok(None);
+        }
+        loop {
+            if self.step_statement()?.is_none() {
+                return Ok(None);
+            }
+            let offset = self.current_byte_offset();
+            if let Some(mapping) = self.statement_for_offset(offset) {
+                if self.engine.is_executing() {
+                    if let Some(span) = mapping.span {
+                        if self.breakpoints.contains(&span.line) {
+                            return Ok(Some(self.state()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn state(&self) -> SessionState {
+        let executed = self.pc.saturating_sub(1);
+        let opcode = self.op_displays.get(executed).cloned();
+        SessionState {
+            pc: self.pc,
+            opcode,
+            mapping: self.mapping_for_offset(self.current_byte_offset()).cloned(),
+            stack: self.format_stack(),
+        }
+    }
+
+    pub fn opcode_count(&self) -> usize {
+        self.op_displays.len()
+    }
+
+    pub fn source_context(&self) -> Option<SourceContext> {
+        let span = self.statement_for_offset(self.current_byte_offset()).and_then(|mapping| mapping.span)?;
+        let line = span.line.saturating_sub(1) as usize;
+        let radius = 6;
+        let start = line.saturating_sub(radius);
+        let end = (line + radius).min(self.source_lines.len().saturating_sub(1));
+
+        let mut lines = Vec::new();
+        for idx in start..=end {
+            let display_line = idx + 1;
+            let content = self.source_lines.get(idx).map(String::as_str).unwrap_or("");
+            lines.push(SourceContextLine { line: display_line as u32, text: content.to_string(), is_active: idx == line });
+        }
+
+        Some(SourceContext { lines })
+    }
+
+    pub fn add_breakpoint(&mut self, line: u32) {
+        self.breakpoints.insert(line);
+    }
+
+    pub fn breakpoints(&self) -> Vec<u32> {
+        let mut lines = self.breakpoints.iter().copied().collect::<Vec<_>>();
+        lines.sort_unstable();
+        lines
+    }
+
+    pub fn clear_breakpoint(&mut self, line: u32) {
+        self.breakpoints.remove(&line);
+    }
+
+    pub fn list_variables(&self) -> Result<Vec<Variable>, String> {
+        let info = self.debug_info.as_ref().ok_or_else(|| "No debug info available".to_string())?;
+        let function_name = self.current_function_name().ok_or_else(|| "No function context available".to_string())?;
+        let offset = self.current_byte_offset();
+        let var_updates = self.current_variable_updates(function_name, offset);
+
+        let mut variables: Vec<Variable> = Vec::new();
+
+        for (name, update) in &var_updates {
+            // Try to evaluate; if it fails (e.g., inline function return), show Unknown
+            let value = self
+                .evaluate_expr(&update.expr, function_name, &var_updates, &mut HashSet::new())
+                .unwrap_or_else(|err| DebugValue::Unknown(err));
+            variables.push(Variable { name: name.clone(), type_name: update.type_name.clone(), value });
+        }
+
+        for param in info.params.iter().filter(|param| param.function == function_name) {
+            if var_updates.contains_key(&param.name) {
+                continue;
+            }
+            let value = self.read_param_value(param)?;
+            variables.push(Variable { name: param.name.clone(), type_name: param.type_name.clone(), value });
+        }
+
+        // Add constructor constants
+        for constant in &info.constants {
+            if var_updates.contains_key(&constant.name) {
+                continue;
+            }
+            let value = self.evaluate_constant(&constant.value);
+            variables.push(Variable { name: constant.name.clone(), type_name: constant.type_name.clone(), value });
+        }
+
+        variables.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(variables)
+    }
+
+    pub fn variable_by_name(&self, name: &str) -> Result<Variable, String> {
+        let info = self.debug_info.as_ref().ok_or_else(|| "No debug info available".to_string())?;
+        let function_name = self.current_function_name().ok_or_else(|| "No function context available".to_string())?;
+        let offset = self.current_byte_offset();
+        let var_updates = self.current_variable_updates(function_name, offset);
+
+        if let Some(update) = var_updates.get(name) {
+            let value = self.evaluate_expr(&update.expr, function_name, &var_updates, &mut HashSet::new())?;
+            return Ok(Variable { name: name.to_string(), type_name: update.type_name.clone(), value });
+        }
+
+        if let Some(param) = info.params.iter().find(|param| param.function == function_name && param.name == name) {
+            let value = self.read_param_value(param)?;
+            return Ok(Variable { name: name.to_string(), type_name: param.type_name.clone(), value });
+        }
+
+        // Check constructor constants
+        if let Some(constant) = info.constants.iter().find(|c| c.name == name) {
+            let value = self.evaluate_constant(&constant.value);
+            return Ok(Variable { name: name.to_string(), type_name: constant.type_name.clone(), value });
+        }
+
+        Err(format!("unknown variable '{name}'"))
+    }
+
+    pub fn format_value(&self, type_name: &str, value: &DebugValue) -> String {
+        let element_type = type_name.strip_suffix("[]");
+        match (type_name, value) {
+            ("int", DebugValue::Int(number)) => number.to_string(),
+            ("bool", DebugValue::Bool(value)) => value.to_string(),
+            ("string", DebugValue::String(value)) => value.clone(),
+            (_, DebugValue::Unknown(_)) => "<from function call>".to_string(),
+            (_, DebugValue::Bytes(bytes)) if element_type.is_some() => {
+                let element_type = element_type.expect("checked");
+                let Some(element_size) = self.array_element_size(element_type) else {
+                    return format!("0x{}", hex::encode(bytes));
+                };
+                if element_size == 0 || bytes.len() % element_size != 0 {
+                    return format!("0x{}", hex::encode(bytes));
+                }
+
+                let mut values: Vec<String> = Vec::new();
+                for chunk in bytes.chunks(element_size) {
+                    let decoded = match element_type {
+                        "int" => DebugValue::Int(self.decode_i64(chunk).unwrap_or(0)),
+                        "bool" => DebugValue::Bool(self.decode_i64(chunk).unwrap_or(0) != 0),
+                        _ => DebugValue::Bytes(chunk.to_vec()),
+                    };
+                    values.push(self.format_value(element_type, &decoded));
+                }
+                format!("[{}]", values.join(", "))
+            }
+            (_, DebugValue::Bytes(bytes)) => format!("0x{}", hex::encode(bytes)),
+            (_, DebugValue::Int(number)) => number.to_string(),
+            (_, DebugValue::Bool(value)) => value.to_string(),
+            (_, DebugValue::String(value)) => value.clone(),
+            (_, DebugValue::Array(values)) => {
+                let value_type = element_type.unwrap_or(type_name);
+                format!("[{}]", values.iter().map(|v| self.format_value(value_type, v)).collect::<Vec<_>>().join(", "))
+            }
+        }
+    }
+
+    pub fn stack(&self) -> Vec<String> {
+        self.format_stack()
+    }
+
+    pub fn current_location(&self) -> Option<DebugMapping> {
+        self.mapping_for_offset(self.current_byte_offset()).cloned()
+    }
+
+    pub fn current_byte_offset(&self) -> usize {
+        self.opcode_offsets.get(self.pc).copied().unwrap_or(self.script_len)
+    }
+
+    pub fn current_span(&self) -> Option<SourceSpan> {
+        self.current_location().and_then(|mapping| mapping.span)
+    }
+
+    pub fn current_function_name(&self) -> Option<&str> {
+        self.current_function_range().map(|range| range.name.as_str())
+    }
+
+    fn current_function_range(&self) -> Option<&DebugFunctionRange> {
+        let info = self.debug_info.as_ref()?;
+        let offset = self.current_byte_offset();
+        info.functions.iter().find(|function| offset >= function.bytecode_start && offset < function.bytecode_end)
+    }
+
+    fn current_variable_updates(&self, function_name: &str, offset: usize) -> HashMap<String, &DebugVariableUpdate> {
+        let mut latest: HashMap<String, &DebugVariableUpdate> = HashMap::new();
+        let Some(info) = self.debug_info.as_ref() else {
+            return latest;
+        };
+        for update in
+            info.variable_updates.iter().filter(|update| update.function == function_name && update.bytecode_offset <= offset)
+        {
+            match latest.get(&update.name) {
+                Some(existing) if existing.bytecode_offset > update.bytecode_offset => {}
+                _ => {
+                    latest.insert(update.name.clone(), update);
+                }
+            }
+        }
+        latest
+    }
+
+    fn mapping_for_offset(&self, offset: usize) -> Option<&DebugMapping> {
+        let mappings = self.debug_info.as_ref()?.mappings.as_slice();
+        let mut best: Option<&DebugMapping> = None;
+        let mut best_len = usize::MAX;
+        for mapping in mappings {
+            if offset >= mapping.bytecode_start && offset < mapping.bytecode_end {
+                let len = mapping.bytecode_end.saturating_sub(mapping.bytecode_start);
+                if len < best_len {
+                    best = Some(mapping);
+                    best_len = len;
+                }
+            }
+        }
+        best
+    }
+
+    fn statement_for_offset(&self, offset: usize) -> Option<&DebugMapping> {
+        let mut best: Option<&DebugMapping> = None;
+        let mut best_len = usize::MAX;
+        for mapping in &self.statement_mappings {
+            if offset >= mapping.bytecode_start && offset < mapping.bytecode_end {
+                let len = mapping.bytecode_end.saturating_sub(mapping.bytecode_start);
+                if len < best_len {
+                    best = Some(mapping);
+                    best_len = len;
+                }
+            }
+        }
+        best
+    }
+
+    fn format_stack(&self) -> Vec<String> {
+        let stacks = self.engine.stacks();
+        stacks.dstack.iter().map(|item| hex::encode(item)).collect()
+    }
+
+    fn evaluate_expr(
+        &self,
+        expr: &Expr,
+        function_name: &str,
+        var_updates: &HashMap<String, &DebugVariableUpdate>,
+        visiting: &mut HashSet<String>,
+    ) -> Result<DebugValue, String> {
+        match expr {
+            Expr::Int(value) => Ok(DebugValue::Int(*value)),
+            Expr::Bool(value) => Ok(DebugValue::Bool(*value)),
+            Expr::Bytes(value) => Ok(DebugValue::Bytes(value.clone())),
+            Expr::String(value) => Ok(DebugValue::String(value.clone())),
+            Expr::Array(values) => {
+                let mut out = Vec::with_capacity(values.len());
+                for value in values {
+                    out.push(self.evaluate_expr(value, function_name, var_updates, visiting)?);
+                }
+                Ok(DebugValue::Array(out))
+            }
+            Expr::Identifier(name) => {
+                if let Some(update) = var_updates.get(name) {
+                    if !visiting.insert(name.clone()) {
+                        return Err(format!("cyclic reference to '{name}'"));
+                    }
+                    let value = self.evaluate_expr(&update.expr, function_name, var_updates, visiting)?;
+                    visiting.remove(name);
+                    return Ok(value);
+                }
+                if let Some(param) = self.param_for_name(function_name, name) {
+                    return self.read_param_value(param);
+                }
+                Err(format!("unknown identifier '{name}'"))
+            }
+            Expr::Unary { op: UnaryOp::Not, expr } => {
+                let value = self.evaluate_expr(expr, function_name, var_updates, visiting)?;
+                Ok(DebugValue::Bool(!self.value_to_bool(&value)))
+            }
+            Expr::Unary { op: UnaryOp::Neg, expr } => {
+                let value = self.evaluate_expr(expr, function_name, var_updates, visiting)?;
+                let number = self.value_to_int(&value)?;
+                Ok(DebugValue::Int(-number))
+            }
+            Expr::Binary { op, left, right } => {
+                let left_value = self.evaluate_expr(left, function_name, var_updates, visiting)?;
+                let right_value = self.evaluate_expr(right, function_name, var_updates, visiting)?;
+                self.evaluate_binary(*op, left_value, right_value)
+            }
+            Expr::IfElse { condition, then_expr, else_expr } => {
+                let cond = self.evaluate_expr(condition, function_name, var_updates, visiting)?;
+                if self.value_to_bool(&cond) {
+                    self.evaluate_expr(then_expr, function_name, var_updates, visiting)
+                } else {
+                    self.evaluate_expr(else_expr, function_name, var_updates, visiting)
+                }
+            }
+            Expr::Split { source, index, part } => {
+                let source_val = self.evaluate_expr(source, function_name, var_updates, visiting)?;
+                let index_val = self.evaluate_expr(index, function_name, var_updates, visiting)?;
+                let idx = self.value_to_int(&index_val)? as usize;
+                match source_val {
+                    DebugValue::Bytes(bytes) => {
+                        let mid = idx.min(bytes.len());
+                        let out = match part {
+                            SplitPart::Left => bytes[..mid].to_vec(),
+                            SplitPart::Right => bytes[mid..].to_vec(),
+                        };
+                        Ok(DebugValue::Bytes(out))
+                    }
+                    DebugValue::Array(values) => {
+                        let mid = idx.min(values.len());
+                        let out = match part {
+                            SplitPart::Left => values[..mid].to_vec(),
+                            SplitPart::Right => values[mid..].to_vec(),
+                        };
+                        Ok(DebugValue::Array(out))
+                    }
+                    _ => Err("split() expects bytes or array".to_string()),
+                }
+            }
+            Expr::Slice { source, start, end } => {
+                let source_val = self.evaluate_expr(source, function_name, var_updates, visiting)?;
+                let start_val = self.evaluate_expr(start, function_name, var_updates, visiting)?;
+                let end_val = self.evaluate_expr(end, function_name, var_updates, visiting)?;
+                let start_idx = self.value_to_int(&start_val)? as usize;
+                let end_idx = self.value_to_int(&end_val)? as usize;
+                match source_val {
+                    DebugValue::Bytes(bytes) => {
+                        let s = start_idx.min(bytes.len());
+                        let e = end_idx.min(bytes.len());
+                        Ok(DebugValue::Bytes(bytes[s..e].to_vec()))
+                    }
+                    DebugValue::Array(values) => {
+                        let s = start_idx.min(values.len());
+                        let e = end_idx.min(values.len());
+                        Ok(DebugValue::Array(values[s..e].to_vec()))
+                    }
+                    _ => Err("slice() expects bytes or array".to_string()),
+                }
+            }
+            Expr::ArrayIndex { source, index } => {
+                let source_val = self.evaluate_expr(source, function_name, var_updates, visiting)?;
+                let index_val = self.evaluate_expr(index, function_name, var_updates, visiting)?;
+                let idx = self.value_to_int(&index_val)? as usize;
+                match source_val {
+                    DebugValue::Array(values) => values.get(idx).cloned().ok_or_else(|| "index out of range".to_string()),
+                    DebugValue::Bytes(bytes) => {
+                        bytes.get(idx).map(|b| DebugValue::Bytes(vec![*b])).ok_or_else(|| "index out of range".to_string())
+                    }
+                    _ => Err("indexing expects array or bytes".to_string()),
+                }
+            }
+            Expr::Call { name, args } => self.evaluate_call(name, args, function_name, var_updates, visiting),
+            Expr::Introspection { kind, .. } => {
+                Err(format!("cannot evaluate introspection ({kind:?}) - requires transaction context"))
+            }
+            Expr::Nullary(op) => Err(format!("cannot evaluate {op:?} - requires transaction context")),
+            Expr::New { name, .. } => Err(format!("cannot evaluate {name}(...) constructor in debugger")),
+        }
+    }
+
+    fn evaluate_call(
+        &self,
+        name: &str,
+        args: &[Expr],
+        function_name: &str,
+        var_updates: &HashMap<String, &DebugVariableUpdate>,
+        visiting: &mut HashSet<String>,
+    ) -> Result<DebugValue, String> {
+        match name {
+            "bytes" => {
+                if args.is_empty() || args.len() > 2 {
+                    return Err("bytes() expects one or two arguments".to_string());
+                }
+                let value = self.evaluate_expr(&args[0], function_name, var_updates, visiting)?;
+                if args.len() == 2 {
+                    let size_val = self.evaluate_expr(&args[1], function_name, var_updates, visiting)?;
+                    let size = self.value_to_int(&size_val)? as usize;
+                    let number = self.value_to_int(&value)?;
+                    return Ok(DebugValue::Bytes(self.encode_i64_le(number, size)));
+                }
+                match value {
+                    DebugValue::String(s) => Ok(DebugValue::Bytes(s.as_bytes().to_vec())),
+                    DebugValue::Bytes(bytes) => Ok(DebugValue::Bytes(bytes)),
+                    DebugValue::Int(number) => Ok(DebugValue::Bytes(self.encode_i64_le(number, 8))),
+                    DebugValue::Bool(value) => Ok(DebugValue::Bytes(vec![if value { 1 } else { 0 }])),
+                    _ => Err("bytes() expects int, bool, bytes, or string".to_string()),
+                }
+            }
+            "int" => {
+                if args.len() != 1 {
+                    return Err("int() expects one argument".to_string());
+                }
+                let value = self.evaluate_expr(&args[0], function_name, var_updates, visiting)?;
+                let number = self.value_to_int(&value)?;
+                Ok(DebugValue::Int(number))
+            }
+            "length" => {
+                if args.len() != 1 {
+                    return Err("length() expects one argument".to_string());
+                }
+                let value = self.evaluate_expr(&args[0], function_name, var_updates, visiting)?;
+                let length = match value {
+                    DebugValue::Bytes(bytes) => bytes.len(),
+                    DebugValue::String(s) => s.as_bytes().len(),
+                    DebugValue::Array(values) => values.len(),
+                    _ => return Err("length() expects bytes, string, or array".to_string()),
+                };
+                Ok(DebugValue::Int(length as i64))
+            }
+            name if name.starts_with("bytes") => {
+                let size = name
+                    .strip_prefix("bytes")
+                    .and_then(|v| v.parse::<usize>().ok())
+                    .ok_or_else(|| format!("{name}() is not supported"))?;
+                if args.len() != 1 {
+                    return Err(format!("{name}() expects one argument"));
+                }
+                let value = self.evaluate_expr(&args[0], function_name, var_updates, visiting)?;
+                let number = self.value_to_int(&value)?;
+                Ok(DebugValue::Bytes(self.encode_i64_le(number, size)))
+            }
+            _ => Err(format!("unsupported call '{name}' in debugger")),
+        }
+    }
+
+    fn evaluate_binary(&self, op: BinaryOp, left: DebugValue, right: DebugValue) -> Result<DebugValue, String> {
+        match op {
+            BinaryOp::Add => match (left, right) {
+                (DebugValue::Bytes(mut left), DebugValue::Bytes(right)) => {
+                    left.extend_from_slice(&right);
+                    Ok(DebugValue::Bytes(left))
+                }
+                (left, right) => Ok(DebugValue::Int(self.value_to_int(&left)? + self.value_to_int(&right)?)),
+            },
+            BinaryOp::Sub => Ok(DebugValue::Int(self.value_to_int(&left)? - self.value_to_int(&right)?)),
+            BinaryOp::Mul => Ok(DebugValue::Int(self.value_to_int(&left)? * self.value_to_int(&right)?)),
+            BinaryOp::Div => Ok(DebugValue::Int(self.value_to_int(&left)? / self.value_to_int(&right)?)),
+            BinaryOp::Mod => Ok(DebugValue::Int(self.value_to_int(&left)? % self.value_to_int(&right)?)),
+            BinaryOp::BitAnd => Ok(DebugValue::Int(self.value_to_int(&left)? & self.value_to_int(&right)?)),
+            BinaryOp::BitOr => Ok(DebugValue::Int(self.value_to_int(&left)? | self.value_to_int(&right)?)),
+            BinaryOp::BitXor => Ok(DebugValue::Int(self.value_to_int(&left)? ^ self.value_to_int(&right)?)),
+            BinaryOp::Eq => Ok(DebugValue::Bool(self.value_equals(&left, &right))),
+            BinaryOp::Ne => Ok(DebugValue::Bool(!self.value_equals(&left, &right))),
+            BinaryOp::Lt => Ok(DebugValue::Bool(self.value_to_int(&left)? < self.value_to_int(&right)?)),
+            BinaryOp::Le => Ok(DebugValue::Bool(self.value_to_int(&left)? <= self.value_to_int(&right)?)),
+            BinaryOp::Gt => Ok(DebugValue::Bool(self.value_to_int(&left)? > self.value_to_int(&right)?)),
+            BinaryOp::Ge => Ok(DebugValue::Bool(self.value_to_int(&left)? >= self.value_to_int(&right)?)),
+            BinaryOp::And => Ok(DebugValue::Bool(self.value_to_bool(&left) && self.value_to_bool(&right))),
+            BinaryOp::Or => Ok(DebugValue::Bool(self.value_to_bool(&left) || self.value_to_bool(&right))),
+        }
+    }
+
+    fn array_element_size(&self, element_type: &str) -> Option<usize> {
+        match element_type {
+            "int" => Some(8),
+            "bool" => Some(1),
+            "byte" => Some(1),
+            other => other.strip_prefix("bytes").and_then(|v| v.parse::<usize>().ok()),
+        }
+    }
+
+    fn value_equals(&self, left: &DebugValue, right: &DebugValue) -> bool {
+        match (left, right) {
+            (DebugValue::Int(a), DebugValue::Int(b)) => a == b,
+            (DebugValue::Bool(a), DebugValue::Bool(b)) => a == b,
+            (DebugValue::Bytes(a), DebugValue::Bytes(b)) => a == b,
+            (DebugValue::String(a), DebugValue::String(b)) => a == b,
+            _ => false,
+        }
+    }
+
+    fn value_to_bool(&self, value: &DebugValue) -> bool {
+        match value {
+            DebugValue::Bool(value) => *value,
+            DebugValue::Int(value) => *value != 0,
+            DebugValue::Bytes(bytes) => bytes.iter().any(|b| *b != 0),
+            DebugValue::String(s) => !s.is_empty(),
+            DebugValue::Array(values) => !values.is_empty(),
+            DebugValue::Unknown(_) => false,
+        }
+    }
+
+    fn value_to_int(&self, value: &DebugValue) -> Result<i64, String> {
+        match value {
+            DebugValue::Int(value) => Ok(*value),
+            DebugValue::Bool(value) => Ok(if *value { 1 } else { 0 }),
+            DebugValue::Bytes(bytes) => self.decode_i64(bytes),
+            DebugValue::String(s) => s.parse::<i64>().map_err(|_| "string is not an int".to_string()),
+            DebugValue::Array(_) => Err("array is not an int".to_string()),
+            DebugValue::Unknown(reason) => Err(format!("unknown value: {reason}")),
+        }
+    }
+
+    fn param_for_name(&self, function_name: &str, name: &str) -> Option<&DebugParamMapping> {
+        let info = self.debug_info.as_ref()?;
+        info.params.iter().find(|param| param.function == function_name && param.name == name)
+    }
+
+    fn read_param_value(&self, param: &DebugParamMapping) -> Result<DebugValue, String> {
+        let bytes = self.read_stack_at_index(param.stack_index)?;
+        self.decode_value_by_type(&param.type_name, bytes)
+    }
+
+    fn evaluate_constant(&self, expr: &Expr) -> DebugValue {
+        match expr {
+            Expr::Int(v) => DebugValue::Int(*v),
+            Expr::Bool(v) => DebugValue::Bool(*v),
+            Expr::Bytes(v) => DebugValue::Bytes(v.clone()),
+            Expr::String(v) => DebugValue::String(v.clone()),
+            _ => DebugValue::Unknown("complex expression".to_string()),
+        }
+    }
+
+    fn read_stack_at_index(&self, index: i64) -> Result<Vec<u8>, String> {
+        if index < 0 {
+            return Err("negative stack index".to_string());
+        }
+        let stacks = self.engine.stacks();
+        let stack = stacks.dstack;
+        let idx = index as usize;
+        if idx >= stack.len() {
+            return Err("stack index out of range".to_string());
+        }
+        let stack_index = stack.len() - 1 - idx;
+        Ok(stack.get(stack_index).cloned().unwrap_or_default())
+    }
+
+    fn decode_value_by_type(&self, type_name: &str, bytes: Vec<u8>) -> Result<DebugValue, String> {
+        match type_name {
+            "int" => Ok(DebugValue::Int(self.decode_i64(&bytes)?)),
+            "bool" => Ok(DebugValue::Bool(self.decode_i64(&bytes)? != 0)),
+            "string" => match String::from_utf8(bytes.clone()) {
+                Ok(value) => Ok(DebugValue::String(value)),
+                Err(_) => Ok(DebugValue::Bytes(bytes)),
+            },
+            _ => Ok(DebugValue::Bytes(bytes)),
+        }
+    }
+
+    fn decode_i64(&self, bytes: &[u8]) -> Result<i64, String> {
+        if bytes.is_empty() {
+            return Ok(0);
+        }
+        if bytes.len() > 8 {
+            return Err("numeric value is longer than 8 bytes".to_string());
+        }
+        let msb = bytes[bytes.len() - 1];
+        let sign = 1 - 2 * ((msb >> 7) as i64);
+        let first_byte = (msb & 0x7f) as i64;
+        let mut value = first_byte;
+        for byte in bytes[..bytes.len() - 1].iter().rev() {
+            value = (value << 8) + (*byte as i64);
+        }
+        Ok(value * sign)
+    }
+
+    fn encode_i64_le(&self, value: i64, size: usize) -> Vec<u8> {
+        let bytes = value.to_le_bytes();
+        let mut out = vec![0u8; size];
+        for (idx, byte) in bytes.iter().take(size).enumerate() {
+            out[idx] = *byte;
+        }
+        out
+    }
+}
+
+fn seed_engine_with_sigscript(engine: &mut DebugEngine<'_>, sigscript: &[u8]) -> Result<(), kaspa_txscript_errors::TxScriptError> {
+    for opcode in parse_script::<DebugTx<'_>, DebugReused>(sigscript) {
+        engine.execute_opcode(opcode?)?;
+    }
+    Ok(())
+}
+
+fn build_opcode_offsets(opcodes: &[Option<DebugOpcode<'_>>]) -> (Vec<usize>, usize) {
+    let mut offsets = Vec::with_capacity(opcodes.len() + 1);
+    let mut offset = 0usize;
+    for opcode in opcodes {
+        offsets.push(offset);
+        if let Some(op) = opcode {
+            offset = offset.saturating_add(op.serialize().len());
+        }
+    }
+    (offsets, offset)
+}

--- a/silverscript-lang/src/lib.rs
+++ b/silverscript-lang/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod ast;
 pub mod compiler;
+pub mod debug;
 pub mod parser;

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -12,6 +12,7 @@ use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::{EngineCtx, EngineFlags, SeqCommitAccessor, TxScriptEngine};
 use silverscript_lang::ast::{Expr, parse_contract_ast};
 use silverscript_lang::compiler::{CompileOptions, CompiledContract, compile_contract, compile_contract_ast, function_branch_index};
+use silverscript_lang::debug::MappingKind;
 
 fn run_script_with_selector(script: Vec<u8>, selector: i64) -> Result<(), kaspa_txscript_errors::TxScriptError> {
     let sigscript = ScriptBuilder::new().add_i64(selector).unwrap().drain();
@@ -262,7 +263,7 @@ fn build_sig_script_omits_selector_without_selector() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = compiled.build_sig_script("spend", vec![1.into(), vec![2u8; 4].into()]).expect("sigscript builds");
 
@@ -526,7 +527,7 @@ fn compiles_int_array_length_to_expected_script() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
 
     let expected = ScriptBuilder::new()
@@ -566,7 +567,7 @@ fn compiles_int_array_push_to_expected_script() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
 
     let expected = ScriptBuilder::new()
@@ -614,7 +615,7 @@ fn compiles_int_array_index_to_expected_script() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
 
     let expected = ScriptBuilder::new()
@@ -671,7 +672,7 @@ fn runs_array_runtime_examples() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = ScriptBuilder::new().drain();
     let result = run_script_with_sigscript(compiled.script, sigscript);
@@ -689,7 +690,7 @@ fn compiles_bytes20_array_push_without_num2bin() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
 
     let value =
@@ -738,7 +739,7 @@ fn runs_bytes20_array_runtime_example() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = ScriptBuilder::new().drain();
     let result = run_script_with_sigscript(compiled.script, sigscript);
@@ -758,7 +759,7 @@ fn allows_array_equality_comparison() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = ScriptBuilder::new().drain();
     let result = run_script_with_sigscript(compiled.script, sigscript);
@@ -778,7 +779,7 @@ fn fails_array_equality_comparison() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = ScriptBuilder::new().drain();
     let result = run_script_with_sigscript(compiled.script, sigscript);
@@ -799,7 +800,7 @@ fn allows_array_inequality_with_different_sizes() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = ScriptBuilder::new().drain();
     let result = run_script_with_sigscript(compiled.script, sigscript);
@@ -821,7 +822,7 @@ fn runs_array_for_loop_example() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = ScriptBuilder::new().drain();
     let result = run_script_with_sigscript(compiled.script, sigscript);
@@ -844,7 +845,7 @@ fn runs_array_for_loop_with_length_guard() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
 
     let sigscript = compiled.build_sig_script("main", vec![vec![1i64, 2i64, 3i64, 4i64].into()]).expect("sigscript builds");
@@ -881,8 +882,8 @@ fn runs_array_loop_and_function_calls_example() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let sigscript = compiled.build_sig_script("main", vec![]).expect("sigscript builds");
+    let result = run_script_with_sigscript(compiled.script, sigscript);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
 
@@ -898,7 +899,7 @@ fn allows_array_assignment_with_compatible_types() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = ScriptBuilder::new().drain();
     let result = run_script_with_sigscript(compiled.script, sigscript);
@@ -914,7 +915,7 @@ fn rejects_unsized_array_type() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     assert!(compile_contract(source, &[], options).is_err());
 }
 
@@ -928,7 +929,7 @@ fn rejects_array_element_assignment() {
             }
         }
     "#;
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     assert!(compile_contract(source, &[], options).is_err());
 }
 
@@ -1050,7 +1051,7 @@ fn compiles_without_selector_single_function() {
     "#;
 
     let contract = parse_contract_ast(source).expect("ast parsed");
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let compiled = compile_contract_ast(&contract, &[], options).expect("compile succeeds");
 
     let expected = ScriptBuilder::new()
@@ -1083,7 +1084,7 @@ fn fails_without_selector_multiple_functions() {
     "#;
 
     let contract = parse_contract_ast(source).expect("ast parsed");
-    let options = CompileOptions { covenants_enabled: true, without_selector: true };
+    let options = CompileOptions { covenants_enabled: true, without_selector: true, ..Default::default() };
     let err = compile_contract_ast(&contract, &[], options).expect_err("should fail without selector for multiple functions");
     assert!(err.to_string().contains("without_selector"));
 }
@@ -2199,4 +2200,27 @@ fn compiles_sigscript_reused_inputs_and_fails_on_wrong_value() {
 
     let result = run_script_with_sigscript(compiled.script, sigscript);
     assert!(result.is_err());
+}
+
+#[test]
+fn debug_spans_are_recorded_for_statements() {
+    let source = r#"
+        contract Debug() {
+            function main() {
+                int x = 1;
+                require(x == 1);
+            }
+        }
+    "#;
+
+    let options = CompileOptions { covenants_enabled: true, without_selector: false, record_debug_spans: true };
+    let compiled = compile_contract(source, &[], options).expect("compile succeeds");
+    let info = compiled.debug_info.expect("debug info recorded");
+
+    let statement_count =
+        info.mappings.iter().filter(|mapping| matches!(mapping.kind, MappingKind::Statement { .. }) && mapping.span.is_some()).count();
+    assert!(statement_count >= 1, "expected at least one statement mapping");
+
+    let has_synthetic = info.mappings.iter().any(|mapping| matches!(mapping.kind, MappingKind::Synthetic { .. }));
+    assert!(has_synthetic, "expected dispatcher synthetic mappings when selector is enabled");
 }

--- a/silverscript-lang/tests/debug_session_tests.rs
+++ b/silverscript-lang/tests/debug_session_tests.rs
@@ -1,0 +1,99 @@
+use std::collections::HashSet;
+use std::error::Error;
+use std::fs;
+use std::path::PathBuf;
+
+use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
+use kaspa_txscript::caches::Cache;
+use kaspa_txscript::{EngineCtx, EngineFlags};
+
+use silverscript_lang::ast::parse_contract_ast;
+use silverscript_lang::compiler::{CompileOptions, compile_contract};
+use silverscript_lang::debug::session::DebugSession;
+
+fn example_contract_path() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.join("tests/examples/if_statement.sil")
+}
+
+fn with_session<F>(mut f: F) -> Result<(), Box<dyn Error>>
+where
+    F: FnMut(&mut DebugSession<'_>) -> Result<(), Box<dyn Error>>,
+{
+    let contract_path = example_contract_path();
+    assert!(contract_path.exists(), "example contract not found: {}", contract_path.display());
+
+    let source = fs::read_to_string(&contract_path)?;
+    let parsed_contract = parse_contract_ast(&source)?;
+
+    let ctor_args = vec![silverscript_lang::ast::Expr::Int(3), silverscript_lang::ast::Expr::Int(10)];
+
+    assert_eq!(parsed_contract.params.len(), ctor_args.len());
+
+    let compile_opts = CompileOptions { covenants_enabled: true, without_selector: false, record_debug_spans: true };
+    let compiled = compile_contract(&source, &ctor_args, compile_opts)?;
+    let debug_info = compiled.debug_info.clone();
+
+    let sig_cache = Cache::new(10_000);
+    let reused_values = SigHashReusedValuesUnsync::new();
+    let ctx = EngineCtx::new(&sig_cache).with_reused(&reused_values);
+
+    let flags = EngineFlags { covenants_enabled: compile_opts.covenants_enabled };
+    let engine = silverscript_lang::debug::session::DebugEngine::new(ctx, flags);
+
+    let selected_name = "hello".to_string();
+    let entry = compiled.abi.iter().find(|entry| entry.name == selected_name).ok_or("function 'hello' not found")?;
+
+    let typed_args = vec![silverscript_lang::ast::Expr::Int(1), silverscript_lang::ast::Expr::Int(2)];
+
+    assert_eq!(entry.inputs.len(), typed_args.len());
+
+    let sigscript = compiled.build_sig_script(&selected_name, typed_args)?;
+    let mut session = DebugSession::full(&sigscript, &compiled.script, &source, debug_info, engine)?;
+
+    f(&mut session)
+}
+
+#[test]
+fn debug_session_provides_source_context_and_vars() -> Result<(), Box<dyn Error>> {
+    with_session(|session| {
+        session.run_to_first_executed_statement()?;
+        let context = session.source_context();
+        assert!(context.is_some(), "expected source context");
+
+        let vars = session.list_variables().expect("variables available");
+        let names = vars.iter().map(|var| var.name.as_str()).collect::<HashSet<_>>();
+        assert!(names.contains("a"), "expected param 'a' in variables");
+        assert!(names.contains("b"), "expected param 'b' in variables");
+
+        Ok(())
+    })
+}
+
+#[test]
+fn debug_session_steps_forward() -> Result<(), Box<dyn Error>> {
+    with_session(|session| {
+        session.run_to_first_executed_statement()?;
+        let before = session.state().pc;
+        session.step_statement()?;
+        let after = session.state().pc;
+        assert!(after > before, "expected pc to advance");
+        Ok(())
+    })
+}
+
+#[test]
+fn debug_session_breakpoint_management() -> Result<(), Box<dyn Error>> {
+    with_session(|session| {
+        session.run_to_first_executed_statement()?;
+        let span = session.current_span().ok_or("no current span")?;
+        let line = span.line;
+
+        session.add_breakpoint(line);
+        assert!(session.breakpoints().contains(&line));
+
+        session.clear_breakpoint(line);
+        assert!(!session.breakpoints().contains(&line));
+        Ok(())
+    })
+}

--- a/silverscript-lang/tests/debugger_cli_tests.rs
+++ b/silverscript-lang/tests/debugger_cli_tests.rs
@@ -1,0 +1,49 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn example_contract_path() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir.join("tests/examples/if_statement.sil")
+}
+
+#[test]
+fn sil_debug_repl_all_commands_smoke() {
+    let contract_path = example_contract_path();
+    assert!(contract_path.exists(), "example contract not found: {}", contract_path.display());
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_sil-debug"))
+        .arg(contract_path)
+        .arg("--function")
+        .arg("hello")
+        .arg("--ctor-arg")
+        .arg("3")
+        .arg("--ctor-arg")
+        .arg("10")
+        .arg("--arg")
+        .arg("1")
+        .arg("--arg")
+        .arg("2")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn sil-debug");
+
+    let input = b"help\nl\nstack\nb 1\nb\nn\nsi\nq\n";
+    child.stdin.as_mut().expect("stdin available").write_all(input).expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for sil-debug");
+    assert!(output.status.success(), "sil-debug exited with status {:?}", output.status.code());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(stderr.is_empty(), "unexpected stderr: {stderr}");
+    assert!(stdout.contains("Stepping through"), "missing startup output");
+    assert!(stdout.contains("(sdb)"), "missing prompt output");
+    assert!(stdout.contains("Commands:"), "missing help output");
+    assert!(stdout.contains("Stack:"), "missing stack output");
+    assert!(stdout.contains("Breakpoint set at line 1"), "missing breakpoint confirmation");
+    assert!(stdout.contains("Breakpoints: 1"), "missing breakpoint listing");
+}

--- a/silverscript-lang/tests/examples/sum_array_calls.sil
+++ b/silverscript-lang/tests/examples/sum_array_calls.sil
@@ -1,0 +1,25 @@
+pragma silverscript ^0.1.0;
+
+contract Sum() {
+    int constant MAX_ARRAY_SIZE = 5;
+
+    function sumArray(int[] arr) : (int) {
+        require(arr.length <= MAX_ARRAY_SIZE);
+        int sum = 0;
+        for (i, 0, MAX_ARRAY_SIZE) {
+            if (i < arr.length) {
+                sum = sum + arr[i];
+            }
+        }
+        return(sum);
+    }
+
+    function main() {
+        int[] x;
+        x.push(1);
+        x.push(2);
+        x.push(3);
+        (int total) = sumArray(x);
+        require(total == 6);
+    }
+}


### PR DESCRIPTION
(Entire code was written by LLM)
The compiler now emits and records debug metadata: it tracks constructor inputs, records every variable assignment as an expression (this allows the debugger to track the current var value by actually running those cached expressions during stepping), and maps opcode offsets to line numbers.
The debugger is split into layers, a session that owns execution state, breakpoints, and expression evaluation as an API, which both a simple CLI and a TUI app use (later we can create a Remix-style web app).

Try -
`cargo run -p silverscript-lang --bin sil-debug-tui -- \
    silverscript-lang/tests/examples/if_statement.sil --function hello \
    --ctor-arg 0 --ctor-arg 2 \
    --arg 1 --arg 1
`