### PR TITLE
Add VS Code extension for SilverScript

### DIFF
--- a/vscode-silverscript/.gitignore
+++ b/vscode-silverscript/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.vsix

--- a/vscode-silverscript/.vscodeignore
+++ b/vscode-silverscript/.vscodeignore
@@ -1,0 +1,2 @@
+.git
+.gitignore

--- a/vscode-silverscript/CHANGELOG.md
+++ b/vscode-silverscript/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [0.1.0] - 2026-02-13
+
+### Added
+- Syntax highlighting for all SilverScript language constructs
+- 18 code snippets for common contract patterns
+- Language configuration (comments, brackets, indentation, folding)
+- Full coverage of PEG grammar: keywords, types, operators, introspection, built-in functions, locking bytecode classes, number units, date literals, and more

--- a/vscode-silverscript/README.md
+++ b/vscode-silverscript/README.md
@@ -1,0 +1,106 @@
+# SilverScript for Visual Studio Code
+
+Syntax highlighting and code snippets for [SilverScript](https://github.com/kaspanet/silverscript) — a smart contract language for Kaspa.
+
+## Features
+
+- Full syntax highlighting for `.sil` files
+- 18 code snippets for common contract patterns
+- Bracket matching, auto-closing pairs, and code folding
+- Indentation support
+
+## Syntax Highlighting
+
+The grammar covers all SilverScript language constructs:
+
+| Element | Scope | Examples |
+|---------|-------|---------|
+| Control flow | `keyword.control` | `if`, `else`, `for`, `return`, `yield`, `require` |
+| Declarations | `keyword.other` | `pragma`, `contract`, `entrypoint`, `function`, `new`, `constant` |
+| Types | `storage.type` | `int`, `bool`, `string`, `pubkey`, `sig`, `datasig`, `byte`, `bytes`, `bytes32` |
+| Booleans | `constant.language.boolean` | `true`, `false` |
+| Numbers | `constant.numeric` | `42`, `1_000`, `1e6`, `0xFF` |
+| Strings | `string.quoted` | `"hello"`, `'world'` |
+| Comments | `comment` | `// line`, `/* block */` |
+| `this.*` introspection | `variable.language.this` | `this.activeInputIndex`, `this.activeBytecode`, `this.age` |
+| `tx.*` introspection | `variable.language.tx` | `tx.version`, `tx.inputs.length`, `tx.outputs[0].value` |
+| Built-in functions | `support.function.builtin` | `blake2b`, `sha256`, `checkSig`, `checkMultiSig`, `checkDataSig` |
+| Locking bytecode classes | `support.class` | `LockingBytecodeP2PK`, `LockingBytecodeP2SH`, etc. |
+| Operators | `keyword.operator` | `+`, `-`, `==`, `!=`, `&&`, `\|\|` |
+| Number units | `support.constant.unit` | `litras`, `grains`, `kas`, `seconds`, `days`, `weeks` |
+| Contract name | `entity.name.type.contract` | name after `contract` |
+| Function name | `entity.name.function` | name after `function` |
+| Postfix methods | `support.function.method` | `.split()`, `.slice()`, `.push()` |
+| Postfix properties | `support.variable.property` | `.length`, `.value`, `.lockingBytecode` |
+| `console.log` | `keyword.other.debug` | `console.log(...)` |
+| `date(...)` | `support.function.date` | `date("2021-01-01T00:00:00")` |
+
+## Snippets
+
+| Prefix | Description |
+|--------|-------------|
+| `pragma` | Pragma directive |
+| `contract` | Complete contract with pragma |
+| `entrypoint` | Entrypoint function |
+| `function` | Internal function |
+| `functionret` | Function with return type |
+| `require` | Require assertion |
+| `requiremsg` | Require with error message |
+| `if` | If statement |
+| `ifelse` | If-else statement |
+| `for` | For loop |
+| `constant` | Constant declaration |
+| `p2pkh` | P2PK contract template |
+| `covenant` | Covenant output check pattern |
+| `checksig` | Signature verification |
+| `timelock` | Time lock check |
+| `yield` | Yield statement |
+| `consolelog` | Debug console.log |
+| `transfertimeout` | Transfer with timeout contract |
+
+## Example
+
+```sil
+pragma silverscript ^0.1.0;
+
+contract TransferWithTimeout(
+    pubkey sender,
+    pubkey recipient,
+    int timeout
+) {
+    entrypoint function transfer(sig recipientSig) {
+        require(checkSig(recipientSig, recipient));
+    }
+
+    entrypoint function reclaim(sig senderSig) {
+        require(checkSig(senderSig, sender));
+        require(tx.time >= timeout);
+    }
+}
+```
+
+## Installation
+
+### From VSIX (local)
+
+```bash
+cd vscode-silverscript
+npx @vscode/vsce package
+code --install-extension silverscript-0.1.0.vsix
+```
+
+### From Source (development)
+
+```bash
+code --extensionDevelopmentPath=/path/to/silverscript/vscode-silverscript
+```
+
+## Links
+
+- [SilverScript Repository](https://github.com/kaspanet/silverscript)
+- [SilverScript Tutorial](https://github.com/kaspanet/silverscript/blob/main/TUTORIAL.md)
+- [Kaspa](https://kaspa.org)
+
+## License
+
+MIT

--- a/vscode-silverscript/language-configuration.json
+++ b/vscode-silverscript/language-configuration.json
@@ -1,0 +1,37 @@
+{
+  "comments": {
+    "lineComment": { "comment": "//" },
+    "blockComment": ["/*", "*/"]
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "'", "close": "'", "notIn": ["string"] },
+    { "open": "/*", "close": "*/", "notIn": ["string"] }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  "indentationRules": {
+    "increaseIndentPattern": "\\{\\s*$",
+    "decreaseIndentPattern": "^\\s*\\}"
+  },
+  "folding": {
+    "markers": {
+      "start": "^\\s*/\\*",
+      "end": "^\\s*\\*/"
+    }
+  },
+  "wordPattern": "[a-zA-Z_][a-zA-Z0-9_]*"
+}

--- a/vscode-silverscript/package.json
+++ b/vscode-silverscript/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "silverscript",
+  "displayName": "SilverScript",
+  "description": "Syntax highlighting and snippets for SilverScript (.sil) — a smart contract language for Kaspa",
+  "version": "0.1.0",
+  "publisher": "kaspanet",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kaspanet/silverscript"
+  },
+  "bugs": {
+    "url": "https://github.com/kaspanet/silverscript/issues"
+  },
+  "engines": {
+    "vscode": "^1.75.0"
+  },
+  "categories": [
+    "Programming Languages",
+    "Snippets"
+  ],
+  "keywords": [
+    "silverscript",
+    "kaspa",
+    "smart contracts",
+    "blockchain",
+    "sil"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "silverscript",
+        "aliases": [
+          "SilverScript",
+          "silverscript"
+        ],
+        "extensions": [
+          ".sil"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "silverscript",
+        "scopeName": "source.silverscript",
+        "path": "./syntaxes/silverscript.tmLanguage.json"
+      }
+    ],
+    "snippets": [
+      {
+        "language": "silverscript",
+        "path": "./snippets/silverscript.json"
+      }
+    ]
+  }
+}

--- a/vscode-silverscript/snippets/silverscript.json
+++ b/vscode-silverscript/snippets/silverscript.json
@@ -1,0 +1,173 @@
+{
+  "Pragma Directive": {
+    "prefix": "pragma",
+    "body": [
+      "pragma silverscript ^${1:0.1.0};"
+    ],
+    "description": "SilverScript pragma directive"
+  },
+  "Contract": {
+    "prefix": "contract",
+    "body": [
+      "pragma silverscript ^${1:0.1.0};",
+      "",
+      "contract ${2:MyContract}(${3:pubkey owner}) {",
+      "    entrypoint function ${4:spend}(${5:sig s}) {",
+      "        $0",
+      "    }",
+      "}"
+    ],
+    "description": "Complete contract with pragma"
+  },
+  "Entrypoint Function": {
+    "prefix": "entrypoint",
+    "body": [
+      "entrypoint function ${1:name}(${2:sig s}) {",
+      "    $0",
+      "}"
+    ],
+    "description": "Entrypoint function"
+  },
+  "Function": {
+    "prefix": "function",
+    "body": [
+      "function ${1:name}(${2:int x}) {",
+      "    $0",
+      "}"
+    ],
+    "description": "Internal function"
+  },
+  "Function with Return Type": {
+    "prefix": "functionret",
+    "body": [
+      "function ${1:name}(${2:int x}): (${3:int}) {",
+      "    $0",
+      "    return (${4:result});",
+      "}"
+    ],
+    "description": "Function with return type"
+  },
+  "Require": {
+    "prefix": "require",
+    "body": [
+      "require(${1:condition});"
+    ],
+    "description": "Require assertion"
+  },
+  "Require with Message": {
+    "prefix": "requiremsg",
+    "body": [
+      "require(${1:condition}, \"${2:error message}\");"
+    ],
+    "description": "Require assertion with error message"
+  },
+  "If Statement": {
+    "prefix": "if",
+    "body": [
+      "if (${1:condition}) {",
+      "    $0",
+      "}"
+    ],
+    "description": "If statement"
+  },
+  "If-Else Statement": {
+    "prefix": "ifelse",
+    "body": [
+      "if (${1:condition}) {",
+      "    $2",
+      "} else {",
+      "    $0",
+      "}"
+    ],
+    "description": "If-else statement"
+  },
+  "For Loop": {
+    "prefix": "for",
+    "body": [
+      "for (${1:i}, ${2:0}, ${3:END}) {",
+      "    $0",
+      "}"
+    ],
+    "description": "For loop"
+  },
+  "Constant": {
+    "prefix": "constant",
+    "body": [
+      "${1:int} constant ${2:NAME} = ${3:value};"
+    ],
+    "description": "Constant declaration"
+  },
+  "P2PK Contract": {
+    "prefix": "p2pkh",
+    "body": [
+      "pragma silverscript ^0.1.0;",
+      "",
+      "contract P2PK(pubkey pk) {",
+      "    entrypoint function spend(sig s) {",
+      "        require(checkSig(s, pk));",
+      "    }",
+      "}"
+    ],
+    "description": "Pay-to-Public-Key contract template"
+  },
+  "Covenant Pattern": {
+    "prefix": "covenant",
+    "body": [
+      "// Enforce output locking bytecode",
+      "bytes34 ${1:recipientLock} = new LockingBytecodeP2PK(${2:recipient});",
+      "require(tx.outputs[${3:0}].lockingBytecode == ${1:recipientLock});",
+      "require(tx.outputs[${3:0}].value >= ${4:amount});"
+    ],
+    "description": "Covenant output check pattern"
+  },
+  "Check Signature": {
+    "prefix": "checksig",
+    "body": [
+      "require(checkSig(${1:s}, ${2:pk}));"
+    ],
+    "description": "Signature verification"
+  },
+  "Time Lock": {
+    "prefix": "timelock",
+    "body": [
+      "require(${1|this.age,tx.time|} >= ${2:timeout});"
+    ],
+    "description": "Time lock check"
+  },
+  "Yield": {
+    "prefix": "yield",
+    "body": [
+      "yield(${1:expression});"
+    ],
+    "description": "Yield statement"
+  },
+  "Console Log": {
+    "prefix": "consolelog",
+    "body": [
+      "console.log(${1:value});"
+    ],
+    "description": "Debug console.log"
+  },
+  "Transfer with Timeout": {
+    "prefix": "transfertimeout",
+    "body": [
+      "pragma silverscript ^0.1.0;",
+      "",
+      "contract TransferWithTimeout(",
+      "    pubkey sender,",
+      "    pubkey recipient,",
+      "    int timeout",
+      ") {",
+      "    entrypoint function transfer(sig recipientSig) {",
+      "        require(checkSig(recipientSig, recipient));",
+      "    }",
+      "",
+      "    entrypoint function reclaim(sig senderSig) {",
+      "        require(checkSig(senderSig, sender));",
+      "        require(tx.time >= timeout);",
+      "    }",
+      "}"
+    ],
+    "description": "Transfer with timeout contract template"
+  }
+}

--- a/vscode-silverscript/syntaxes/silverscript.tmLanguage.json
+++ b/vscode-silverscript/syntaxes/silverscript.tmLanguage.json
@@ -1,0 +1,301 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "SilverScript",
+  "scopeName": "source.silverscript",
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#pragma" },
+    { "include": "#contract-definition" },
+    { "include": "#function-definition" },
+    { "include": "#introspection-this" },
+    { "include": "#introspection-tx-nullary" },
+    { "include": "#introspection-tx-indexed" },
+    { "include": "#console-log" },
+    { "include": "#date-literal" },
+    { "include": "#instantiation" },
+    { "include": "#keywords" },
+    { "include": "#builtin-functions" },
+    { "include": "#types" },
+    { "include": "#constants" },
+    { "include": "#number-with-unit" },
+    { "include": "#numbers" },
+    { "include": "#strings" },
+    { "include": "#operators" },
+    { "include": "#postfix-methods" },
+    { "include": "#postfix-properties" },
+    { "include": "#punctuation" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.block.silverscript",
+          "begin": "/\\*",
+          "end": "\\*/",
+          "beginCaptures": { "0": { "name": "punctuation.definition.comment.begin.silverscript" } },
+          "endCaptures": { "0": { "name": "punctuation.definition.comment.end.silverscript" } }
+        },
+        {
+          "name": "comment.line.double-slash.silverscript",
+          "match": "//.*$",
+          "captures": { "0": { "name": "comment.line.double-slash.silverscript" } }
+        }
+      ]
+    },
+    "pragma": {
+      "patterns": [
+        {
+          "match": "\\b(pragma)\\s+(silverscript)\\s+([^;]+)",
+          "captures": {
+            "1": { "name": "keyword.other.pragma.silverscript" },
+            "2": { "name": "entity.name.tag.silverscript" },
+            "3": { "name": "constant.other.version.silverscript" }
+          }
+        }
+      ]
+    },
+    "contract-definition": {
+      "patterns": [
+        {
+          "match": "\\b(contract)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+          "captures": {
+            "1": { "name": "keyword.other.contract.silverscript" },
+            "2": { "name": "entity.name.type.contract.silverscript" }
+          }
+        }
+      ]
+    },
+    "function-definition": {
+      "patterns": [
+        {
+          "match": "\\b(entrypoint)\\s+(function)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+          "captures": {
+            "1": { "name": "keyword.other.entrypoint.silverscript" },
+            "2": { "name": "keyword.other.function.silverscript" },
+            "3": { "name": "entity.name.function.silverscript" }
+          }
+        },
+        {
+          "match": "\\b(function)\\s+([a-zA-Z_][a-zA-Z0-9_]*)",
+          "captures": {
+            "1": { "name": "keyword.other.function.silverscript" },
+            "2": { "name": "entity.name.function.silverscript" }
+          }
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.silverscript",
+          "match": "\\b(if|else|for|return|yield|require)\\b"
+        },
+        {
+          "name": "keyword.other.silverscript",
+          "match": "\\b(pragma|contract|entrypoint|function|new|constant)\\b"
+        }
+      ]
+    },
+    "introspection-this": {
+      "patterns": [
+        {
+          "name": "variable.language.this.silverscript",
+          "match": "\\b(this\\.scriptSizeDataPrefix|this\\.scriptSize|this\\.activeInputIndex|this\\.activeBytecode|this\\.age)\\b"
+        }
+      ]
+    },
+    "introspection-tx-nullary": {
+      "patterns": [
+        {
+          "name": "variable.language.tx.silverscript",
+          "match": "\\b(tx\\.inputs\\.length|tx\\.outputs\\.length|tx\\.version|tx\\.locktime|tx\\.time)\\b"
+        }
+      ]
+    },
+    "introspection-tx-indexed": {
+      "patterns": [
+        {
+          "match": "\\b(tx\\.outputs)\\s*(\\[)",
+          "captures": {
+            "1": { "name": "variable.language.tx.silverscript" },
+            "2": { "name": "punctuation.bracket.square.silverscript" }
+          }
+        },
+        {
+          "match": "\\b(tx\\.inputs)\\s*(\\[)",
+          "captures": {
+            "1": { "name": "variable.language.tx.silverscript" },
+            "2": { "name": "punctuation.bracket.square.silverscript" }
+          }
+        },
+        {
+          "match": "\\.(value|lockingBytecode|tokenCategory|nftCommitment|tokenAmount|outpointTransactionHash|outpointIndex|unlockingBytecode|sequenceNumber)\\b",
+          "captures": {
+            "1": { "name": "support.variable.property.silverscript" }
+          }
+        }
+      ]
+    },
+    "console-log": {
+      "patterns": [
+        {
+          "match": "\\b(console\\.log)\\b",
+          "name": "keyword.other.debug.silverscript"
+        }
+      ]
+    },
+    "date-literal": {
+      "patterns": [
+        {
+          "match": "\\b(date)\\s*(?=\\()",
+          "captures": {
+            "1": { "name": "support.function.date.silverscript" }
+          }
+        }
+      ]
+    },
+    "instantiation": {
+      "patterns": [
+        {
+          "match": "\\b(new)\\s+(LockingBytecodeP2SHFromRedeemScript|LockingBytecodeP2SH|LockingBytecodeP2PK|LockingBytecodeNullData)\\b",
+          "captures": {
+            "1": { "name": "keyword.other.new.silverscript" },
+            "2": { "name": "support.class.silverscript" }
+          }
+        }
+      ]
+    },
+    "builtin-functions": {
+      "patterns": [
+        {
+          "name": "support.function.builtin.silverscript",
+          "match": "\\b(blake2b|sha256|checkSig|checkMultiSig|checkDataSig|OpNum2Bin|OpBin2Num|length)\\b"
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "name": "storage.type.silverscript",
+          "match": "\\b(bytes)([1-9][0-9]*)\\b"
+        },
+        {
+          "name": "storage.type.silverscript",
+          "match": "\\b(int|bool|string|pubkey|sig|datasig|byte|bytes)\\b"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.language.boolean.silverscript",
+          "match": "\\b(true|false)\\b"
+        }
+      ]
+    },
+    "number-with-unit": {
+      "patterns": [
+        {
+          "match": "(?<=[0-9])\\s+(litras|grains|kas|seconds|minutes|hours|days|weeks)\\b",
+          "captures": {
+            "1": { "name": "support.constant.unit.silverscript" }
+          }
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hex.silverscript",
+          "match": "\\b0[xX][0-9a-fA-F]*\\b"
+        },
+        {
+          "name": "constant.numeric.decimal.silverscript",
+          "match": "\\b-?[0-9][0-9_]*([eE][0-9][0-9_]*)?\\b"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.silverscript",
+          "begin": "\"",
+          "end": "\"",
+          "beginCaptures": { "0": { "name": "punctuation.definition.string.begin.silverscript" } },
+          "endCaptures": { "0": { "name": "punctuation.definition.string.end.silverscript" } },
+          "patterns": [
+            {
+              "name": "constant.character.escape.silverscript",
+              "match": "\\\\."
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.single.silverscript",
+          "begin": "'",
+          "end": "'",
+          "beginCaptures": { "0": { "name": "punctuation.definition.string.begin.silverscript" } },
+          "endCaptures": { "0": { "name": "punctuation.definition.string.end.silverscript" } },
+          "patterns": [
+            {
+              "name": "constant.character.escape.silverscript",
+              "match": "\\\\."
+            }
+          ]
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.logical.silverscript",
+          "match": "\\|\\||&&|!"
+        },
+        {
+          "name": "keyword.operator.comparison.silverscript",
+          "match": "==|!=|<=|>=|<|>"
+        },
+        {
+          "name": "keyword.operator.arithmetic.silverscript",
+          "match": "\\+|-|\\*|/|%"
+        },
+        {
+          "name": "keyword.operator.bitwise.silverscript",
+          "match": "\\||\\^|&"
+        },
+        {
+          "name": "keyword.operator.assignment.silverscript",
+          "match": "="
+        }
+      ]
+    },
+    "postfix-methods": {
+      "patterns": [
+        {
+          "match": "\\.(split|slice|push)\\s*(?=\\()",
+          "captures": {
+            "1": { "name": "support.function.method.silverscript" }
+          }
+        }
+      ]
+    },
+    "postfix-properties": {
+      "patterns": [
+        {
+          "match": "\\.(length)\\b",
+          "captures": {
+            "1": { "name": "support.variable.property.silverscript" }
+          }
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        {
+          "name": "punctuation.separator.silverscript",
+          "match": "[;,]"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a complete VS Code extension under `vscode-silverscript/` that provides developer tooling for `.sil` files. Currently, there is no editor support for SilverScript — developers write contracts without syntax highlighting, code snippets, or any IDE assistance. This PR aims to change that.

**What's included:**

- **TextMate grammar** (`silverscript.tmLanguage.json`) — full syntax highlighting derived from `silverscript.pest`, covering all language constructs: keywords, types (`int`, `bool`, `pubkey`, `sig`, `datasig`, `bytesN`), literals (numbers, hex, strings, booleans), operators, comments, introspection fields (`this.*`, `tx.*`), built-in functions (`blake2b`, `sha256`, `checkSig`, `checkMultiSig`, `checkDataSig`, `OpNum2Bin`, `OpBin2Num`), locking bytecode classes (`LockingBytecodeP2PK`, `LockingBytecodeP2SH`, etc.), number units (`litras`, `grains`, `kas`, `seconds`, `days`, `weeks`), `date()` literals, `console.log`, postfix methods (`.split()`, `.slice()`, `.push()`), and postfix properties (`.length`, `.value`, `.lockingBytecode`, etc.)
- **18 code snippets** — common patterns like `contract`, `entrypoint`, `require`, `for`, `checksig`, `covenant`, `timelock`, `transfertimeout`, and more
- **Language configuration** — comment toggling (`//`, `/* */`), bracket matching, auto-closing pairs, indentation rules, and code folding

**How it was validated:**

- Grammar was tested programmatically using the `vscode-textmate` engine (the same tokenizer VS Code uses internally) against 10 example files from `silverscript-lang/tests/examples/`, totaling 73 assertions — all passing
- Visually tested in VS Code with `--extensionDevelopmentPath`

**Structure:**

```
vscode-silverscript/
├── package.json                        # Extension manifest
├── language-configuration.json         # Comments, brackets, indentation
├── syntaxes/
│   └── silverscript.tmLanguage.json    # TextMate grammar
├── snippets/
│   └── silverscript.json               # Code snippets
├── README.md                           # Documentation
├── CHANGELOG.md                        # v0.1.0
├── .vscodeignore
└── .gitignore
```

## Disclosure

This extension was generated with AI assistance (Claude). Please review all files carefully before merging — in particular the TextMate grammar patterns and their ordering, which are critical for correct tokenization. The grammar was derived directly from `silverscript.pest` and validated against example contracts, but edge cases may exist.

## Test plan

- [ ] Open VS Code with `code --extensionDevelopmentPath=./vscode-silverscript`
- [ ] Open example `.sil` files from `silverscript-lang/tests/examples/` and verify highlighting
- [ ] Test snippets by typing prefixes (e.g., `contract`, `require`, `checksig`) in a `.sil` file
- [ ] Verify comment toggling with `Ctrl+/` and `Shift+Alt+A`
- [ ] Verify bracket matching and auto-closing pairs
- [ ] Optionally package with `npx @vscode/vsce package` and install the `.vsix`