### PR TITLE
Fix debugger shadow eval for array params

### DIFF
--- a/debugger/session/src/session.rs
+++ b/debugger/session/src/session.rs
@@ -928,6 +928,7 @@ mod tests {
     use super::*;
 
     use silverscript_lang::ast::{BinaryOp, Expr, ExprKind};
+    use silverscript_lang::compiler::{CompileOptions, compile_contract};
     use silverscript_lang::debug_info::{
         DebugConstantMapping, DebugFunctionRange, DebugInfo, DebugParamMapping, DebugStep, DebugVariableUpdate, SourceSpan, StepKind,
     };
@@ -987,6 +988,46 @@ mod tests {
         };
         let value = session.evaluate_update_with_shadow_vm("f", &update, &HashMap::new()).unwrap();
         assert!(matches!(value, DebugValue::Int(12)));
+    }
+
+    #[test]
+    fn shadow_vm_evaluates_array_param_index_expression() {
+        let source = r#"
+            contract Demo() {
+                entrypoint function main(int[] payouts) {
+                    require(payouts.length >= 2);
+                }
+            }
+        "#;
+        let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+        let sigscript = compiled.build_sig_script("main", vec![vec![1500i64, 1400i64, 2100i64].into()]).expect("sigscript builds");
+
+        let session = make_session(
+            vec![DebugParamMapping {
+                name: "payouts".to_string(),
+                type_name: "int[]".to_string(),
+                stack_index: 0,
+                function: "f".to_string(),
+            }],
+            vec![],
+            &sigscript,
+        )
+        .unwrap();
+
+        let mut updates = HashMap::new();
+        let j_update = DebugVariableUpdate { name: "j".to_string(), type_name: "int".to_string(), expr: Expr::int(1) };
+        updates.insert("j".to_string(), &j_update);
+
+        let update = DebugVariableUpdate {
+            name: "item".to_string(),
+            type_name: "int".to_string(),
+            expr: Expr::new(
+                ExprKind::ArrayIndex { source: Box::new(Expr::identifier("payouts")), index: Box::new(Expr::identifier("j")) },
+                span::Span::default(),
+            ),
+        };
+        let value = session.evaluate_update_with_shadow_vm("f", &update, &updates).unwrap();
+        assert!(matches!(value, DebugValue::Int(1400)));
     }
 
     #[test]

--- a/silverscript-lang/src/compiler.rs
+++ b/silverscript-lang/src/compiler.rs
@@ -3225,7 +3225,7 @@ fn compile_inline_call<'i>(
     }
 
     let call_start = builder.script().len();
-    recorder.begin_inline_call(call_span, call_start, function, &bindings.debug_env)?;
+    recorder.begin_inline_call(call_span, call_start, function, &bindings.debug_env, &bindings.types)?;
 
     let mut yields: Vec<Expr<'i>> = Vec::new();
     let body_len = function.body.len();
@@ -5386,9 +5386,10 @@ pub fn compile_debug_expr<'i>(
 pub(super) fn resolve_expr_for_debug<'i>(
     expr: Expr<'i>,
     env: &HashMap<String, Expr<'i>>,
+    types: &HashMap<String, String>,
     visiting: &mut HashSet<String>,
 ) -> Result<Expr<'i>, CompilerError> {
-    resolve_expr(expr, env, visiting)
+    resolve_expr_for_runtime(expr, env, types, visiting)
 }
 
 #[cfg(test)]

--- a/silverscript-lang/src/compiler/debug_recording.rs
+++ b/silverscript-lang/src/compiler/debug_recording.rs
@@ -72,8 +72,9 @@ impl<'i> DebugRecorder<'i> {
         bytecode_offset: usize,
         function: &FunctionAst<'i>,
         env: &HashMap<String, Expr<'i>>,
+        types: &HashMap<String, String>,
     ) -> Result<(), CompilerError> {
-        self.inner.begin_inline_call(span, bytecode_offset, function, env)
+        self.inner.begin_inline_call(span, bytecode_offset, function, env, types)
     }
 
     /// Records an inline call exit step and closes the active nested call frame.
@@ -118,6 +119,7 @@ trait DebugRecorderImpl<'i>: fmt::Debug {
         bytecode_offset: usize,
         function: &FunctionAst<'i>,
         env: &HashMap<String, Expr<'i>>,
+        types: &HashMap<String, String>,
     ) -> Result<(), CompilerError>;
     fn finish_inline_call(&mut self, span: SourceSpan, bytecode_offset: usize, callee: &str);
     fn record_variable_binding(&mut self, name: String, type_name: String, expr: Expr<'i>, bytecode_offset: usize, span: SourceSpan);
@@ -150,6 +152,7 @@ impl<'i> DebugRecorderImpl<'i> for NoopDebugRecorder {
         _bytecode_offset: usize,
         _function: &FunctionAst<'i>,
         _env: &HashMap<String, Expr<'i>>,
+        _types: &HashMap<String, String>,
     ) -> Result<(), CompilerError> {
         Ok(())
     }
@@ -255,6 +258,7 @@ impl<'i> DebugRecorderImpl<'i> for ActiveDebugRecorder<'i> {
         bytecode_offset: usize,
         function: &FunctionAst<'i>,
         env: &HashMap<String, Expr<'i>>,
+        types: &HashMap<String, String>,
     ) -> Result<(), CompilerError> {
         let Some(entrypoint) = self.active_entrypoint_mut() else {
             return Ok(());
@@ -276,13 +280,14 @@ impl<'i> DebugRecorderImpl<'i> for ActiveDebugRecorder<'i> {
         synthetic_names.sort_unstable();
         for name in synthetic_names {
             if let Some(expr) = env.get(&name).cloned() {
-                resolve_variable_update(env, &mut updates, &name, "internal", expr)?;
+                resolve_variable_update(env, types, &mut updates, &name, "internal", expr)?;
             }
         }
 
         for param in &function.params {
             resolve_variable_update(
                 env,
+                types,
                 &mut updates,
                 &param.name,
                 &param.type_ref.type_name(),
@@ -486,19 +491,20 @@ fn collect_variable_updates<'i>(
         let Some(type_name) = types.get(&name) else {
             continue;
         };
-        resolve_variable_update(after_env, &mut updates, &name, type_name, after_expr.clone())?;
+        resolve_variable_update(after_env, types, &mut updates, &name, type_name, after_expr.clone())?;
     }
     Ok(updates)
 }
 
 fn resolve_variable_update<'i>(
     env: &HashMap<String, Expr<'i>>,
+    types: &HashMap<String, String>,
     updates: &mut Vec<DebugVariableUpdate<'i>>,
     name: &str,
     type_name: &str,
     expr: Expr<'i>,
 ) -> Result<(), CompilerError> {
-    let resolved = resolve_expr_for_debug(expr, env, &mut HashSet::new())?;
+    let resolved = resolve_expr_for_debug(expr, env, types, &mut HashSet::new())?;
     updates.push(DebugVariableUpdate { name: name.to_string(), type_name: type_name.to_string(), expr: resolved });
     Ok(())
 }
@@ -535,7 +541,7 @@ mod tests {
         recorder.begin_statement_at(0, &HashMap::new());
         recorder.finish_statement_at(stmt, 0, &HashMap::new(), &HashMap::new()).expect("noop statement recording");
 
-        recorder.begin_inline_call(span, 1, function, &HashMap::new()).expect("noop begin call recording");
+        recorder.begin_inline_call(span, 1, function, &HashMap::new(), &HashMap::new()).expect("noop begin call recording");
         recorder.finish_inline_call(span, 2, "callee");
         recorder.record_variable_binding("tmp".to_string(), "int".to_string(), Expr::int(1), 2, span);
         recorder.finish_entrypoint(1);
@@ -576,7 +582,7 @@ mod tests {
         let span = SourceSpan::from(stmt.span());
         let mut inline_env = HashMap::new();
         inline_env.insert("x".to_string(), Expr::int(3));
-        recorder.begin_inline_call(span, 1, function, &inline_env).expect("begin call recording");
+        recorder.begin_inline_call(span, 1, function, &inline_env, &types).expect("begin call recording");
         recorder.record_variable_binding("tmp".to_string(), "int".to_string(), Expr::int(9), 1, span);
         recorder.finish_inline_call(span, 2, "callee");
 

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -5309,3 +5309,32 @@ fn nested_inline_calls_with_args_compile_and_execute() {
     let result = run_script_with_sigscript(compiled.script, sigscript);
     assert!(result.is_ok(), "nested inline calls should execute correctly: {}", result.unwrap_err());
 }
+
+#[test]
+fn debug_recording_preserves_array_params_in_inline_updates() {
+    let source = r#"
+        contract DebugArrayArgs() {
+            int constant MAX_RECIPIENTS = 5;
+
+            function sumArray(int[] arr) : (int) {
+                int total = 0;
+                for (i, 0, MAX_RECIPIENTS) {
+                    if (i < arr.length) {
+                        total = total + arr[i];
+                    }
+                }
+                return(total);
+            }
+
+            entrypoint function main(int[] payouts) {
+                require(payouts.length <= MAX_RECIPIENTS);
+                (int total) = sumArray(payouts);
+                require(total >= 0);
+            }
+        }
+    "#;
+
+    let options = CompileOptions { record_debug_infos: true, ..Default::default() };
+    let compiled = compile_contract(source, &[], options).expect("debug compile succeeds");
+    assert!(compiled.debug_info.is_some(), "debug info should be recorded");
+}


### PR DESCRIPTION
Fixes a debugger issue - var inspection fail for array indexing :
`int item = array[j];`
To fix this, the recorder keeps array identifiers in debug recording so the debugger can evaluate those updates correctly.