### PR TITLE
Clarify scalar byte casts for one-byte hex literals

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -519,6 +519,13 @@ byte[] empty = 0x;
 byte[] pubkeyBytes = 0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef;
 ```
 
+Hex literals are always parsed as byte sequences. That means `0x00` is not a scalar `byte`; use an explicit cast when you want one:
+
+```javascript
+byte bad = 0x00;        // compiler error: use byte(0x00) to cast a one-byte hex literal to byte
+byte good = byte(0x00); // compiles
+```
+
 ### Number Units
 
 SilverScript supports convenient number units for values and time:
@@ -719,6 +726,9 @@ byte[] fromString = byte[]("hello");
 // Cast to specific byte size
 byte[32] hash = byte[32](data);
 byte[65] signatureBytes = byte[65](sigBytes);
+
+// Cast a one-byte hex literal to scalar byte
+byte b = byte(0x00);
 
 // Cast to pubkey or sig
 pubkey pk = pubkey(keyBytes);

--- a/silverscript-lang/src/compiler.rs
+++ b/silverscript-lang/src/compiler.rs
@@ -1854,6 +1854,18 @@ fn expr_matches_return_type_ref<'i>(
     }
 }
 
+fn expr_matches_return_type_ref_hint<'i>(expr: &Expr<'i>, type_ref: &TypeRef) -> Option<String> {
+    match (&expr.kind, &type_ref.base, type_ref.array_dims.is_empty()) {
+        (ExprKind::Array(values), TypeBase::Byte, true) if values.len() == 1 => match values[0].kind {
+            ExprKind::Byte(byte) => {
+                Some(format!("hex literals are byte arrays; use byte({byte:#04x}) to cast a one-byte hex literal to byte"))
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 fn infer_fixed_array_type_from_initializer_ref<'i>(
     declared_type: &TypeRef,
     initializer: Option<&Expr<'i>>,
@@ -2665,7 +2677,14 @@ fn compile_statement<'i>(
                 let expr = lower_runtime_expr(&expr, types, structs)?;
                 let expected_type_ref = parse_type_ref(&effective_type_name)?;
                 if !expr_matches_return_type_ref(&expr, &expected_type_ref, types, contract_constants) {
-                    return Err(CompilerError::Unsupported(format!("variable '{}' expects {}", name, effective_type_name)));
+                    return Err(CompilerError::Unsupported(format!(
+                        "variable '{}' expects {}{}",
+                        name,
+                        effective_type_name,
+                        expr_matches_return_type_ref_hint(&expr, &expected_type_ref)
+                            .map(|hint| format!("; {hint}"))
+                            .unwrap_or_default()
+                    )));
                 }
                 types.insert(name.clone(), effective_type_name.clone());
                 let existing_is_predeclared_default = is_predeclared_scalar_default(name, &effective_type_name, env);
@@ -3183,7 +3202,14 @@ fn compile_statement<'i>(
                 }
                 let lowered_expr = lower_runtime_expr(expr, types, structs)?;
                 if !expr_matches_return_type_ref(&lowered_expr, &expected_type_ref, types, contract_constants) {
-                    return Err(CompilerError::Unsupported(format!("variable '{}' expects {}", name, type_name)));
+                    return Err(CompilerError::Unsupported(format!(
+                        "variable '{}' expects {}{}",
+                        name,
+                        type_name,
+                        expr_matches_return_type_ref_hint(&lowered_expr, &expected_type_ref)
+                            .map(|hint| format!("; {hint}"))
+                            .unwrap_or_default()
+                    )));
                 }
                 let updated =
                     if let Some(previous) = env.get(name) { replace_identifier(&lowered_expr, name, previous) } else { lowered_expr };

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -3850,6 +3850,26 @@ fn plain_state_return_accepts_local_fixed_byte_field_from_local_identifier() {
 }
 
 #[test]
+fn byte_hex_literal_error_recommends_scalar_cast() {
+    let source = r#"
+        contract C() {
+            entrypoint function main() {
+                byte local = 0x07;
+                require(local == local);
+            }
+        }
+    "#;
+
+    let err =
+        compile_contract(source, &[], CompileOptions::default()).expect_err("scalar byte hex literal should require an explicit cast");
+
+    assert_eq!(
+        err.to_string(),
+        "unsupported feature: variable 'local' expects byte; hex literals are byte arrays; use byte(0x07) to cast a one-byte hex literal to byte"
+    );
+}
+
+#[test]
 fn compiles_read_input_state_to_expected_script() {
     let source = r#"
         contract C(int initX, byte[2] initY) {


### PR DESCRIPTION
Improves the error message for cases like `byte b = 0x00`, which fail because hex literals are parsed as byte sequences rather than scalar `byte` values:

- add a compiler hint recommending `byte(0x..)` with the actual literal value
- clarify the tutorial with a short failing/working example
- add a regression test for the diagnostic