### PR TITLE
Support console logging functionality in the debugger

### DIFF
--- a/debugger/cli/src/main.rs
+++ b/debugger/cli/src/main.rs
@@ -154,9 +154,30 @@ fn print_variable_section(
     }
 }
 
-fn show_step_view(session: &DebugSession<'_, '_>) {
+fn print_console_messages(lines: &[String]) {
+    for line in lines {
+        println!("{line}");
+    }
+}
+
+fn print_non_status_stdout(stdout: &str) {
+    for line in stdout.lines() {
+        if line == "PASS" || line == "PASS (expected failure)" {
+            continue;
+        }
+        println!("{line}");
+    }
+    if stdout.ends_with('\n') || stdout.is_empty() {
+        return;
+    }
+    println!();
+}
+
+fn show_step_view(session: &DebugSession<'_, '_>, console_lines: &[String]) {
     show_source_context(session);
     show_vars(session);
+    println!("Console:");
+    print_console_messages(console_lines);
 }
 
 fn print_failure(session: &DebugSession<'_, '_>, err: kaspa_txscript_errors::TxScriptError) {
@@ -180,8 +201,12 @@ fn run_repl(session: &mut DebugSession<'_, '_>) -> Result<(), Box<dyn std::error
         let cmd = cmd.trim();
         if cmd.is_empty() || cmd == "n" || cmd == "next" {
             match session.step_over() {
-                Ok(Some(_)) => show_step_view(session),
-                Ok(None) => {
+                Ok(Some(_)) => {
+                    let console_output = session.take_console_output();
+                    show_step_view(session, &console_output);
+                }
+                Ok(_) => {
+                    print_console_messages(&session.take_console_output());
                     println!("Done.");
                     break;
                 }
@@ -198,8 +223,12 @@ fn run_repl(session: &mut DebugSession<'_, '_>) -> Result<(), Box<dyn std::error
         let rest = parts.next().unwrap_or("").trim();
         match command {
             "step" | "s" => match session.step_into() {
-                Ok(Some(_)) => show_step_view(session),
-                Ok(None) => {
+                Ok(Some(_)) => {
+                    let console_output = session.take_console_output();
+                    show_step_view(session, &console_output);
+                }
+                Ok(_) => {
+                    print_console_messages(&session.take_console_output());
                     println!("Done.");
                     break;
                 }
@@ -209,8 +238,12 @@ fn run_repl(session: &mut DebugSession<'_, '_>) -> Result<(), Box<dyn std::error
                 }
             },
             "si" => match session.step_opcode() {
-                Ok(Some(_)) => show_step_view(session),
-                Ok(None) => {
+                Ok(Some(_)) => {
+                    let console_output = session.take_console_output();
+                    show_step_view(session, &console_output);
+                }
+                Ok(_) => {
+                    print_console_messages(&session.take_console_output());
                     println!("Done.");
                     break;
                 }
@@ -220,8 +253,12 @@ fn run_repl(session: &mut DebugSession<'_, '_>) -> Result<(), Box<dyn std::error
                 }
             },
             "finish" | "out" => match session.step_out() {
-                Ok(Some(_)) => show_step_view(session),
-                Ok(None) => {
+                Ok(Some(_)) => {
+                    let console_output = session.take_console_output();
+                    show_step_view(session, &console_output);
+                }
+                Ok(_) => {
+                    print_console_messages(&session.take_console_output());
                     println!("Done.");
                     break;
                 }
@@ -231,8 +268,12 @@ fn run_repl(session: &mut DebugSession<'_, '_>) -> Result<(), Box<dyn std::error
                 }
             },
             "c" | "continue" => match session.continue_to_breakpoint() {
-                Ok(Some(_)) => show_step_view(session),
+                Ok(Some(_)) => {
+                    let console_output = session.take_console_output();
+                    show_step_view(session, &console_output);
+                }
                 Ok(None) => {
+                    print_console_messages(&session.take_console_output());
                     println!("Done.");
                     break;
                 }
@@ -317,7 +358,12 @@ fn run_all_tests(test_file: &str, script_path: Option<&str>) -> Result<(), Box<d
             args.push(path);
         }
         let result = std::process::Command::new(std::env::current_exe()?).args(&args).output()?;
+        let stdout = String::from_utf8_lossy(&result.stdout);
         let stderr = String::from_utf8_lossy(&result.stderr);
+        println!("  RUN   {name}");
+        if !stdout.is_empty() {
+            print_non_status_stdout(&stdout);
+        }
         if result.status.success() {
             passed += 1;
             println!("  PASS  {name}");
@@ -549,12 +595,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if cli.run {
         let expect_fail = expect == Some(TestExpectation::Fail);
-        match session.continue_to_breakpoint() {
-            Ok(_) if expect_fail => {
+        match session.run_to_completion() {
+            Ok(()) if expect_fail => {
+                print_console_messages(&session.take_console_output());
                 eprintln!("FAIL: expected failure but script passed");
                 Err("FAIL".into())
             }
-            Ok(_) => {
+            Ok(()) => {
+                print_console_messages(&session.take_console_output());
                 println!("PASS");
                 Ok(())
             }
@@ -570,7 +618,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         println!("Stepping through {} bytes of script", compiled.script.len());
         session.run_to_first_executed_statement()?;
-        show_source_context(&session);
+        let console_output = session.take_console_output();
+        show_step_view(&session, &console_output);
         run_repl(&mut session)?;
         Ok(())
     }

--- a/debugger/cli/tests/cli_tests.rs
+++ b/debugger/cli/tests/cli_tests.rs
@@ -6,6 +6,49 @@ fn write_test_fixture() -> (std::path::PathBuf, std::path::PathBuf) {
     write_named_test_fixture("simple.sil", "simple.test.json")
 }
 
+fn write_logging_test_fixture() -> (std::path::PathBuf, std::path::PathBuf) {
+    let nonce = SystemTime::now().duration_since(UNIX_EPOCH).expect("clock").as_nanos();
+    let dir = std::env::temp_dir().join(format!("cli_debugger_logging_fixture_{}_{}", std::process::id(), nonce));
+    std::fs::create_dir_all(&dir).expect("create temp fixture dir");
+
+    let script_path = dir.join("logging.sil");
+    let test_file_path = dir.join("logging.test.json");
+
+    std::fs::write(
+        &script_path,
+        r#"pragma silverscript ^0.1.0;
+
+contract Logging(int seed) {
+    entrypoint function check(int a) {
+        console.log("seed", seed);
+        console.log("sum", seed + a);
+        require(seed + a > 0);
+    }
+}
+"#,
+    )
+    .expect("write logging fixture contract");
+
+    std::fs::write(
+        &test_file_path,
+        r#"{
+  "tests": [
+    {
+      "name": "log_case",
+      "function": "check",
+      "constructor_args": [5],
+      "args": [4],
+      "expect": "pass"
+    }
+  ]
+}
+"#,
+    )
+    .expect("write logging fixture test file");
+
+    (script_path, test_file_path)
+}
+
 fn write_named_test_fixture(script_name: &str, test_file_name: &str) -> (std::path::PathBuf, std::path::PathBuf) {
     let nonce = SystemTime::now().duration_since(UNIX_EPOCH).expect("clock").as_nanos();
     let dir = std::env::temp_dir().join(format!("cli_debugger_test_fixture_{}_{}", std::process::id(), nonce));
@@ -157,6 +200,36 @@ fn cli_debugger_eval_command_reports_results_and_errors() {
 }
 
 #[test]
+fn cli_debugger_interactive_prints_console_logs_automatically() {
+    let (script_path, _test_file_path) = write_logging_test_fixture();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cli-debugger"))
+        .arg(&script_path)
+        .arg("--function")
+        .arg("check")
+        .arg("--ctor-arg")
+        .arg("5")
+        .arg("--arg")
+        .arg("4")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn cli-debugger");
+
+    child.stdin.as_mut().expect("stdin available").write_all(b"q\n").expect("write stdin");
+
+    let output = child.wait_with_output().expect("wait for cli-debugger");
+    assert!(output.status.success(), "cli-debugger exited with status {:?}", output.status.code());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(stderr.is_empty(), "unexpected stderr: {stderr}");
+    assert!(stdout.contains("seed 5"), "missing first console log: {stdout}");
+}
+
+#[test]
 fn cli_debugger_run_test_file_pass_case() {
     let (_script_path, test_file_path) = write_test_fixture();
 
@@ -220,8 +293,10 @@ fn cli_debugger_run_all_uses_test_file_suite() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("PASS  pass_case"), "missing pass_case line: {stdout}");
-    assert!(stdout.contains("PASS  fail_case"), "missing fail_case line (expected-fail test should still pass): {stdout}");
+    assert!(stdout.contains("RUN   pass_case"), "missing pass_case header: {stdout}");
+    assert!(stdout.contains("RUN   fail_case"), "missing fail_case header: {stdout}");
+    assert!(stdout.contains("PASS  pass_case"), "missing pass_case status: {stdout}");
+    assert!(stdout.contains("PASS  fail_case"), "missing fail_case status: {stdout}");
     assert!(stdout.contains("2 tests: 2 passed, 0 failed"), "missing summary line: {stdout}");
 }
 
@@ -242,8 +317,10 @@ fn cli_debugger_run_all_infers_test_file_from_script_path() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("PASS  pass_case"), "missing pass_case line: {stdout}");
-    assert!(stdout.contains("PASS  fail_case"), "missing fail_case line: {stdout}");
+    assert!(stdout.contains("RUN   pass_case"), "missing pass_case header: {stdout}");
+    assert!(stdout.contains("RUN   fail_case"), "missing fail_case header: {stdout}");
+    assert!(stdout.contains("PASS  pass_case"), "missing pass_case status: {stdout}");
+    assert!(stdout.contains("PASS  fail_case"), "missing fail_case status: {stdout}");
     assert!(stdout.contains("2 tests: 2 passed, 0 failed"), "missing summary line: {stdout}");
 }
 
@@ -266,8 +343,10 @@ fn cli_debugger_run_all_uses_script_override_for_mismatched_sidecar_name() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("PASS  pass_case"), "missing pass_case line: {stdout}");
-    assert!(stdout.contains("PASS  fail_case"), "missing fail_case line: {stdout}");
+    assert!(stdout.contains("RUN   pass_case"), "missing pass_case header: {stdout}");
+    assert!(stdout.contains("RUN   fail_case"), "missing fail_case header: {stdout}");
+    assert!(stdout.contains("PASS  pass_case"), "missing pass_case status: {stdout}");
+    assert!(stdout.contains("PASS  fail_case"), "missing fail_case status: {stdout}");
     assert!(stdout.contains("2 tests: 2 passed, 0 failed"), "missing summary line: {stdout}");
 }
 
@@ -291,6 +370,32 @@ fn cli_debugger_run_test_name_infers_test_file_from_script_path() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("PASS"), "expected PASS in stdout, got: {stdout}");
+}
+
+#[test]
+fn cli_debugger_run_prints_console_logs_before_pass() {
+    let (_script_path, test_file_path) = write_logging_test_fixture();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cli-debugger"))
+        .arg("--run")
+        .arg("--test-file")
+        .arg(&test_file_path)
+        .arg("--test-name")
+        .arg("log_case")
+        .output()
+        .expect("run cli-debugger logging test");
+
+    assert!(
+        output.status.success(),
+        "expected success, status={:?}, stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let seed_index = stdout.find("seed 5").expect("missing seed log");
+    let sum_index = stdout.find("sum 9").expect("missing sum log");
+    let pass_index = stdout.find("PASS").expect("missing PASS output");
+    assert!(seed_index < sum_index && sum_index < pass_index, "unexpected stdout order: {stdout}");
 }
 
 #[test]

--- a/debugger/session/src/session.rs
+++ b/debugger/session/src/session.rs
@@ -143,6 +143,7 @@ pub struct DebugSession<'a, 'i> {
     breakpoints: HashSet<u32>,
     // Source-level step ids that were already visited in this session.
     executed_steps: HashSet<StepId>,
+    console_output: Vec<String>,
 }
 
 struct ShadowBindingValue {
@@ -236,6 +237,7 @@ impl<'a, 'i> DebugSession<'a, 'i> {
             source_lines,
             breakpoints: HashSet::new(),
             executed_steps: HashSet::new(),
+            console_output: Vec::new(),
         })
     }
 
@@ -270,6 +272,11 @@ impl<'a, 'i> DebugSession<'a, 'i> {
     /// Step out: advance to next source step at a shallower call depth.
     pub fn step_out(&mut self) -> Result<Option<SessionState<'i>>, kaspa_txscript_errors::TxScriptError> {
         self.step_with_depth_predicate(|candidate, current| candidate < current)
+    }
+
+    pub fn run_to_completion(&mut self) -> Result<(), kaspa_txscript_errors::TxScriptError> {
+        while self.step_into()?.is_some() {}
+        Ok(())
     }
 
     /// Shared stepping loop for `step_into`, `step_over`, and `step_out`.
@@ -330,24 +337,24 @@ impl<'a, 'i> DebugSession<'a, 'i> {
     /// Advances execution to the first user statement, skipping dispatcher/synthetic bytecode.
     /// Call this after session creation to skip over contract setup code.
     /// Skips opcodes until the first source step is encountered.
-    pub fn run_to_first_executed_statement(&mut self) -> Result<(), kaspa_txscript_errors::TxScriptError> {
+    pub fn run_to_first_executed_statement(&mut self) -> Result<Option<SessionState<'i>>, kaspa_txscript_errors::TxScriptError> {
         if self.step_order.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
         loop {
             if self.pc >= self.opcodes.len() {
-                return Ok(());
+                return Ok(None);
             }
             let offset = self.current_byte_offset();
             if self.engine.is_executing() {
                 if let Some(index) = self.steppable_step_index_for_offset(offset, None) {
                     self.current_step_index = Some(index);
                     self.mark_step_executed(index);
-                    return Ok(());
+                    return Ok(Some(self.state()));
                 }
             }
             if self.step_opcode()?.is_none() {
-                return Ok(());
+                return Ok(None);
             }
         }
     }
@@ -355,7 +362,7 @@ impl<'a, 'i> DebugSession<'a, 'i> {
     /// Continues execution until a breakpoint is hit or script completes.
     pub fn continue_to_breakpoint(&mut self) -> Result<Option<SessionState<'i>>, kaspa_txscript_errors::TxScriptError> {
         if self.breakpoints.is_empty() {
-            while self.step_opcode()?.is_some() {}
+            self.run_to_completion()?;
             return Ok(None);
         }
         loop {
@@ -380,6 +387,10 @@ impl<'a, 'i> DebugSession<'a, 'i> {
     /// Returns true if the script engine is still running.
     pub fn is_executing(&self) -> bool {
         self.engine.is_executing()
+    }
+
+    pub fn take_console_output(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.console_output)
     }
 
     pub fn debug_info(&self) -> &DebugInfo<'i> {
@@ -475,15 +486,8 @@ impl<'a, 'i> DebugSession<'a, 'i> {
     }
 
     pub fn evaluate_expression(&self, expr_src: &str) -> Result<EvaluatedExpression, String> {
-        let scope_state = self.scope_state(self.active_scope_step_id())?;
         let expr = parse_expression_ast(expr_src).map_err(|err| format!("parse error: {err}"))?;
-        let (shadow_bindings, env, stack_bindings, eval_types) = self.scope_state_eval_context(&scope_state)?;
-        let (bytecode, type_name) = compile_debug_expr(&expr, &env, &stack_bindings, &eval_types)
-            .map_err(|err| format!("failed to compile debug expression: {err}"))?;
-        let script = self.build_shadow_script(&shadow_bindings, &bytecode)?;
-        let bytes = self.execute_shadow_script(&script)?;
-        let value = decode_value_by_type(&type_name, bytes)?;
-        Ok(EvaluatedExpression { type_name, value })
+        self.evaluate_parsed_expression(&expr)
     }
 
     // --- DebugValue formatting ---
@@ -724,9 +728,27 @@ impl<'a, 'i> DebugSession<'a, 'i> {
     }
 
     fn mark_step_executed(&mut self, step_index: usize) {
-        if let Some(step) = self.step_at_order(step_index) {
+        if let Some(step) = self.step_at_order(step_index).cloned() {
             self.executed_steps.insert(step.id());
+            self.render_console_messages(&step);
         }
+    }
+
+    fn render_console_messages(&mut self, step: &DebugStep<'i>) {
+        if step.console_args.is_empty() {
+            return;
+        }
+
+        self.console_output.push(
+            step.console_args
+                .iter()
+                .map(|expr| match self.evaluate_parsed_expression(expr) {
+                    Ok(result) => self.format_value(&result.type_name, &result.value),
+                    Err(err) => self.format_value("", &DebugValue::Unknown(err)),
+                })
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
     }
 
     fn sync_step_cursor_to_current_offset(&mut self) {
@@ -955,6 +977,21 @@ impl<'a, 'i> DebugSession<'a, 'i> {
         let script = self.build_shadow_script(&shadow_bindings, &bytecode)?;
         let bytes = self.execute_shadow_script(&script)?;
         decode_value_by_type(type_name, bytes)
+    }
+
+    fn evaluate_parsed_expression(&self, expr: &Expr<'i>) -> Result<EvaluatedExpression, String> {
+        let scope_state = self.scope_state(self.active_scope_step_id())?;
+        self.evaluate_expr_in_scope(&scope_state, expr)
+    }
+
+    fn evaluate_expr_in_scope(&self, scope_state: &ScopeState<'i>, expr: &Expr<'i>) -> Result<EvaluatedExpression, String> {
+        let (shadow_bindings, env, stack_bindings, eval_types) = self.scope_state_eval_context(scope_state)?;
+        let (bytecode, type_name) = compile_debug_expr(expr, &env, &stack_bindings, &eval_types)
+            .map_err(|err| format!("failed to compile debug expression: {err}"))?;
+        let script = self.build_shadow_script(&shadow_bindings, &bytecode)?;
+        let bytes = self.execute_shadow_script(&script)?;
+        let value = decode_value_by_type(&type_name, bytes)?;
+        Ok(EvaluatedExpression { type_name, value })
     }
 
     fn scope_state_eval_context(&self, scope_state: &ScopeState<'i>) -> Result<ShadowResolution<'i>, String> {
@@ -1237,6 +1274,64 @@ mod tests {
     }
 
     #[test]
+    fn console_logs_resolve_inline_frame_bindings() {
+        let mut sig_builder = ScriptBuilder::new();
+        sig_builder.add_i64(5).unwrap();
+        let sigscript = sig_builder.drain();
+
+        let mut session = make_session(
+            vec![DebugParamMapping { name: "a".to_string(), type_name: "int".to_string(), stack_index: 0, function: "f".to_string() }],
+            vec![
+                DebugStep {
+                    bytecode_start: 0,
+                    bytecode_end: 0,
+                    span: SourceSpan { line: 1, col: 1, end_line: 1, end_col: 1 },
+                    kind: StepKind::InlineCallEnter { callee: "inner".to_string() },
+                    sequence: 0,
+                    call_depth: 0,
+                    frame_id: 1,
+                    variable_updates: vec![DebugVariableUpdate {
+                        name: "x".to_string(),
+                        type_name: "int".to_string(),
+                        runtime_binding: None,
+                        expr: Expr::identifier("a"),
+                    }],
+                    console_args: vec![],
+                },
+                DebugStep {
+                    bytecode_start: 0,
+                    bytecode_end: 0,
+                    span: SourceSpan { line: 1, col: 1, end_line: 1, end_col: 1 },
+                    kind: StepKind::Source {},
+                    sequence: 1,
+                    call_depth: 1,
+                    frame_id: 1,
+                    variable_updates: vec![],
+                    console_args: vec![
+                        Expr::new(ExprKind::String("inner".to_string()), span::Span::default()),
+                        Expr::new(
+                            ExprKind::Binary {
+                                op: BinaryOp::Add,
+                                left: Box::new(Expr::identifier("x")),
+                                right: Box::new(Expr::int(1)),
+                            },
+                            span::Span::default(),
+                        ),
+                    ],
+                },
+            ],
+            &sigscript,
+        )
+        .unwrap();
+
+        session.current_step_index = Some(1);
+        session.executed_steps.insert(StepId::new(0, 1));
+        session.mark_step_executed(1);
+
+        assert_eq!(session.take_console_output(), vec!["inner 6"]);
+    }
+
+    #[test]
     fn list_variables_returns_unknown_for_uncompilable_expr() {
         let mut sig_builder = ScriptBuilder::new();
         sig_builder.add_i64(5).unwrap();
@@ -1258,6 +1353,7 @@ mod tests {
                     runtime_binding: None,
                     expr: Expr::identifier("missing"),
                 }],
+                console_args: vec![],
             }],
             &sigscript,
         )
@@ -1308,6 +1404,7 @@ mod tests {
                         ),
                     },
                 ],
+                console_args: vec![],
             }],
             &sigscript,
         )
@@ -1412,6 +1509,7 @@ mod tests {
                         ),
                     },
                 ],
+                console_args: vec![],
             }],
             &sigscript,
         )
@@ -1448,6 +1546,7 @@ mod tests {
                         runtime_binding: Some(RuntimeBinding::DataStackSlot { from_top: 0 }),
                         expr: Expr::identifier("missing"),
                     }],
+                    console_args: vec![],
                 },
                 DebugStep {
                     bytecode_start: 0,
@@ -1458,6 +1557,7 @@ mod tests {
                     call_depth: 0,
                     frame_id: 0,
                     variable_updates: vec![],
+                    console_args: vec![],
                 },
             ],
             &sigscript,
@@ -1495,6 +1595,7 @@ mod tests {
                         runtime_binding: Some(RuntimeBinding::DataStackSlot { from_top: 0 }),
                         expr: Expr::identifier("missing"),
                     }],
+                    console_args: vec![],
                 },
                 DebugStep {
                     bytecode_start: 0,
@@ -1505,6 +1606,7 @@ mod tests {
                     call_depth: 0,
                     frame_id: 0,
                     variable_updates: vec![],
+                    console_args: vec![],
                 },
             ],
             &sigscript,

--- a/debugger/session/tests/debug_session_tests.rs
+++ b/debugger/session/tests/debug_session_tests.rs
@@ -109,6 +109,28 @@ fn debug_session_provides_source_context_and_vars() -> Result<(), Box<dyn Error>
 }
 
 #[test]
+fn debug_session_emits_console_logs_when_landing_on_step() -> Result<(), Box<dyn Error>> {
+    let source = r#"pragma silverscript ^0.1.0;
+
+contract ConsoleStep() {
+    entrypoint function inspect(int a, int b) {
+        console.log("sum", a + b);
+        require(a + b > 0);
+    }
+}
+"#;
+
+    with_session_for_source(source, vec![], "inspect", vec![Expr::int(2), Expr::int(3)], |session| {
+        session.run_to_first_executed_statement()?;
+        assert_eq!(session.take_console_output(), vec!["sum 5"]);
+
+        session.step_opcode()?;
+        assert!(session.take_console_output().is_empty(), "single-opcode stepping should move past the zero-width console step");
+        Ok(())
+    })
+}
+
+#[test]
 fn debug_session_steps_forward() -> Result<(), Box<dyn Error>> {
     with_session(|session| {
         session.run_to_first_executed_statement()?;

--- a/silverscript-lang/src/ast.rs
+++ b/silverscript-lang/src/ast.rs
@@ -381,7 +381,7 @@ pub enum Statement<'i> {
         span: Span<'i>,
     },
     Console {
-        args: Vec<ConsoleArg<'i>>,
+        args: Vec<Expr<'i>>,
         #[serde(skip_deserializing)]
         span: Span<'i>,
     },
@@ -406,13 +406,6 @@ impl<'i> Statement<'i> {
             | Statement::Console { span, .. } => *span,
         }
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", content = "data", rename_all = "snake_case")]
-pub enum ConsoleArg<'i> {
-    Identifier(String, #[serde(skip_deserializing)] Span<'i>),
-    Literal(Expr<'i>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -915,14 +908,8 @@ fn format_state_bindings(bindings: &[StateBindingAst<'_>]) -> String {
         .join(", ")
 }
 
-fn format_console_args(args: &[ConsoleArg<'_>]) -> String {
-    args.iter()
-        .map(|arg| match arg {
-            ConsoleArg::Identifier(name, _) => name.clone(),
-            ConsoleArg::Literal(expr) => format_expr(expr),
-        })
-        .collect::<Vec<_>>()
-        .join(", ")
+fn format_console_args(args: &[Expr<'_>]) -> String {
+    args.iter().map(format_expr).collect::<Vec<_>>().join(", ")
 }
 
 fn format_expr_list(exprs: &[Expr<'_>]) -> String {
@@ -1689,19 +1676,11 @@ fn parse_block<'i>(pair: Pair<'i, Rule>) -> Result<(Vec<Statement<'i>>, Span<'i>
     }
 }
 
-fn parse_console_parameter_list<'i>(pair: Pair<'i, Rule>) -> Result<Vec<ConsoleArg<'i>>, CompilerError> {
+fn parse_console_parameter_list<'i>(pair: Pair<'i, Rule>) -> Result<Vec<Expr<'i>>, CompilerError> {
     let mut args = Vec::new();
 
     for param in pair.into_inner() {
-        let value = if param.as_rule() == Rule::console_parameter { single_inner(param)? } else { param };
-        match value.as_rule() {
-            Rule::Identifier => {
-                let Identifier { name, span } = parse_identifier(value)?;
-                args.push(ConsoleArg::Identifier(name, span));
-            }
-            Rule::literal => args.push(ConsoleArg::Literal(parse_literal(single_inner(value)?)?)),
-            _ => return Err(CompilerError::Unsupported("console.log arguments not supported".to_string())),
-        }
+        args.push(parse_expression(param)?);
     }
     Ok(args)
 }

--- a/silverscript-lang/src/ast/visit.rs
+++ b/silverscript-lang/src/ast/visit.rs
@@ -1,6 +1,6 @@
 use super::{
-    ConsoleArg, ConstantAst, ContractAst, ContractFieldAst, Expr, ExprKind, FunctionAst, FunctionAttributeArgAst,
-    FunctionAttributeAst, ParamAst, StateBindingAst, Statement,
+    ConstantAst, ContractAst, ContractFieldAst, Expr, ExprKind, FunctionAst, FunctionAttributeArgAst, FunctionAttributeAst, ParamAst,
+    StateBindingAst, Statement,
 };
 use crate::span::Span;
 
@@ -20,7 +20,6 @@ pub enum NameKind {
     StateBinding,
     CallTarget,
     IdentifierExpr,
-    ConsoleIdentifier,
 }
 
 pub trait AstVisitorMut<'i> {
@@ -61,10 +60,6 @@ pub trait AstVisitorMut<'i> {
 
     fn visit_statement(&mut self, statement: &mut Statement<'i>) {
         walk_statement_mut(self, statement);
-    }
-
-    fn visit_console_arg(&mut self, arg: &mut ConsoleArg<'i>) {
-        walk_console_arg_mut(self, arg);
     }
 
     fn visit_expr(&mut self, expr: &mut Expr<'i>) {
@@ -300,19 +295,9 @@ pub fn walk_statement_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, st
         Statement::Console { args, span } => {
             visitor.visit_span(span);
             for arg in args {
-                visitor.visit_console_arg(arg);
+                visitor.visit_expr(arg);
             }
         }
-    }
-}
-
-pub fn walk_console_arg_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, arg: &mut ConsoleArg<'i>) {
-    match arg {
-        ConsoleArg::Identifier(name, span) => {
-            visitor.visit_name(name, NameKind::ConsoleIdentifier);
-            visitor.visit_span(span);
-        }
-        ConsoleArg::Literal(expr) => visitor.visit_expr(expr),
     }
 }
 

--- a/silverscript-lang/src/compiler.rs
+++ b/silverscript-lang/src/compiler.rs
@@ -1130,10 +1130,7 @@ fn statement_uses_script_size(stmt: &Statement<'_>) -> bool {
                 || body.iter().any(statement_uses_script_size)
         }
         Statement::Return { exprs, .. } => exprs.iter().any(expr_uses_script_size),
-        Statement::Console { args, .. } => args.iter().any(|arg| match arg {
-            crate::ast::ConsoleArg::Identifier(_, _) => false,
-            crate::ast::ConsoleArg::Literal(expr) => expr_uses_script_size(expr),
-        }),
+        Statement::Console { args, .. } => args.iter().any(expr_uses_script_size),
     }
 }
 
@@ -1676,10 +1673,7 @@ fn collect_statement_identifier_uses<'i>(stmt: &Statement<'i>, uses: &mut HashMa
         }
         Statement::Console { args, .. } => {
             for arg in args {
-                match arg {
-                    crate::ast::ConsoleArg::Identifier(name, ..) => bump_identifier_use(uses, name),
-                    crate::ast::ConsoleArg::Literal(expr) => collect_expr_identifier_uses(expr, uses),
-                }
+                collect_expr_identifier_uses(arg, uses);
             }
         }
     }

--- a/silverscript-lang/src/compiler/debug_recording.rs
+++ b/silverscript-lang/src/compiler/debug_recording.rs
@@ -281,10 +281,12 @@ impl<'i> DebugRecorderImpl<'i> for ActiveDebugRecorder<'i> {
         };
 
         let updates = collect_variable_updates(&frame.env_before, &frame.stack_bindings_before, env, types, stack_bindings)?;
+        let console_args = collect_console_args(stmt, env)?;
         let span = SourceSpan::from(stmt.span());
         let bytecode_len = bytecode_end.saturating_sub(frame.start);
         let step_index = entrypoint.push_step(frame.start, frame.start + bytecode_len, span, StepKind::Source {});
         entrypoint.steps[step_index].variable_updates.extend(updates);
+        entrypoint.steps[step_index].console_args.extend(console_args);
         Ok(())
     }
 
@@ -373,6 +375,7 @@ impl<'i> DebugRecorderImpl<'i> for ActiveDebugRecorder<'i> {
                     call_depth: step.call_depth,
                     frame_id: step.frame_id,
                     variable_updates: step.variable_updates,
+                    console_args: step.console_args,
                 });
             }
 
@@ -475,6 +478,7 @@ impl<'i> StagedEntrypointDebug<'i> {
             call_depth,
             frame_id,
             variable_updates: Vec::new(),
+            console_args: Vec::new(),
         });
         self.steps.len().saturating_sub(1)
     }
@@ -555,6 +559,14 @@ fn resolve_variable_update<'i>(
     let resolved = resolve_expr_for_debug(expr, env, &mut HashSet::new())?;
     updates.push(DebugVariableUpdate { name: name.to_string(), type_name: type_name.to_string(), runtime_binding, expr: resolved });
     Ok(())
+}
+
+fn collect_console_args<'i>(stmt: &Statement<'i>, env: &HashMap<String, Expr<'i>>) -> Result<Vec<Expr<'i>>, CompilerError> {
+    let Statement::Console { args, .. } = stmt else {
+        return Ok(Vec::new());
+    };
+
+    args.iter().cloned().map(|expr| resolve_expr_for_debug(expr, env, &mut HashSet::new())).collect()
 }
 
 fn runtime_binding_for_stack_name(name: &str, stack_bindings: &HashMap<String, i64>) -> Option<RuntimeBinding> {

--- a/silverscript-lang/src/debug_info.rs
+++ b/silverscript-lang/src/debug_info.rs
@@ -171,6 +171,8 @@ pub struct DebugStep<'i> {
     pub frame_id: u32,
     #[serde(default)]
     pub variable_updates: Vec<DebugVariableUpdate<'i>>,
+    #[serde(default)]
+    pub console_args: Vec<Expr<'i>>,
 }
 
 impl<'i> DebugStep<'i> {

--- a/silverscript-lang/src/silverscript.pest
+++ b/silverscript-lang/src/silverscript.pest
@@ -65,8 +65,7 @@ for_statement = { "for" ~ "(" ~ Identifier ~ "," ~ expression ~ "," ~ expression
 console_statement = { "console.log" ~ console_parameter_list ~ ";" }
 require_message = { StringLiteral }
 
-console_parameter = { Identifier | literal }
-console_parameter_list = { "(" ~ (console_parameter ~ ("," ~ console_parameter)* ~ ","?)? ~ ")" }
+console_parameter_list = { "(" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ ")" }
 
 function_call = { Identifier ~ expression_list }
 expression_list = { "(" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ ")" }

--- a/silverscript-lang/tests/ast_format_tests.rs
+++ b/silverscript-lang/tests/ast_format_tests.rs
@@ -77,7 +77,7 @@ contract Advanced(int limit, pubkey owner) {
         byte[] tail = this.activeScriptPubKey.slice(1, this.activeScriptPubKey.length);
         validateOutputState(0, {balance: current});
         for (i, 0, limit, limit) {
-            console.log("loop", i);
+            console.log("loop", i + current);
         }
         balance = current;
         require(this.age >= 10, "age");
@@ -114,7 +114,7 @@ fn compiled_formatted_contract_preserves_exact_ast_for_basic_contract() {
         int input = 1 + 2;
         (int left, int right) = compute(input);
         require(left < right, "ordered");
-        console.log("pair", LIMIT);
+        console.log("pair", LIMIT + input);
     }
 }
 "#;

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -14,12 +14,12 @@ use kaspa_txscript::{
     EngineCtx, EngineFlags, SeqCommitAccessor, TxScriptEngine, pay_to_address_script, pay_to_script_hash_script,
     pay_to_script_hash_signature_script,
 };
-use silverscript_lang::ast::{Expr, parse_contract_ast};
+use silverscript_lang::ast::{Expr, ExprKind, parse_contract_ast};
 use silverscript_lang::compiler::{
     CompileOptions, CompiledContract, CovenantDeclCallOptions, FunctionAbiEntry, FunctionInputAbi, compile_contract,
     compile_contract_ast, function_branch_index, struct_object,
 };
-use silverscript_lang::debug_info::RuntimeBinding;
+use silverscript_lang::debug_info::{RuntimeBinding, StepKind};
 
 fn run_script_with_selector(script: Vec<u8>, selector: Option<i64>) -> Result<(), kaspa_txscript_errors::TxScriptError> {
     let sigscript = selector_sigscript(selector);
@@ -202,6 +202,33 @@ fn compile_contract_emits_debug_info_when_recording_enabled() {
     assert!(!debug_info.steps.is_empty());
     assert!(!debug_info.functions.is_empty());
     assert!(debug_info.params.iter().any(|param| param.name == "x"));
+}
+
+#[test]
+fn debug_info_records_console_expression_args() {
+    let source = r#"
+        contract DebugConsole() {
+            entrypoint function spend(int x, int y) {
+                console.log("sum", x + y);
+                require(x + y > 0);
+            }
+        }
+    "#;
+
+    let options = CompileOptions { record_debug_infos: true, ..Default::default() };
+    let compiled = compile_contract(source, &[], options).expect("compile succeeds");
+    let debug_info = compiled.debug_info.expect("debug info should be present");
+
+    let console_step = debug_info
+        .steps
+        .iter()
+        .find(|step| matches!(step.kind, StepKind::Source {}) && !step.console_args.is_empty())
+        .expect("console step should be recorded");
+
+    assert_eq!(console_step.bytecode_start, console_step.bytecode_end, "console step should be zero-width");
+    assert_eq!(console_step.console_args.len(), 2);
+    assert!(matches!(console_step.console_args[0].kind, ExprKind::String(ref value) if value == "sum"));
+    assert!(matches!(console_step.console_args[1].kind, ExprKind::Binary { .. }));
 }
 
 #[test]

--- a/silverscript-lang/tests/parser_tests.rs
+++ b/silverscript-lang/tests/parser_tests.rs
@@ -23,7 +23,7 @@ fn parses_timeops_and_console() {
         contract TimeLock(pubkey owner) {
             function unlock(sig s) {
                 require(this.age >= 10 days, "too early");
-                console.log("ok", 1, true);
+                console.log("ok", 1 + 2, checkSig(s, owner));
             }
         }
     "#;


### PR DESCRIPTION
Resolves #75 -
- console.log args refactored to be full expressions (and not just identifiers) - `console.log("avg", (b + a)/2)`
- The debugger uses the same evaluation path as eval to resolve those log expressions at runtime, and print then during debug session or test run.
```
(sdb) n
     1 | pragma silverscript ^0.1.0;
     2 | 
     3 | contract Logging(int seed) {
     4 |     entrypoint function check(int a) {
     5 |         console.log("seed", seed);
→    6 |         console.log("sum", seed + a);
     7 |         require(seed + a > 0);
     8 |     }
     9 | }
Contract Constants:
  seed (int) = 5
Entrypoint Parameters:
  a (int) = 4
Console:
sum 9 
```