### PR TITLE
Refine explicit `#[covenant.singleton]` semantics for verification state shape

### DIFF
--- a/silverscript-lang/src/compiler/covenant_declarations.rs
+++ b/silverscript-lang/src/compiler/covenant_declarations.rs
@@ -465,7 +465,11 @@ fn build_auth_wrapper<'i>(
                     ));
                 } else {
                     let new_states_name = &policy.params[1].name;
-                    body.push(require_statement(binary_expr(BinaryOp::Le, identifier_expr(out_count_name), declaration.to_expr.clone())));
+                    body.push(require_statement(binary_expr(
+                        BinaryOp::Le,
+                        identifier_expr(out_count_name),
+                        declaration.to_expr.clone(),
+                    )));
                     body.push(require_statement(binary_expr(
                         BinaryOp::Eq,
                         identifier_expr(out_count_name),

--- a/silverscript-lang/src/compiler/covenant_declarations.rs
+++ b/silverscript-lang/src/compiler/covenant_declarations.rs
@@ -290,7 +290,7 @@ fn parse_covenant_declaration<'i>(
         binding,
         mode,
         groups,
-        singleton: from_value == 1 && to_value == 1,
+        singleton: syntax == CovenantSyntax::Singleton,
         termination,
         from_expr: from_expr.clone(),
         to_expr: to_expr.clone(),

--- a/silverscript-lang/src/compiler/covenant_declarations.rs
+++ b/silverscript-lang/src/compiler/covenant_declarations.rs
@@ -275,9 +275,6 @@ fn parse_covenant_declaration<'i>(
         return Err(CompilerError::Unsupported("binding=cov with groups=multiple is not supported yet".to_string()));
     }
 
-    if args_by_name.contains_key("termination") && mode != CovenantMode::Transition {
-        return Err(CompilerError::Unsupported("termination is only supported in mode=transition".to_string()));
-    }
     if args_by_name.contains_key("termination") && !(from_value == 1 && to_value == 1) {
         return Err(CompilerError::Unsupported("termination is only supported for singleton covenants (from=1, to=1)".to_string()));
     }
@@ -319,7 +316,7 @@ fn validate_covenant_policy_state_shape<'i>(
 
     match (declaration.binding, declaration.mode) {
         (CovenantBinding::Auth, CovenantMode::Verification) => {
-            if declaration.singleton {
+            if declaration.singleton && declaration.termination != CovenantTermination::Allowed {
                 if policy.params.len() < 2
                     || !is_state_type_ref(&policy.params[0].type_ref)
                     || !is_state_type_ref(&policy.params[1].type_ref)
@@ -453,7 +450,7 @@ fn build_auth_wrapper<'i>(
                     state_object_expr_from_contract_fields(contract_fields),
                 ));
                 body.push(call_statement(policy_name, policy.params.iter().map(|param| identifier_expr(&param.name)).collect()));
-                if declaration.singleton {
+                if declaration.singleton && declaration.termination != CovenantTermination::Allowed {
                     let new_state_name = &policy.params[1].name;
                     body.push(require_statement(binary_expr(BinaryOp::Eq, identifier_expr(out_count_name), Expr::int(1))));
                     let out_idx_name = "__cov_out_idx";

--- a/silverscript-lang/src/compiler/covenant_declarations.rs
+++ b/silverscript-lang/src/compiler/covenant_declarations.rs
@@ -319,7 +319,17 @@ fn validate_covenant_policy_state_shape<'i>(
 
     match (declaration.binding, declaration.mode) {
         (CovenantBinding::Auth, CovenantMode::Verification) => {
-            if policy.params.len() < 2
+            if declaration.singleton {
+                if policy.params.len() < 2
+                    || !is_state_type_ref(&policy.params[0].type_ref)
+                    || !is_state_type_ref(&policy.params[1].type_ref)
+                {
+                    return Err(CompilerError::Unsupported(format!(
+                        "mode=verification with binding=auth on singleton function '{}' expects parameters '(State prev_state, State new_state, ...)'",
+                        policy.name
+                    )));
+                }
+            } else if policy.params.len() < 2
                 || !is_state_type_ref(&policy.params[0].type_ref)
                 || !is_state_array_type_ref(&policy.params[1].type_ref)
             {
@@ -437,26 +447,41 @@ fn build_auth_wrapper<'i>(
             CovenantMode::Verification => {
                 entrypoint_params = policy.params.iter().skip(1).cloned().collect();
                 let prev_state_name = &policy.params[0].name;
-                let new_states_name = &policy.params[1].name;
                 body.push(var_def_statement(
                     state_type_ref(),
                     prev_state_name,
                     state_object_expr_from_contract_fields(contract_fields),
                 ));
                 body.push(call_statement(policy_name, policy.params.iter().map(|param| identifier_expr(&param.name)).collect()));
-                body.push(require_statement(binary_expr(BinaryOp::Le, identifier_expr(out_count_name), declaration.to_expr.clone())));
-                body.push(require_statement(binary_expr(
-                    BinaryOp::Eq,
-                    identifier_expr(out_count_name),
-                    length_expr(identifier_expr(new_states_name)),
-                )));
-                append_auth_output_state_array_checks_from_state_array(
-                    &mut body,
-                    &active_input,
-                    out_count_name,
-                    declaration.to_expr.clone(),
-                    new_states_name,
-                );
+                if declaration.singleton {
+                    let new_state_name = &policy.params[1].name;
+                    body.push(require_statement(binary_expr(BinaryOp::Eq, identifier_expr(out_count_name), Expr::int(1))));
+                    let out_idx_name = "__cov_out_idx";
+                    body.push(var_def_statement(
+                        int_type_ref(),
+                        out_idx_name,
+                        Expr::call("OpAuthOutputIdx", vec![active_input.clone(), Expr::int(0)]),
+                    ));
+                    body.push(call_statement(
+                        "validateOutputState",
+                        vec![identifier_expr(out_idx_name), identifier_expr(new_state_name)],
+                    ));
+                } else {
+                    let new_states_name = &policy.params[1].name;
+                    body.push(require_statement(binary_expr(BinaryOp::Le, identifier_expr(out_count_name), declaration.to_expr.clone())));
+                    body.push(require_statement(binary_expr(
+                        BinaryOp::Eq,
+                        identifier_expr(out_count_name),
+                        length_expr(identifier_expr(new_states_name)),
+                    )));
+                    append_auth_output_state_array_checks_from_state_array(
+                        &mut body,
+                        &active_input,
+                        out_count_name,
+                        declaration.to_expr.clone(),
+                        new_states_name,
+                    );
+                }
             }
             CovenantMode::Transition => {
                 entrypoint_params = policy.params.iter().skip(1).cloned().collect();

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -1232,14 +1232,14 @@ fn build_sig_script_for_covenant_decl_routes_to_hidden_auth_entrypoint() {
             int value = init_value;
 
             #[covenant.singleton]
-            function step(State prev_state, State[] new_states) {
-                require(new_states.length <= 1);
+            function step(State prev_state, State new_state) {
+                require(new_state.value >= prev_state.value);
             }
         }
     "#;
 
     let compiled = compile_contract(source, &[Expr::int(7)], CompileOptions::default()).expect("compile succeeds");
-    let args = vec![vec![struct_object(vec![("value", Expr::int(8))])].into()];
+    let args = vec![struct_object(vec![("value", Expr::int(8))])];
 
     let actual = compiled
         .build_sig_script_for_covenant_decl("step", args.clone(), CovenantDeclCallOptions { is_leader: false })

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -188,9 +188,9 @@ fn rejects_canonical_one_to_one_auth_verification_with_scalar_new_state() {
 
     let err = compile_contract(source, &[Expr::int(7)], CompileOptions::default())
         .expect_err("canonical one-to-one auth verification should require State[] new_states");
-    assert!(err
-        .to_string()
-        .contains("mode=verification with binding=auth on function 'step' expects parameters '(State prev_state, State[] new_states, ...)'"));
+    assert!(err.to_string().contains(
+        "mode=verification with binding=auth on function 'step' expects parameters '(State prev_state, State[] new_states, ...)'"
+    ));
 }
 
 #[test]

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -174,6 +174,26 @@ fn rejects_old_per_field_covenant_state_syntax() {
 }
 
 #[test]
+fn rejects_canonical_one_to_one_auth_verification_with_scalar_new_state() {
+    let source = r#"
+        contract Decls(int init_value) {
+            int value = init_value;
+
+            #[covenant(binding = auth, from = 1, to = 1, groups = single)]
+            function step(State prev_state, State new_state) {
+                require(new_state.value >= prev_state.value);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[Expr::int(7)], CompileOptions::default())
+        .expect_err("canonical one-to-one auth verification should require State[] new_states");
+    assert!(err
+        .to_string()
+        .contains("mode=verification with binding=auth on function 'step' expects parameters '(State prev_state, State[] new_states, ...)'"));
+}
+
+#[test]
 fn lowers_singleton_sugar_to_auth_one_to_one_defaults() {
     let source = r#"
         contract Decls() {

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -371,19 +371,20 @@ fn rejects_termination_disallowed_for_non_singleton() {
 }
 
 #[test]
-fn rejects_termination_in_verification_mode() {
+fn allows_termination_in_singleton_verification_mode() {
     let source = r#"
-        contract Decls() {
+        contract Decls(int init_value) {
+            int value = init_value;
+
             #[covenant.singleton(mode = verification, termination = allowed)]
-            function check() {
+            function check(State prev_state, State[] new_states) {
                 require(true);
             }
         }
     "#;
 
-    let err =
-        compile_contract(source, &[], CompileOptions::default()).expect_err("termination should not be allowed in verification mode");
-    assert!(err.to_string().contains("termination is only supported in mode=transition"));
+    let compiled = compile_contract(source, &[Expr::int(3)], CompileOptions::default()).expect("compile succeeds");
+    assert!(compiled.ast.functions.iter().any(|f| f.name == "__check" && f.entrypoint));
 }
 
 #[test]

--- a/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_singleton_sugar_verification_termination_allowed_to_state_array_validation.sil
+++ b/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_singleton_sugar_verification_termination_allowed_to_state_array_validation.sil
@@ -1,0 +1,32 @@
+contract Counter(int init_value) {
+    int value = init_value;
+
+    #[covenant.singleton(termination = allowed)]
+    function step(State prev_state, State[] new_states) {
+        require(new_states.length <= 1);
+    }
+}
+
+// --- lowered ---
+
+contract Counter(int init_value) {
+    int value = init_value;
+
+    function covenant_policy_step(State prev_state, State[] new_states) {
+        require(new_states.length <= 1);
+    }
+
+    entrypoint function step(State[] new_states) {
+        int cov_out_count = OpAuthOutputCount(this.activeInputIndex);
+
+        State prev_state = { value: value };
+        covenant_policy_step(prev_state, new_states);
+        require(cov_out_count <= 1);
+        require(cov_out_count == new_states.length);
+
+        for(cov_k, 0, cov_out_count, 1) {
+            int cov_out_idx = OpAuthOutputIdx(this.activeInputIndex, cov_k);
+            validateOutputState(cov_out_idx, new_states[cov_k]);
+        }
+    }
+}

--- a/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_singleton_sugar_verification_to_single_state_validation.sil
+++ b/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_singleton_sugar_verification_to_single_state_validation.sil
@@ -1,0 +1,29 @@
+contract Counter(int init_value) {
+    int value = init_value;
+
+    #[covenant.singleton]
+    function step(State prev_state, State new_state) {
+        require(new_state.value == prev_state.value + 1);
+    }
+}
+
+// --- lowered ---
+
+contract Counter(int init_value) {
+    int value = init_value;
+
+    function covenant_policy_step(State prev_state, State new_state) {
+        require(new_state.value == prev_state.value + 1);
+    }
+
+    entrypoint function step(State new_state) {
+        int cov_out_count = OpAuthOutputCount(this.activeInputIndex);
+
+        State prev_state = { value: value };
+        covenant_policy_step(prev_state, new_state);
+        require(cov_out_count == 1);
+
+        int cov_out_idx = OpAuthOutputIdx(this.activeInputIndex, 0);
+        validateOutputState(cov_out_idx, new_state);
+    }
+}

--- a/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_termination_allowed_in_transition_non_singleton_mode.sil
+++ b/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_termination_allowed_in_transition_non_singleton_mode.sil
@@ -1,0 +1,32 @@
+contract Decls(int max_outs, int init_value) {
+    int value = init_value;
+
+    #[covenant(from = 1, to = max_outs, mode = transition, termination = allowed)]
+    function fanout(State prev_state) : (State[]) {
+        return(next_states);
+    }
+}
+
+// --- lowered ---
+
+contract Decls(int max_outs, int init_value) {
+    int value = init_value;
+
+    function covenant_policy_fanout(State prev_state) : (State[]) {
+        return(next_states);
+    }
+
+    entrypoint function fanout(State[] next_states) {
+        int cov_out_count = OpAuthOutputCount(this.activeInputIndex);
+
+        State prev_state = { value: value };
+        (State[] cov_new_states) = covenant_policy_fanout(prev_state, next_states);
+        require(cov_out_count <= max_outs);
+        require(cov_out_count == cov_new_states.length);
+
+        for(cov_k, 0, cov_out_count, max_outs) {
+            int cov_out_idx = OpAuthOutputIdx(this.activeInputIndex, cov_k);
+            validateOutputState(cov_out_idx, cov_new_states[cov_k]);
+        }
+    }
+}

--- a/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_termination_allowed_in_transition_non_singleton_mode.sil
+++ b/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_termination_allowed_in_transition_non_singleton_mode.sil
@@ -1,8 +1,8 @@
 contract Decls(int max_outs, int init_value) {
     int value = init_value;
 
-    #[covenant(from = 1, to = max_outs, mode = transition, termination = allowed)]
-    function fanout(State prev_state) : (State[]) {
+    #[covenant(from = 1, to = max_outs, mode = transition)]
+    function fanout(State prev_state, State[] next_states) : (State[]) {
         return(next_states);
     }
 }
@@ -12,7 +12,7 @@ contract Decls(int max_outs, int init_value) {
 contract Decls(int max_outs, int init_value) {
     int value = init_value;
 
-    function covenant_policy_fanout(State prev_state) : (State[]) {
+    function covenant_policy_fanout(State prev_state, State[] next_states) : (State[]) {
         return(next_states);
     }
 

--- a/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_termination_allowed_in_verification_non_singleton_mode.sil
+++ b/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_termination_allowed_in_verification_non_singleton_mode.sil
@@ -1,0 +1,34 @@
+contract Matrix(int max_outs, int init_amount, byte[32] init_owner) {
+    int amount = init_amount;
+    byte[32] owner = init_owner;
+
+    #[covenant(from = 1, to = max_outs, termination = allowed)]
+    function step(State prev_state, State[] new_states) {
+        require(new_states.length == new_states.length);
+    }
+}
+
+// --- lowered ---
+
+contract Matrix(int max_outs, int init_amount, byte[32] init_owner) {
+    int amount = init_amount;
+    byte[32] owner = init_owner;
+
+    function covenant_policy_step(State prev_state, State[] new_states) {
+        require(new_states.length == new_states.length);
+    }
+
+    entrypoint function step(State[] new_states) {
+        int cov_out_count = OpAuthOutputCount(this.activeInputIndex);
+
+        State prev_state = { amount: amount, owner: owner };
+        covenant_policy_step(prev_state, new_states);
+        require(cov_out_count <= max_outs);
+        require(cov_out_count == new_states.length);
+
+        for(cov_k, 0, cov_out_count, max_outs) {
+            int cov_out_idx = OpAuthOutputIdx(this.activeInputIndex, cov_k);
+            validateOutputState(cov_out_idx, new_states[cov_k]);
+        }
+    }
+}

--- a/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_termination_allowed_in_verification_non_singleton_mode.sil
+++ b/silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_termination_allowed_in_verification_non_singleton_mode.sil
@@ -2,7 +2,7 @@ contract Matrix(int max_outs, int init_amount, byte[32] init_owner) {
     int amount = init_amount;
     byte[32] owner = init_owner;
 
-    #[covenant(from = 1, to = max_outs, termination = allowed)]
+    #[covenant(from = 1, to = max_outs)]
     function step(State prev_state, State[] new_states) {
         require(new_states.length == new_states.length);
     }

--- a/silverscript-lang/tests/covenant_declaration_ast_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_ast_tests.rs
@@ -97,12 +97,12 @@ fixture_ast_test!(
     lowers_inferred_cov_verification_two_field_state,
     [Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(vec![7u8; 32])]
 );
-fixture_ast_test!(lowers_termination_allowed_in_verification_non_singleton_mode, [Expr::int(4), Expr::int(10), Expr::bytes(vec![7u8; 32])]);
-fixture_ast_test!(lowers_termination_allowed_in_transition_non_singleton_mode, [Expr::int(4), Expr::int(10)]);
 fixture_ast_test!(
-    lowers_inferred_singleton_transition_two_field_state,
-    [Expr::int(10), Expr::bytes(vec![7u8; 32])]
+    lowers_termination_allowed_in_verification_non_singleton_mode,
+    [Expr::int(4), Expr::int(10), Expr::bytes(vec![7u8; 32])]
 );
+fixture_ast_test!(lowers_termination_allowed_in_transition_non_singleton_mode, [Expr::int(4), Expr::int(10)]);
+fixture_ast_test!(lowers_inferred_singleton_transition_two_field_state, [Expr::int(10), Expr::bytes(vec![7u8; 32])]);
 fixture_ast_test!(lowers_singleton_sugar_transition_two_field_state, [Expr::int(10), Expr::bytes(vec![7u8; 32])]);
 fixture_ast_test!(lowers_singleton_sugar_transition_termination_allowed_two_field_state, [Expr::int(10), Expr::bytes(vec![7u8; 32])]);
 fixture_ast_test!(lowers_fanout_sugar_verification_two_field_state, [Expr::int(4), Expr::int(10), Expr::bytes(vec![7u8; 32])]);

--- a/silverscript-lang/tests/covenant_declaration_ast_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_ast_tests.rs
@@ -82,6 +82,7 @@ macro_rules! fixture_ast_test {
 fixture_ast_test!(lowers_auth_groups_single, [Expr::int(4)]);
 fixture_ast_test!(lowers_cov_to_leader_and_delegate_expected_wrapper_ast, [Expr::int(2), Expr::int(3)]);
 fixture_ast_test!(lowers_singleton_sugar_verification_to_single_state_validation, [Expr::int(7)]);
+fixture_ast_test!(lowers_singleton_sugar_verification_termination_allowed_to_state_array_validation, [Expr::int(7)]);
 fixture_ast_test!(lowers_singleton_transition_uses_returned_state_in_validation, [Expr::int(7)]);
 fixture_ast_test!(lowers_transition_array_return_to_exact_output_count_match, [Expr::int(4), Expr::int(10)]);
 fixture_ast_test!(lowers_singleton_transition_with_termination_allowed_to_array_cardinality_checks, [Expr::int(10)]);

--- a/silverscript-lang/tests/covenant_declaration_ast_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_ast_tests.rs
@@ -97,7 +97,12 @@ fixture_ast_test!(
     lowers_inferred_cov_verification_two_field_state,
     [Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(vec![7u8; 32])]
 );
-fixture_ast_test!(lowers_inferred_singleton_transition_two_field_state, [Expr::int(10), Expr::bytes(vec![7u8; 32])]);
+fixture_ast_test!(lowers_termination_allowed_in_verification_non_singleton_mode, [Expr::int(4), Expr::int(10), Expr::bytes(vec![7u8; 32])]);
+fixture_ast_test!(lowers_termination_allowed_in_transition_non_singleton_mode, [Expr::int(4), Expr::int(10)]);
+fixture_ast_test!(
+    lowers_inferred_singleton_transition_two_field_state,
+    [Expr::int(10), Expr::bytes(vec![7u8; 32])]
+);
 fixture_ast_test!(lowers_singleton_sugar_transition_two_field_state, [Expr::int(10), Expr::bytes(vec![7u8; 32])]);
 fixture_ast_test!(lowers_singleton_sugar_transition_termination_allowed_two_field_state, [Expr::int(10), Expr::bytes(vec![7u8; 32])]);
 fixture_ast_test!(lowers_fanout_sugar_verification_two_field_state, [Expr::int(4), Expr::int(10), Expr::bytes(vec![7u8; 32])]);

--- a/silverscript-lang/tests/covenant_declaration_ast_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_ast_tests.rs
@@ -81,6 +81,7 @@ macro_rules! fixture_ast_test {
 
 fixture_ast_test!(lowers_auth_groups_single, [Expr::int(4)]);
 fixture_ast_test!(lowers_cov_to_leader_and_delegate_expected_wrapper_ast, [Expr::int(2), Expr::int(3)]);
+fixture_ast_test!(lowers_singleton_sugar_verification_to_single_state_validation, [Expr::int(7)]);
 fixture_ast_test!(lowers_singleton_transition_uses_returned_state_in_validation, [Expr::int(7)]);
 fixture_ast_test!(lowers_transition_array_return_to_exact_output_count_match, [Expr::int(4), Expr::int(10)]);
 fixture_ast_test!(lowers_singleton_transition_with_termination_allowed_to_array_cardinality_checks, [Expr::int(10)]);

--- a/silverscript-lang/tests/covenant_declaration_security_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_security_tests.rs
@@ -21,9 +21,9 @@ const AUTH_SINGLETON_SOURCE: &str = r#"
         int value = init_value;
 
         #[covenant.singleton]
-        function step(State prev_state, State[] new_states) {
+        function step(State prev_state, State new_state) {
             require(prev_state.value >= 0);
-            require(new_states.length <= 1);
+            require(new_state.value >= 0);
             require(OpAuthOutputIdx(this.activeInputIndex, 0) >= 0);
         }
     }
@@ -102,9 +102,8 @@ const AUTH_SINGLETON_ARRAY_RUNTIME_SOURCE: &str = r#"
         int value = init_value;
 
         #[covenant.singleton]
-        function step(State prev_state, State[] new_states) {
-            require(new_states.length == 1);
-            require(new_states[0].value == prev_state.value + 1);
+        function step(State prev_state, State new_state) {
+            require(new_state.value == prev_state.value + 1);
             require(OpAuthOutputIdx(this.activeInputIndex, 0) >= 0);
         }
     }
@@ -156,6 +155,10 @@ fn covenant_decl_sigscript(compiled: &CompiledContract<'_>, function_name: &str,
 
 fn state_array_arg(values: Vec<i64>) -> Expr<'static> {
     values.into_iter().map(|value| struct_object(vec![("value", Expr::int(value))])).collect::<Vec<_>>().into()
+}
+
+fn state_arg(value: i64) -> Expr<'static> {
+    struct_object(vec![("value", Expr::int(value))])
 }
 
 fn cov_decl_nm_leader_sigscript(compiled: &CompiledContract<'_>, next_values: Vec<i64>) -> Vec<u8> {
@@ -227,7 +230,7 @@ fn singleton_allows_exactly_one_authorized_output() {
     let active = compile_state(AUTH_SINGLETON_SOURCE, 10);
     let out = compile_state(AUTH_SINGLETON_SOURCE, 10);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_array_arg(vec![10])], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_arg(10)], false));
     let outputs = vec![covenant_output(&out, 0, COV_A)];
     let tx = Transaction::new(1, vec![input0], outputs, 0, Default::default(), 0, vec![]);
     let entries = vec![covenant_utxo(&active, COV_A)];
@@ -242,7 +245,7 @@ fn singleton_rejects_two_authorized_outputs_from_same_input() {
     let out0 = compile_state(AUTH_SINGLETON_SOURCE, 10);
     let out1 = compile_state(AUTH_SINGLETON_SOURCE, 10);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_array_arg(vec![10])], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_arg(10)], false));
     let outputs = vec![covenant_output(&out0, 0, COV_A), covenant_output(&out1, 0, COV_A)];
     let tx = Transaction::new(1, vec![input0], outputs, 0, Default::default(), 0, vec![]);
     let entries = vec![covenant_utxo(&active, COV_A)];
@@ -356,7 +359,7 @@ fn singleton_transition_termination_allowed_rejects_two_outputs() {
 fn singleton_missing_authorized_output_returns_invalid_auth_index_error() {
     let active = compile_state(AUTH_SINGLETON_SOURCE, 10);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_array_arg(vec![])], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_arg(10)], false));
     let tx = Transaction::new(1, vec![input0], vec![], 0, Default::default(), 0, vec![]);
     let entries = vec![covenant_utxo(&active, COV_A)];
 
@@ -372,7 +375,7 @@ fn auth_groups_single_rejects_parallel_group_with_same_covenant_id() {
     let active = compile_state(AUTH_SINGLE_GROUP_SOURCE, 10);
     let out = compile_state(AUTH_SINGLE_GROUP_SOURCE, 10);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_array_arg(vec![10])], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_arg(10)], false));
     let input1 = tx_input(1, vec![]);
     let outputs = vec![covenant_output(&out, 0, COV_A), plain_covenant_output(1, COV_A)];
     let tx = Transaction::new(1, vec![input0, input1], outputs, 0, Default::default(), 0, vec![]);
@@ -578,27 +581,27 @@ fn many_to_many_transition_happy_path_succeeds() {
 }
 
 #[test]
-fn runtime_accepts_state_array_entrypoint_argument_for_generated_wrapper() {
+fn runtime_accepts_state_entrypoint_argument_for_generated_wrapper() {
     let active = compile_state(AUTH_SINGLETON_ARRAY_RUNTIME_SOURCE, 10);
     let out = compile_state(AUTH_SINGLETON_ARRAY_RUNTIME_SOURCE, 11);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_array_arg(vec![11])], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_arg(11)], false));
     let outputs = vec![covenant_output(&out, 0, COV_A)];
     let tx = Transaction::new(1, vec![input0], outputs, 0, Default::default(), 0, vec![]);
     let entries = vec![covenant_utxo(&active, COV_A)];
 
     let result = execute_input_with_covenants(tx, entries, 0);
-    assert!(result.is_ok(), "generated wrapper should accept State[] entrypoint args at runtime: {}", result.unwrap_err());
+    assert!(result.is_ok(), "generated wrapper should accept State entrypoint args at runtime: {}", result.unwrap_err());
 }
 
 #[test]
-fn runtime_passes_state_array_into_generated_policy_function() {
+fn runtime_passes_state_into_generated_policy_function() {
     let active = compile_state(AUTH_SINGLETON_ARRAY_RUNTIME_SOURCE, 10);
     let out = compile_state(AUTH_SINGLETON_ARRAY_RUNTIME_SOURCE, 11);
 
     let wrapper_name = generated_auth_entrypoint_name("step");
     let wrapper_param_types = function_param_type_names(&active, &wrapper_name);
-    assert_eq!(wrapper_param_types, vec!["State[]".to_string()]);
+    assert_eq!(wrapper_param_types, vec!["State".to_string()]);
 
     let policy = active
         .ast
@@ -608,15 +611,15 @@ fn runtime_passes_state_array_into_generated_policy_function() {
         .expect("generated covenant policy exists");
     assert!(!policy.entrypoint, "generated covenant policy must remain non-entrypoint");
     let policy_param_types: Vec<String> = policy.params.iter().map(|param| param.type_ref.type_name()).collect();
-    assert_eq!(policy_param_types, vec!["State".to_string(), "State[]".to_string()]);
+    assert_eq!(policy_param_types, vec!["State".to_string(), "State".to_string()]);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_array_arg(vec![12])], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_arg(12)], false));
     let outputs = vec![covenant_output(&out, 0, COV_A)];
     let tx = Transaction::new(1, vec![input0], outputs, 0, Default::default(), 0, vec![]);
     let entries = vec![covenant_utxo(&active, COV_A)];
 
     let err = execute_input_with_covenants(tx, entries, 0)
-        .expect_err("generated policy should reject when the State[] argument content is wrong");
+        .expect_err("generated policy should reject when the State argument content is wrong");
     assert_verify_like_error(err);
 }
 

--- a/silverscript-lang/tests/covenant_declaration_security_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_security_tests.rs
@@ -375,7 +375,7 @@ fn auth_groups_single_rejects_parallel_group_with_same_covenant_id() {
     let active = compile_state(AUTH_SINGLE_GROUP_SOURCE, 10);
     let out = compile_state(AUTH_SINGLE_GROUP_SOURCE, 10);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_arg(10)], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_array_arg(vec![10])], false));
     let input1 = tx_input(1, vec![]);
     let outputs = vec![covenant_output(&out, 0, COV_A), plain_covenant_output(1, COV_A)];
     let tx = Transaction::new(1, vec![input0, input1], outputs, 0, Default::default(), 0, vec![]);
@@ -522,7 +522,7 @@ fn singleton_rejects_authorized_output_with_different_script() {
     let active = compile_state(AUTH_SINGLETON_SOURCE, 10);
     let different = compile_state(AUTH_SINGLETON_SOURCE, 11);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_array_arg(vec![10])], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "step", vec![state_arg(10)], false));
     let tx = Transaction::new(1, vec![input0], vec![covenant_output(&different, 0, COV_A)], 0, Default::default(), 0, vec![]);
     let entries = vec![covenant_utxo(&active, COV_A)];
 


### PR DESCRIPTION
  This PR narrows singleton-specific language behavior to the explicit `#[covenant.singleton]` syntax and updates the verification-mode state shape rules accordingly.

  ## Language Changes

  - `#[covenant.singleton]` now has distinct verification semantics.
  - With default or explicit `termination = disallowed`, the policy must use a single successor state:
    - `function step(State prev_state, State new_state, ...)`
  - With `termination = allowed`, the policy must use successor states as an array:
    - `function step(State prev_state, State[] new_states, ...)`

  - Canonical one-to-one auth declarations do not inherit singleton-only state-shape behavior.
  - This remains valid:
    - `#[covenant(binding = auth, from = 1, to = 1, groups = single)]`
    - `function step(State prev_state, State[] new_states) { ... }`
  - This is now invalid unless the declaration is written with explicit singleton sugar:
    - `#[covenant(binding = auth, from = 1, to = 1, groups = single)]`
    - `function step(State prev_state, State new_state) { ... }`

  - `termination` is now accepted in verification mode for explicit singleton declarations.
  - This enables the distinction between:
    - strict one-successor singleton verification
    - termination-capable singleton verification

  ## Compatibility Notes

  This is a behavior change for contracts that relied on implicit singleton semantics from `from = 1, to = 1` alone. Those contracts should migrate to explicit `#[covenant.singleton]` if they want singleton
  verification signatures based on `State` rather than `State[]`.
