### PR TITLE
Disallow call to entrypoints and allow function call at any order

### DIFF
--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -115,9 +115,6 @@ pub(super) fn compile_contract_impl<'i>(
 
     let without_selector = entrypoint_functions.len() == 1;
 
-    let functions_map = lowered_contract.functions.iter().cloned().map(|func| (func.name.clone(), func)).collect::<HashMap<_, _>>();
-    let function_order =
-        lowered_contract.functions.iter().enumerate().map(|(index, func)| (func.name.clone(), index)).collect::<HashMap<_, _>>();
     let function_abi_entries = build_function_abi_entries(&covenant_lowered_contract);
     let uses_script_size = contract_uses_script_size(&lowered_contract);
 
@@ -133,8 +130,6 @@ pub(super) fn compile_contract_impl<'i>(
             script_size,
             without_selector,
             &structs,
-            &functions_map,
-            &function_order,
             &mut debug_recorder,
         )?;
 
@@ -177,8 +172,6 @@ fn compile_contract_script_iteration<'i>(
     script_size: Option<i64>,
     without_selector: bool,
     structs: &StructRegistry,
-    functions_map: &HashMap<String, FunctionAst<'i>>,
-    function_order: &HashMap<String, usize>,
     debug_recorder: &mut DebugRecorder<'i>,
 ) -> Result<(Vec<u8>, CompiledStateLayout), CompilerError> {
     let (_contract_fields, field_prolog_script) =
@@ -193,8 +186,6 @@ fn compile_contract_script_iteration<'i>(
         lowered_constants,
         options,
         structs,
-        functions_map,
-        function_order,
         script_size,
         debug_recorder,
     )?;
@@ -209,21 +200,14 @@ fn compile_entrypoint_scripts<'i>(
     lowered_constants: &HashMap<String, Expr<'i>>,
     options: CompileOptions,
     structs: &StructRegistry,
-    functions_map: &HashMap<String, FunctionAst<'i>>,
-    function_order: &HashMap<String, usize>,
     script_size: Option<i64>,
     debug_recorder: &mut DebugRecorder<'i>,
 ) -> Result<Vec<(String, Vec<u8>)>, CompilerError> {
     let mut compiled_entrypoints = Vec::new();
     for func in &lowered_contract.functions {
         if func.entrypoint {
-            let function_index = function_order
-                .get(&func.name)
-                .copied()
-                .ok_or_else(|| CompilerError::Unsupported(format!("function '{}' not found", func.name)))?;
             let compiled = compile_entrypoint_function(
                 func,
-                function_index,
                 &lowered_contract.params,
                 &lowered_contract.fields,
                 &lowered_contract.constants,
@@ -231,8 +215,6 @@ fn compile_entrypoint_scripts<'i>(
                 lowered_constants,
                 options,
                 structs,
-                functions_map,
-                function_order,
                 script_size,
                 debug_recorder,
             )?;
@@ -1075,7 +1057,6 @@ pub fn function_branch_index<'i>(contract: &ContractAst<'i>, function_name: &str
 #[allow(clippy::too_many_arguments)]
 fn compile_entrypoint_function<'i>(
     function: &FunctionAst<'i>,
-    function_index: usize,
     contract_params: &[ParamAst<'i>],
     contract_fields: &[ContractFieldAst<'i>],
     contract_constants: &[ConstantAst<'i>],
@@ -1083,8 +1064,6 @@ fn compile_entrypoint_function<'i>(
     constants: &HashMap<String, Expr<'i>>,
     options: CompileOptions,
     structs: &StructRegistry,
-    functions: &HashMap<String, FunctionAst<'i>>,
-    function_order: &HashMap<String, usize>,
     script_size: Option<i64>,
     debug_recorder: &mut DebugRecorder<'i>,
 ) -> Result<(String, Vec<u8>), CompilerError> {
@@ -1138,9 +1117,6 @@ fn compile_entrypoint_function<'i>(
         contract_field_prefix_len,
         contract_constants: constants,
         structs,
-        functions,
-        function_order,
-        function_index,
         script_size,
         debug_recorder,
     };
@@ -1259,9 +1235,6 @@ struct CompileStatementContext<'a, 'i> {
     contract_field_prefix_len: usize,
     contract_constants: &'a HashMap<String, Expr<'i>>,
     structs: &'a StructRegistry,
-    functions: &'a HashMap<String, FunctionAst<'i>>,
-    function_order: &'a HashMap<String, usize>,
-    function_index: usize,
     script_size: Option<i64>,
     debug_recorder: &'a mut DebugRecorder<'i>,
 }
@@ -1286,9 +1259,6 @@ impl<'a, 'i> CompileStatementContext<'a, 'i> {
             contract_field_prefix_len: self.contract_field_prefix_len,
             contract_constants: self.contract_constants,
             structs: self.structs,
-            functions: self.functions,
-            function_order: self.function_order,
-            function_index: self.function_index,
             script_size: self.script_size,
             debug_recorder: self.debug_recorder,
         }

--- a/silverscript-lang/src/compiler/debug_recording.rs
+++ b/silverscript-lang/src/compiler/debug_recording.rs
@@ -1042,6 +1042,13 @@ impl<'i> StagedEntrypointDebug<'i> {
 
         for plan in plans {
             let (call_depth, frame_id) = self.parent_frame_context(&plan);
+            let variable_updates = self
+                .steps
+                .iter()
+                .rev()
+                .find(|step| matches!(step.kind, StepKind::Source {}) && step.frame_id == plan.frame_id)
+                .map(|step| step.variable_updates.clone())
+                .unwrap_or_default();
             self.record_step(DebugStep {
                 bytecode_start,
                 bytecode_end: bytecode_start,
@@ -1050,7 +1057,7 @@ impl<'i> StagedEntrypointDebug<'i> {
                 sequence: 0,
                 call_depth,
                 frame_id,
-                variable_updates: Vec::new(),
+                variable_updates,
                 console_args: Vec::new(),
             });
         }

--- a/silverscript-lang/src/compiler/inline_functions.rs
+++ b/silverscript-lang/src/compiler/inline_functions.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::debug_info::SourceSpan;
 
@@ -10,17 +10,20 @@ pub(super) fn lower_inline_functions<'i>(
     contract: &ContractAst<'i>,
     debug_recorder: &mut DebugRecorder<'i>,
 ) -> Result<ContractAst<'i>, CompilerError> {
-    let functions = contract.functions.iter().cloned().map(|function| (function.name.clone(), function)).collect::<HashMap<_, _>>();
-    let function_order =
-        contract.functions.iter().enumerate().map(|(index, function)| (function.name.clone(), index)).collect::<HashMap<_, _>>();
-    let mut inliner = Inliner { functions, function_order, fresh_counter: 0, debug_recorder };
+    let functions = contract
+        .functions
+        .iter()
+        .filter(|function| !function.entrypoint)
+        .cloned()
+        .map(|function| (function.name.clone(), function))
+        .collect::<HashMap<_, _>>();
+    let mut inliner = Inliner { functions, fresh_counter: 0, debug_recorder };
 
     let lowered_functions = contract
         .functions
         .iter()
-        .enumerate()
-        .filter(|(_, function)| function.entrypoint)
-        .map(|(index, function)| inliner.lower_entrypoint_function(function, index))
+        .filter(|function| function.entrypoint)
+        .map(|function| inliner.lower_entrypoint_function(function))
         .collect::<Result<Vec<_>, _>>()?;
 
     Ok(ContractAst {
@@ -37,7 +40,6 @@ pub(super) fn lower_inline_functions<'i>(
 
 struct Inliner<'i, 'd> {
     functions: HashMap<String, FunctionAst<'i>>,
-    function_order: HashMap<String, usize>,
     fresh_counter: usize,
     debug_recorder: &'d mut DebugRecorder<'i>,
 }
@@ -49,17 +51,14 @@ impl<'i, 'd> Inliner<'i, 'd> {
         name
     }
 
-    fn lower_entrypoint_function(
-        &mut self,
-        function: &FunctionAst<'i>,
-        function_index: usize,
-    ) -> Result<FunctionAst<'i>, CompilerError> {
+    fn lower_entrypoint_function(&mut self, function: &FunctionAst<'i>) -> Result<FunctionAst<'i>, CompilerError> {
         let mut scope = HashMap::new();
         for param in &function.params {
             scope.insert(param.name.clone(), param.name.clone());
         }
         self.debug_recorder.begin_source_function(&function.name);
-        let body = self.lower_block(&function.body, &mut scope, function_index)?;
+        let mut visited_functions = HashSet::new();
+        let body = self.lower_block(&function.body, &mut scope, &mut visited_functions)?;
         self.debug_recorder.finish_source_function();
         Ok(FunctionAst { body, ..function.clone() })
     }
@@ -68,11 +67,11 @@ impl<'i, 'd> Inliner<'i, 'd> {
         &mut self,
         statements: &[Statement<'i>],
         scope: &mut HashMap<String, String>,
-        function_index: usize,
+        visited_functions: &mut HashSet<String>,
     ) -> Result<Vec<Statement<'i>>, CompilerError> {
         let mut lowered = Vec::new();
         for statement in statements {
-            lowered.extend(self.lower_statement(statement, scope, function_index)?);
+            lowered.extend(self.lower_statement(statement, scope, visited_functions)?);
         }
         Ok(lowered)
     }
@@ -117,7 +116,7 @@ impl<'i, 'd> Inliner<'i, 'd> {
         &mut self,
         statement: &Statement<'i>,
         scope: &mut HashMap<String, String>,
-        function_index: usize,
+        visited_functions: &mut HashSet<String>,
     ) -> Result<Vec<Statement<'i>>, CompilerError> {
         let mut lowered = Vec::new();
         match statement {
@@ -183,12 +182,12 @@ impl<'i, 'd> Inliner<'i, 'd> {
             }
             Statement::Block { body, span } => {
                 let mut block_scope = scope.clone();
-                let lowered_body = self.lower_block(body, &mut block_scope, function_index)?;
+                let lowered_body = self.lower_block(body, &mut block_scope, visited_functions)?;
                 self.push_lowered_statement(&mut lowered, Statement::Block { body: lowered_body, span: *span });
             }
             Statement::FunctionCall { name, args, span, name_span } => {
                 if let Some(function) = self.inline_target(name) {
-                    lowered.extend(self.inline_call(&function, args, None, scope, function_index, *span)?);
+                    lowered.extend(self.inline_call(&function, args, None, scope, visited_functions, *span)?);
                 } else {
                     let renamed_args = args.iter().map(|arg| self.rename_expr(arg, scope)).collect::<Result<Vec<_>, _>>()?;
                     self.push_lowered_statement(
@@ -206,7 +205,7 @@ impl<'i, 'd> Inliner<'i, 'd> {
                             ParamAst { name: fresh, ..binding.clone() }
                         })
                         .collect::<Vec<_>>();
-                    lowered.extend(self.inline_call(&function, args, Some(&renamed_bindings), scope, function_index, *span)?);
+                    lowered.extend(self.inline_call(&function, args, Some(&renamed_bindings), scope, visited_functions, *span)?);
                 } else {
                     let renamed_bindings = bindings
                         .iter()
@@ -294,12 +293,12 @@ impl<'i, 'd> Inliner<'i, 'd> {
                 let renamed_condition = self.rename_expr(condition, scope)?;
                 let mut then_scope = scope.clone();
                 self.predeclare_branch_bindings(then_branch, &mut then_scope);
-                let lowered_then = self.lower_block(then_branch, &mut then_scope, function_index)?;
+                let lowered_then = self.lower_block(then_branch, &mut then_scope, visited_functions)?;
 
                 let lowered_else = if let Some(else_branch) = else_branch {
                     let mut else_scope = scope.clone();
                     self.predeclare_branch_bindings(else_branch, &mut else_scope);
-                    Some(self.lower_block(else_branch, &mut else_scope, function_index)?)
+                    Some(self.lower_block(else_branch, &mut else_scope, visited_functions)?)
                 } else {
                     None
                 };
@@ -318,7 +317,7 @@ impl<'i, 'd> Inliner<'i, 'd> {
             Statement::For { ident, start, end, max_iterations, body, span, ident_span, body_span } => {
                 let mut body_scope = scope.clone();
                 let lowered_ident = self.bind_visible_name(ident, &mut body_scope);
-                let lowered_body = self.lower_block(body, &mut body_scope, function_index)?;
+                let lowered_body = self.lower_block(body, &mut body_scope, visited_functions)?;
                 let lowered_start = self.rename_expr(start, scope)?;
                 let lowered_end = self.rename_expr(end, scope)?;
                 let lowered_max_iterations = self.rename_expr(max_iterations, scope)?;
@@ -358,16 +357,11 @@ impl<'i, 'd> Inliner<'i, 'd> {
         args: &[Expr<'i>],
         bindings: Option<&[ParamAst<'i>]>,
         caller_scope: &HashMap<String, String>,
-        caller_index: usize,
+        visited_functions: &mut HashSet<String>,
         span: span::Span<'i>,
     ) -> Result<Vec<Statement<'i>>, CompilerError> {
-        let callee_index = self
-            .function_order
-            .get(&function.name)
-            .copied()
-            .ok_or_else(|| CompilerError::Unsupported(format!("function '{}' not found", function.name)))?;
-        if callee_index >= caller_index {
-            return Err(CompilerError::Unsupported("functions may only call earlier-defined functions".to_string()));
+        if visited_functions.contains(&function.name) {
+            return Err(CompilerError::Unsupported(format!("recursive function call: {}", function.name)));
         }
         if function.params.len() != args.len() {
             return Err(CompilerError::Unsupported(format!(
@@ -380,6 +374,7 @@ impl<'i, 'd> Inliner<'i, 'd> {
         let mut local_scope = HashMap::new();
         let mut lowered = Vec::new();
         self.debug_recorder.begin_inline_source_call(&function.name, SourceSpan::from(span));
+        visited_functions.insert(function.name.clone());
         for (param, arg) in function.params.iter().zip(args.iter()) {
             let fresh = self.bind_visible_name(&param.name, &mut local_scope);
             let renamed_arg = self.rename_expr(arg, caller_scope)?;
@@ -405,29 +400,35 @@ impl<'i, 'd> Inliner<'i, 'd> {
             None => (&[][..], None),
         };
 
-        for statement in callee_body {
-            lowered.extend(self.lower_statement(statement, &mut local_scope, callee_index)?);
-        }
-        let body_end_statement_index = self.debug_recorder.current_source_statement_index();
-
-        if let (Some(bindings), Some(return_exprs)) = (bindings, return_exprs) {
-            for (binding, expr) in bindings.iter().zip(return_exprs.iter()) {
-                let renamed_expr = self.rename_expr(expr, &local_scope)?;
-                self.push_lowered_statement(
-                    &mut lowered,
-                    Statement::VariableDefinition {
-                        type_ref: binding.type_ref.clone(),
-                        modifiers: Vec::new(),
-                        name: binding.name.clone(),
-                        expr: Some(renamed_expr),
-                        span,
-                        type_span: binding.type_span,
-                        modifier_spans: Vec::new(),
-                        name_span: binding.name_span,
-                    },
-                );
+        let lowered_result = (|| -> Result<(), CompilerError> {
+            for statement in callee_body {
+                lowered.extend(self.lower_statement(statement, &mut local_scope, visited_functions)?);
             }
-        }
+
+            if let (Some(bindings), Some(return_exprs)) = (bindings, return_exprs) {
+                for (binding, expr) in bindings.iter().zip(return_exprs.iter()) {
+                    let renamed_expr = self.rename_expr(expr, &local_scope)?;
+                    self.push_lowered_statement(
+                        &mut lowered,
+                        Statement::VariableDefinition {
+                            type_ref: binding.type_ref.clone(),
+                            modifiers: Vec::new(),
+                            name: binding.name.clone(),
+                            expr: Some(renamed_expr),
+                            span,
+                            type_span: binding.type_span,
+                            modifier_spans: Vec::new(),
+                            name_span: binding.name_span,
+                        },
+                    );
+                }
+            }
+
+            Ok(())
+        })();
+        let body_end_statement_index = self.debug_recorder.current_source_statement_index();
+        visited_functions.remove(&function.name);
+        lowered_result?;
         self.debug_recorder.finish_inline_source_call(body_end_statement_index);
         Ok(lowered)
     }

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -358,15 +358,7 @@ fn validate_function_call_statement_shape<'i>(
         validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
     }
     if ctx.functions.contains_key(name) {
-        validate_internal_call(
-            name,
-            args,
-            ctx.types,
-            ctx.structs,
-            ctx.constants,
-            ctx.functions,
-            ctx.contract_fields,
-        )?;
+        validate_internal_call(name, args, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)?;
     }
     Ok(())
 }
@@ -380,15 +372,7 @@ fn validate_function_call_assign_statement_shape<'i>(
     for arg in args {
         validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
     }
-    let function = validate_internal_call(
-        name,
-        args,
-        ctx.types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )?;
+    let function = validate_internal_call(name, args, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)?;
     if bindings.len() != function.return_types.len() {
         return Err(CompilerError::Unsupported("function call assignment return count mismatch".to_string()));
     }

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -74,10 +74,8 @@ fn validate_function_signatures<'i>(
     options: CompileOptions,
 ) -> Result<(), CompilerError> {
     let functions = contract.functions.iter().map(|function| (function.name.clone(), function)).collect::<HashMap<_, _>>();
-    let function_order =
-        contract.functions.iter().enumerate().map(|(index, function)| (function.name.clone(), index)).collect::<HashMap<_, _>>();
 
-    for (function_index, function) in contract.functions.iter().enumerate() {
+    for function in &contract.functions {
         for param in &function.params {
             ensure_array_elements_have_known_size(&param.type_ref, structs, &type_name_from_ref(&param.type_ref))?;
         }
@@ -114,8 +112,6 @@ fn validate_function_signatures<'i>(
             structs,
             constants,
             &functions,
-            &function_order,
-            function_index,
             &contract.fields,
         )?;
     }
@@ -158,8 +154,6 @@ fn validate_statement_shapes<'i>(
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
-    function_order: &HashMap<String, usize>,
-    function_index: usize,
     contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
     let mut ctx = ValidateStatementShapesContext {
@@ -170,8 +164,6 @@ fn validate_statement_shapes<'i>(
         structs,
         constants,
         functions,
-        function_order,
-        function_index,
         contract_fields,
     };
 
@@ -220,8 +212,6 @@ struct ValidateStatementShapesContext<'a, 'i> {
     structs: &'a StructRegistry,
     constants: &'a HashMap<String, Expr<'i>>,
     functions: &'a HashMap<String, &'a FunctionAst<'i>>,
-    function_order: &'a HashMap<String, usize>,
-    function_index: usize,
     contract_fields: &'a [ContractFieldAst<'i>],
 }
 
@@ -375,8 +365,6 @@ fn validate_function_call_statement_shape<'i>(
             ctx.structs,
             ctx.constants,
             ctx.functions,
-            ctx.function_order,
-            ctx.function_index,
             ctx.contract_fields,
         )?;
     }
@@ -399,8 +387,6 @@ fn validate_function_call_assign_statement_shape<'i>(
         ctx.structs,
         ctx.constants,
         ctx.functions,
-        ctx.function_order,
-        ctx.function_index,
         ctx.contract_fields,
     )?;
     if bindings.len() != function.return_types.len() {
@@ -491,8 +477,6 @@ fn validate_if_statement_shape<'i>(
         ctx.structs,
         ctx.constants,
         ctx.functions,
-        ctx.function_order,
-        ctx.function_index,
         ctx.contract_fields,
     )?;
     if let Some(else_branch) = else_branch {
@@ -508,8 +492,6 @@ fn validate_if_statement_shape<'i>(
             ctx.structs,
             ctx.constants,
             ctx.functions,
-            ctx.function_order,
-            ctx.function_index,
             ctx.contract_fields,
         )?;
     }
@@ -532,8 +514,6 @@ fn validate_block_statement_shape<'i>(
         ctx.structs,
         ctx.constants,
         ctx.functions,
-        ctx.function_order,
-        ctx.function_index,
         ctx.contract_fields,
     )
 }
@@ -562,8 +542,6 @@ fn validate_for_statement_shape<'i>(
         ctx.structs,
         ctx.constants,
         ctx.functions,
-        ctx.function_order,
-        ctx.function_index,
         ctx.contract_fields,
     )
 }
@@ -982,21 +960,13 @@ fn validate_internal_call<'i>(
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
     functions: &'i HashMap<String, &'i FunctionAst<'i>>,
-    function_order: &HashMap<String, usize>,
-    function_index: usize,
     contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<&'i FunctionAst<'i>, CompilerError> {
     let Some(function) = functions.get(name).copied() else {
         return Err(CompilerError::Unsupported(format!("function '{}' not found", name)));
     };
-
-    let callee_index =
-        function_order.get(name).copied().ok_or_else(|| CompilerError::Unsupported(format!("function '{}' not found", name)))?;
-    if callee_index > function_index {
-        return Err(CompilerError::Unsupported("functions may only call earlier-defined functions".to_string()));
-    }
-    if callee_index == function_index {
-        return Err(CompilerError::Unsupported(format!("unknown function '{}'", name)));
+    if function.entrypoint {
+        return Err(CompilerError::Unsupported(format!("entrypoint function '{}' cannot be called", name)));
     }
     if function.params.len() != args.len() {
         return Err(CompilerError::Unsupported(format!("function '{}' expects {} arguments", name, function.params.len())));

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -2924,14 +2924,34 @@ fn recursive_fibonacci_inlining_behavior() {
             }
 
             entrypoint function main(int n) {
-                require(fib(n) > 0);
+                (int out) = fib(n);
+                require(out > 0);
             }
         }
     "#;
 
     let err = compile_contract(source, &[], CompileOptions::default()).expect_err("recursive call should fail");
     let err_msg = err.to_string();
-    assert!(err_msg.contains("unknown function"), "expected 'unknown function' error, got: {err_msg}");
+    assert!(err_msg.contains("recursive function call: fib"), "unexpected error: {err_msg}");
+}
+
+#[test]
+fn non_recursive_helper_call_in_expression_position_regresses_to_byte_array_type() {
+    let source = r#"
+        contract Calls() {
+            function plus_one(int n) : (int) {
+                return(n + 1);
+            }
+
+            entrypoint function main(int n) {
+                require(plus_one(n) > 0);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("expression-position helper call should fail");
+    let err_msg = err.to_string();
+    assert!(err_msg.contains("type mismatch: cannot compare byte[] and int"), "unexpected error: {err_msg}");
 }
 
 #[test]
@@ -2948,8 +2968,48 @@ fn rejects_calling_later_defined_function() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("forward call should fail");
-    assert!(err.to_string().contains("earlier-defined"));
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("forward call should now compile");
+    let selector = selector_for(&compiled, "first");
+    let result = run_script_with_selector(compiled.script, selector);
+    assert!(result.is_ok(), "forward call should execute successfully: {}", result.unwrap_err());
+}
+
+#[test]
+fn rejects_mutually_recursive_helper_calls() {
+    let source = r#"
+        contract Recursion() {
+            function even(int n) : (int) {
+                int result = 0;
+                if (n == 0) {
+                    result = 1;
+                } else {
+                    (int out) = odd(n - 1);
+                    result = out;
+                }
+                return(result);
+            }
+
+            function odd(int n) : (int) {
+                int result = 0;
+                if (n == 0) {
+                    result = 0;
+                } else {
+                    (int out) = even(n - 1);
+                    result = out;
+                }
+                return(result);
+            }
+
+            entrypoint function main() {
+                (int out) = even(2);
+                require(out == 1);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("mutual recursion should fail");
+    let err_msg = err.to_string();
+    assert!(err_msg.contains("recursive function call"), "expected recursion error, got: {err_msg}");
 }
 
 #[test]
@@ -2985,6 +3045,83 @@ fn allows_call_chain_with_earlier_defined_functions() {
     let result = run_script_with_selector(compiled.script, selector);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
+
+#[test]
+fn allows_call_chain_with_later_defined_functions() {
+    let source = r#"
+        contract Calls() {
+            function f(int w) : (int) {
+                require(w > 2);
+                (int v) = g(3);
+                return(v + w);
+            }
+
+            entrypoint function main() {
+                (int out) = f(4);
+                require(out == 10);
+            }
+
+            function g(int y) : (int) {
+                require(y > 1);
+                (int z) = h(2);
+                return(z + y);
+            }
+
+            function h(int x) : (int) {
+                require(x > 0);
+                return(x + 1);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let selector = selector_for(&compiled, "main");
+    let result = run_script_with_selector(compiled.script, selector);
+    assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
+}
+
+#[test]
+fn rejects_calling_entrypoint_from_helper() {
+    let source = r#"
+        contract Calls() {
+            entrypoint function main() {
+                helper();
+            }
+
+            entrypoint function other() {
+                require(true);
+            }
+
+            function helper() {
+                other();
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("helper should not be able to call entrypoint");
+    let err_msg = err.to_string();
+    assert!(err_msg.contains("entrypoint function 'other' cannot be called"), "unexpected error: {err_msg}");
+}
+
+#[test]
+fn rejects_calling_entrypoint_from_entrypoint() {
+    let source = r#"
+        contract Calls() {
+            entrypoint function main() {
+                other();
+            }
+
+            entrypoint function other() {
+                require(true);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("entrypoint should not be able to call entrypoint");
+    let err_msg = err.to_string();
+    assert!(err_msg.contains("entrypoint function 'other' cannot be called"), "unexpected error: {err_msg}");
+}
+
 #[test]
 fn allows_calling_void_function_fails() {
     let source = r#"


### PR DESCRIPTION
This PR changes SilverScript function-call behavior for user-defined functions.

  ## Language Behavior Changes

  - Non-entrypoint functions can now call other non-entrypoint functions regardless of declaration order.
  - Recursive helper calls are now rejected explicitly.
  - Mutual recursion between helper functions is also rejected explicitly.
  - Entrypoint functions cannot be called from helper functions.
  - Entrypoint functions also cannot be called from other entrypoint functions.