### PR TITLE
  Support bare single-return syntax and single-return helper calls in expressions

### DIFF
--- a/silverscript-lang/src/ast/mod.rs
+++ b/silverscript-lang/src/ast/mod.rs
@@ -1583,9 +1583,12 @@ fn parse_statement<'i>(pair: Pair<'i, Rule>) -> Result<Statement<'i>, CompilerEr
         }
         Rule::return_statement => {
             let mut inner = pair.into_inner();
-            let list_pair =
+            let value_pair =
                 inner.next().ok_or_else(|| CompilerError::Unsupported("missing return values".to_string()).with_span(&span))?;
-            let exprs = parse_expression_list(list_pair).map_err(|err| err.with_span(&span))?;
+            let exprs = match value_pair.as_rule() {
+                Rule::expression_list => parse_expression_list(value_pair).map_err(|err| err.with_span(&span))?,
+                _ => vec![parse_expression(value_pair).map_err(|err| err.with_span(&span))?],
+            };
             Ok(Statement::Return { exprs, span })
         }
         Rule::time_op_statement => {

--- a/silverscript-lang/src/ast/mod.rs
+++ b/silverscript-lang/src/ast/mod.rs
@@ -1934,12 +1934,19 @@ fn parse_return_type_list<'i>(pair: Pair<'i, Rule>) -> Result<(Vec<TypeRef>, Vec
     let mut return_types = Vec::new();
     let mut return_spans = Vec::new();
     for user_type in pair.into_inner() {
-        if user_type.as_rule() != Rule::type_name {
-            continue;
+        match user_type.as_rule() {
+            Rule::type_name => {
+                let type_span = Span::from(user_type.as_span());
+                return_types.push(parse_type_name_pair(user_type)?);
+                return_spans.push(type_span);
+            }
+            Rule::return_type_list => {
+                let (nested_types, nested_spans) = parse_return_type_list(user_type)?;
+                return_types.extend(nested_types);
+                return_spans.extend(nested_spans);
+            }
+            _ => {}
         }
-        let type_span = Span::from(user_type.as_span());
-        return_types.push(parse_type_name_pair(user_type)?);
-        return_spans.push(type_span);
     }
     Ok((return_types, return_spans))
 }

--- a/silverscript-lang/src/compiler/inline_functions.rs
+++ b/silverscript-lang/src/compiler/inline_functions.rs
@@ -122,20 +122,34 @@ impl<'i, 'd> Inliner<'i, 'd> {
         match statement {
             Statement::VariableDefinition { type_ref, modifiers, name, expr, span, type_span, modifier_spans, name_span } => {
                 let fresh = self.bind_visible_name(name, scope);
-                let renamed_expr = expr.as_ref().map(|expr| self.rename_expr(expr, scope)).transpose()?;
-                self.push_lowered_statement(
-                    &mut lowered,
-                    Statement::VariableDefinition {
+                if let Some(expr) = expr
+                    && let ExprKind::Call { name: call_name, args, .. } = &expr.kind
+                    && let Some(function) = self.inline_target(call_name)
+                {
+                    let binding = ParamAst {
                         type_ref: type_ref.clone(),
-                        modifiers: modifiers.clone(),
                         name: fresh,
-                        expr: renamed_expr,
                         span: *span,
                         type_span: *type_span,
-                        modifier_spans: modifier_spans.clone(),
                         name_span: *name_span,
-                    },
-                );
+                    };
+                    lowered.extend(self.inline_call(&function, args, Some(&[binding]), scope, visited_functions, *span)?);
+                } else {
+                    let renamed_expr = expr.as_ref().map(|expr| self.rename_expr(expr, scope)).transpose()?;
+                    self.push_lowered_statement(
+                        &mut lowered,
+                        Statement::VariableDefinition {
+                            type_ref: type_ref.clone(),
+                            modifiers: modifiers.clone(),
+                            name: fresh,
+                            expr: renamed_expr,
+                            span: *span,
+                            type_span: *type_span,
+                            modifier_spans: modifier_spans.clone(),
+                            name_span: *name_span,
+                        },
+                    );
+                }
             }
             Statement::TupleAssignment {
                 left_type_ref,

--- a/silverscript-lang/src/compiler/inline_functions.rs
+++ b/silverscript-lang/src/compiler/inline_functions.rs
@@ -524,12 +524,7 @@ impl<'i, 'd> Inliner<'i, 'd> {
                 Ok((
                     prelude,
                     Expr::new(
-                        ExprKind::Split {
-                            source: Box::new(source),
-                            index: Box::new(index),
-                            part: *part,
-                            span: *split_span,
-                        },
+                        ExprKind::Split { source: Box::new(source), index: Box::new(index), part: *part, span: *split_span },
                         span,
                     ),
                 ))
@@ -543,12 +538,7 @@ impl<'i, 'd> Inliner<'i, 'd> {
                 Ok((
                     prelude,
                     Expr::new(
-                        ExprKind::Slice {
-                            source: Box::new(source),
-                            start: Box::new(start),
-                            end: Box::new(end),
-                            span: *slice_span,
-                        },
+                        ExprKind::Slice { source: Box::new(source), start: Box::new(start), end: Box::new(end), span: *slice_span },
                         span,
                     ),
                 ))
@@ -567,10 +557,7 @@ impl<'i, 'd> Inliner<'i, 'd> {
                 let (mut prelude, left) = self.lower_expr(left, scope, visited_functions)?;
                 let (more_prelude, right) = self.lower_expr(right, scope, visited_functions)?;
                 prelude.extend(more_prelude);
-                Ok((
-                    prelude,
-                    Expr::new(ExprKind::Binary { op: *op, left: Box::new(left), right: Box::new(right) }, span),
-                ))
+                Ok((prelude, Expr::new(ExprKind::Binary { op: *op, left: Box::new(left), right: Box::new(right) }, span)))
             }
             ExprKind::IfElse { condition, then_expr, else_expr } => {
                 let (mut prelude, condition) = self.lower_expr(condition, scope, visited_functions)?;
@@ -625,13 +612,7 @@ impl<'i, 'd> Inliner<'i, 'd> {
             }
             ExprKind::UnarySuffix { source, kind, span: suffix_span } => {
                 let (prelude, source) = self.lower_expr(source, scope, visited_functions)?;
-                Ok((
-                    prelude,
-                    Expr::new(
-                        ExprKind::UnarySuffix { source: Box::new(source), kind: *kind, span: *suffix_span },
-                        span,
-                    ),
-                ))
+                Ok((prelude, Expr::new(ExprKind::UnarySuffix { source: Box::new(source), kind: *kind, span: *suffix_span }, span)))
             }
         }
     }

--- a/silverscript-lang/src/compiler/inline_functions.rs
+++ b/silverscript-lang/src/compiler/inline_functions.rs
@@ -122,34 +122,26 @@ impl<'i, 'd> Inliner<'i, 'd> {
         match statement {
             Statement::VariableDefinition { type_ref, modifiers, name, expr, span, type_span, modifier_spans, name_span } => {
                 let fresh = self.bind_visible_name(name, scope);
-                if let Some(expr) = expr
-                    && let ExprKind::Call { name: call_name, args, .. } = &expr.kind
-                    && let Some(function) = self.inline_target(call_name)
-                {
-                    let binding = ParamAst {
+                let renamed_expr = if let Some(expr) = expr {
+                    let (prelude, renamed_expr) = self.lower_expr(expr, scope, visited_functions)?;
+                    lowered.extend(prelude);
+                    Some(renamed_expr)
+                } else {
+                    None
+                };
+                self.push_lowered_statement(
+                    &mut lowered,
+                    Statement::VariableDefinition {
                         type_ref: type_ref.clone(),
+                        modifiers: modifiers.clone(),
                         name: fresh,
+                        expr: renamed_expr,
                         span: *span,
                         type_span: *type_span,
+                        modifier_spans: modifier_spans.clone(),
                         name_span: *name_span,
-                    };
-                    lowered.extend(self.inline_call(&function, args, Some(&[binding]), scope, visited_functions, *span)?);
-                } else {
-                    let renamed_expr = expr.as_ref().map(|expr| self.rename_expr(expr, scope)).transpose()?;
-                    self.push_lowered_statement(
-                        &mut lowered,
-                        Statement::VariableDefinition {
-                            type_ref: type_ref.clone(),
-                            modifiers: modifiers.clone(),
-                            name: fresh,
-                            expr: renamed_expr,
-                            span: *span,
-                            type_span: *type_span,
-                            modifier_spans: modifier_spans.clone(),
-                            name_span: *name_span,
-                        },
-                    );
-                }
+                    },
+                );
             }
             Statement::TupleAssignment {
                 left_type_ref,
@@ -165,7 +157,8 @@ impl<'i, 'd> Inliner<'i, 'd> {
             } => {
                 let left_fresh = self.bind_visible_name(left_name, scope);
                 let right_fresh = self.bind_visible_name(right_name, scope);
-                let renamed_expr = self.rename_expr(expr, scope)?;
+                let (prelude, renamed_expr) = self.lower_expr(expr, scope, visited_functions)?;
+                lowered.extend(prelude);
                 self.push_lowered_statement(
                     &mut lowered,
                     Statement::TupleAssignment {
@@ -183,7 +176,8 @@ impl<'i, 'd> Inliner<'i, 'd> {
                 );
             }
             Statement::ArrayPush { name, expr, span, name_span } => {
-                let renamed_expr = self.rename_expr(expr, scope)?;
+                let (prelude, renamed_expr) = self.lower_expr(expr, scope, visited_functions)?;
+                lowered.extend(prelude);
                 self.push_lowered_statement(
                     &mut lowered,
                     Statement::ArrayPush {
@@ -203,7 +197,8 @@ impl<'i, 'd> Inliner<'i, 'd> {
                 if let Some(function) = self.inline_target(name) {
                     lowered.extend(self.inline_call(&function, args, None, scope, visited_functions, *span)?);
                 } else {
-                    let renamed_args = args.iter().map(|arg| self.rename_expr(arg, scope)).collect::<Result<Vec<_>, _>>()?;
+                    let (prelude, renamed_args) = self.lower_exprs(args, scope, visited_functions)?;
+                    lowered.extend(prelude);
                     self.push_lowered_statement(
                         &mut lowered,
                         Statement::FunctionCall { name: name.clone(), args: renamed_args, span: *span, name_span: *name_span },
@@ -228,7 +223,8 @@ impl<'i, 'd> Inliner<'i, 'd> {
                             ParamAst { name: fresh, ..binding.clone() }
                         })
                         .collect::<Vec<_>>();
-                    let renamed_args = args.iter().map(|arg| self.rename_expr(arg, scope)).collect::<Result<Vec<_>, _>>()?;
+                    let (prelude, renamed_args) = self.lower_exprs(args, scope, visited_functions)?;
+                    lowered.extend(prelude);
                     self.push_lowered_statement(
                         &mut lowered,
                         Statement::FunctionCallAssign {
@@ -249,7 +245,8 @@ impl<'i, 'd> Inliner<'i, 'd> {
                         StateBindingAst { name: fresh, ..binding.clone() }
                     })
                     .collect();
-                let renamed_args = args.iter().map(|arg| self.rename_expr(arg, scope)).collect::<Result<Vec<_>, _>>()?;
+                let (prelude, renamed_args) = self.lower_exprs(args, scope, visited_functions)?;
+                lowered.extend(prelude);
                 self.push_lowered_statement(
                     &mut lowered,
                     Statement::StateFunctionCallAssign {
@@ -269,21 +266,24 @@ impl<'i, 'd> Inliner<'i, 'd> {
                         StateBindingAst { name: fresh, ..binding.clone() }
                     })
                     .collect();
-                let renamed_expr = self.rename_expr(expr, scope)?;
+                let (prelude, renamed_expr) = self.lower_expr(expr, scope, visited_functions)?;
+                lowered.extend(prelude);
                 self.push_lowered_statement(
                     &mut lowered,
                     Statement::StructDestructure { bindings: renamed_bindings, expr: renamed_expr, span: *span },
                 );
             }
             Statement::Assign { name, expr, span, name_span } => {
-                let renamed_expr = self.rename_expr(expr, scope)?;
+                let (prelude, renamed_expr) = self.lower_expr(expr, scope, visited_functions)?;
+                lowered.extend(prelude);
                 self.push_lowered_statement(
                     &mut lowered,
                     Statement::Assign { name: self.rename_name(name, scope), expr: renamed_expr, span: *span, name_span: *name_span },
                 );
             }
             Statement::TimeOp { tx_var, expr, message, span, tx_var_span, message_span } => {
-                let renamed_expr = self.rename_expr(expr, scope)?;
+                let (prelude, renamed_expr) = self.lower_expr(expr, scope, visited_functions)?;
+                lowered.extend(prelude);
                 self.push_lowered_statement(
                     &mut lowered,
                     Statement::TimeOp {
@@ -297,14 +297,16 @@ impl<'i, 'd> Inliner<'i, 'd> {
                 );
             }
             Statement::Require { expr, message, span, message_span } => {
-                let renamed_expr = self.rename_expr(expr, scope)?;
+                let (prelude, renamed_expr) = self.lower_expr(expr, scope, visited_functions)?;
+                lowered.extend(prelude);
                 self.push_lowered_statement(
                     &mut lowered,
                     Statement::Require { expr: renamed_expr, message: message.clone(), span: *span, message_span: *message_span },
                 );
             }
             Statement::If { condition, then_branch, else_branch, span, then_span, else_span } => {
-                let renamed_condition = self.rename_expr(condition, scope)?;
+                let (prelude, renamed_condition) = self.lower_expr(condition, scope, visited_functions)?;
+                lowered.extend(prelude);
                 let mut then_scope = scope.clone();
                 self.predeclare_branch_bindings(then_branch, &mut then_scope);
                 let lowered_then = self.lower_block(then_branch, &mut then_scope, visited_functions)?;
@@ -332,9 +334,12 @@ impl<'i, 'd> Inliner<'i, 'd> {
                 let mut body_scope = scope.clone();
                 let lowered_ident = self.bind_visible_name(ident, &mut body_scope);
                 let lowered_body = self.lower_block(body, &mut body_scope, visited_functions)?;
-                let lowered_start = self.rename_expr(start, scope)?;
-                let lowered_end = self.rename_expr(end, scope)?;
-                let lowered_max_iterations = self.rename_expr(max_iterations, scope)?;
+                let (mut prelude, lowered_start) = self.lower_expr(start, scope, visited_functions)?;
+                let (more_prelude, lowered_end) = self.lower_expr(end, scope, visited_functions)?;
+                prelude.extend(more_prelude);
+                let (more_prelude, lowered_max_iterations) = self.lower_expr(max_iterations, scope, visited_functions)?;
+                prelude.extend(more_prelude);
+                lowered.extend(prelude);
                 self.push_lowered_statement(
                     &mut lowered,
                     Statement::For {
@@ -350,11 +355,13 @@ impl<'i, 'd> Inliner<'i, 'd> {
                 );
             }
             Statement::Return { exprs, span } => {
-                let renamed_exprs = exprs.iter().map(|expr| self.rename_expr(expr, scope)).collect::<Result<Vec<_>, _>>()?;
+                let (prelude, renamed_exprs) = self.lower_exprs(exprs, scope, visited_functions)?;
+                lowered.extend(prelude);
                 self.push_lowered_statement(&mut lowered, Statement::Return { exprs: renamed_exprs, span: *span });
             }
             Statement::Console { args, span } => {
-                let renamed_args = args.iter().map(|arg| self.rename_expr(arg, scope)).collect::<Result<Vec<_>, _>>()?;
+                let (prelude, renamed_args) = self.lower_exprs(args, scope, visited_functions)?;
+                lowered.extend(prelude);
                 self.push_lowered_statement(&mut lowered, Statement::Console { args: renamed_args, span: *span });
             }
         }
@@ -391,7 +398,8 @@ impl<'i, 'd> Inliner<'i, 'd> {
         visited_functions.insert(function.name.clone());
         for (param, arg) in function.params.iter().zip(args.iter()) {
             let fresh = self.bind_visible_name(&param.name, &mut local_scope);
-            let renamed_arg = self.rename_expr(arg, caller_scope)?;
+            let (prelude, renamed_arg) = self.lower_expr(arg, caller_scope, visited_functions)?;
+            lowered.extend(prelude);
             self.debug_recorder.record_inline_source_param(&param.name, &param.type_ref, renamed_arg.clone());
             self.push_lowered_statement(
                 &mut lowered,
@@ -421,7 +429,8 @@ impl<'i, 'd> Inliner<'i, 'd> {
 
             if let (Some(bindings), Some(return_exprs)) = (bindings, return_exprs) {
                 for (binding, expr) in bindings.iter().zip(return_exprs.iter()) {
-                    let renamed_expr = self.rename_expr(expr, &local_scope)?;
+                    let (prelude, renamed_expr) = self.lower_expr(expr, &local_scope, visited_functions)?;
+                    lowered.extend(prelude);
                     self.push_lowered_statement(
                         &mut lowered,
                         Statement::VariableDefinition {
@@ -447,6 +456,186 @@ impl<'i, 'd> Inliner<'i, 'd> {
         Ok(lowered)
     }
 
+    fn lower_exprs(
+        &mut self,
+        exprs: &[Expr<'i>],
+        scope: &HashMap<String, String>,
+        visited_functions: &mut HashSet<String>,
+    ) -> Result<(Vec<Statement<'i>>, Vec<Expr<'i>>), CompilerError> {
+        let mut lowered_statements = Vec::new();
+        let mut lowered_exprs = Vec::with_capacity(exprs.len());
+        for expr in exprs {
+            let (prelude, lowered_expr) = self.lower_expr(expr, scope, visited_functions)?;
+            lowered_statements.extend(prelude);
+            lowered_exprs.push(lowered_expr);
+        }
+        Ok((lowered_statements, lowered_exprs))
+    }
+
+    fn lower_expr(
+        &mut self,
+        expr: &Expr<'i>,
+        scope: &HashMap<String, String>,
+        visited_functions: &mut HashSet<String>,
+    ) -> Result<(Vec<Statement<'i>>, Expr<'i>), CompilerError> {
+        let span = expr.span;
+        match &expr.kind {
+            ExprKind::Int(value) => Ok((Vec::new(), Expr::new(ExprKind::Int(*value), span))),
+            ExprKind::Bool(value) => Ok((Vec::new(), Expr::new(ExprKind::Bool(*value), span))),
+            ExprKind::Byte(value) => Ok((Vec::new(), Expr::new(ExprKind::Byte(*value), span))),
+            ExprKind::String(value) => Ok((Vec::new(), Expr::new(ExprKind::String(value.clone()), span))),
+            ExprKind::DateLiteral(value) => Ok((Vec::new(), Expr::new(ExprKind::DateLiteral(*value), span))),
+            ExprKind::Identifier(name) => Ok((Vec::new(), Expr::new(ExprKind::Identifier(self.rename_name(name, scope)), span))),
+            ExprKind::Array(values) => {
+                let (prelude, values) = self.lower_exprs(values, scope, visited_functions)?;
+                Ok((prelude, Expr::new(ExprKind::Array(values), span)))
+            }
+            ExprKind::Call { name, args, name_span } => {
+                let (mut prelude, args) = self.lower_exprs(args, scope, visited_functions)?;
+                if let Some(function) = self.inline_target(name) {
+                    if function.return_types.len() != 1 {
+                        return Err(CompilerError::Unsupported(format!(
+                            "function '{}' with multiple return values cannot be used in expressions",
+                            function.name
+                        )));
+                    }
+                    let temp_name = self.fresh_name(name);
+                    let binding = ParamAst {
+                        type_ref: function.return_types[0].clone(),
+                        name: temp_name.clone(),
+                        span,
+                        type_span: *name_span,
+                        name_span: *name_span,
+                    };
+                    prelude.extend(self.inline_call(&function, &args, Some(&[binding]), scope, visited_functions, span)?);
+                    Ok((prelude, Expr::identifier(temp_name)))
+                } else {
+                    Ok((prelude, Expr::new(ExprKind::Call { name: name.clone(), args, name_span: *name_span }, span)))
+                }
+            }
+            ExprKind::New { name, args, name_span } => {
+                let (prelude, args) = self.lower_exprs(args, scope, visited_functions)?;
+                Ok((prelude, Expr::new(ExprKind::New { name: name.clone(), args, name_span: *name_span }, span)))
+            }
+            ExprKind::Split { source, index, part, span: split_span } => {
+                let (mut prelude, source) = self.lower_expr(source, scope, visited_functions)?;
+                let (more_prelude, index) = self.lower_expr(index, scope, visited_functions)?;
+                prelude.extend(more_prelude);
+                Ok((
+                    prelude,
+                    Expr::new(
+                        ExprKind::Split {
+                            source: Box::new(source),
+                            index: Box::new(index),
+                            part: *part,
+                            span: *split_span,
+                        },
+                        span,
+                    ),
+                ))
+            }
+            ExprKind::Slice { source, start, end, span: slice_span } => {
+                let (mut prelude, source) = self.lower_expr(source, scope, visited_functions)?;
+                let (more_prelude, start) = self.lower_expr(start, scope, visited_functions)?;
+                prelude.extend(more_prelude);
+                let (more_prelude, end) = self.lower_expr(end, scope, visited_functions)?;
+                prelude.extend(more_prelude);
+                Ok((
+                    prelude,
+                    Expr::new(
+                        ExprKind::Slice {
+                            source: Box::new(source),
+                            start: Box::new(start),
+                            end: Box::new(end),
+                            span: *slice_span,
+                        },
+                        span,
+                    ),
+                ))
+            }
+            ExprKind::ArrayIndex { source, index } => {
+                let (mut prelude, source) = self.lower_expr(source, scope, visited_functions)?;
+                let (more_prelude, index) = self.lower_expr(index, scope, visited_functions)?;
+                prelude.extend(more_prelude);
+                Ok((prelude, Expr::new(ExprKind::ArrayIndex { source: Box::new(source), index: Box::new(index) }, span)))
+            }
+            ExprKind::Unary { op, expr } => {
+                let (prelude, expr) = self.lower_expr(expr, scope, visited_functions)?;
+                Ok((prelude, Expr::new(ExprKind::Unary { op: *op, expr: Box::new(expr) }, span)))
+            }
+            ExprKind::Binary { op, left, right } => {
+                let (mut prelude, left) = self.lower_expr(left, scope, visited_functions)?;
+                let (more_prelude, right) = self.lower_expr(right, scope, visited_functions)?;
+                prelude.extend(more_prelude);
+                Ok((
+                    prelude,
+                    Expr::new(ExprKind::Binary { op: *op, left: Box::new(left), right: Box::new(right) }, span),
+                ))
+            }
+            ExprKind::IfElse { condition, then_expr, else_expr } => {
+                let (mut prelude, condition) = self.lower_expr(condition, scope, visited_functions)?;
+                let (more_prelude, then_expr) = self.lower_expr(then_expr, scope, visited_functions)?;
+                prelude.extend(more_prelude);
+                let (more_prelude, else_expr) = self.lower_expr(else_expr, scope, visited_functions)?;
+                prelude.extend(more_prelude);
+                Ok((
+                    prelude,
+                    Expr::new(
+                        ExprKind::IfElse {
+                            condition: Box::new(condition),
+                            then_expr: Box::new(then_expr),
+                            else_expr: Box::new(else_expr),
+                        },
+                        span,
+                    ),
+                ))
+            }
+            ExprKind::Nullary(op) => Ok((Vec::new(), Expr::new(ExprKind::Nullary(*op), span))),
+            ExprKind::Introspection { kind, index, field_span } => {
+                let (prelude, index) = self.lower_expr(index, scope, visited_functions)?;
+                Ok((
+                    prelude,
+                    Expr::new(ExprKind::Introspection { kind: *kind, index: Box::new(index), field_span: *field_span }, span),
+                ))
+            }
+            ExprKind::StateObject(fields) => {
+                let mut prelude = Vec::new();
+                let mut lowered_fields = Vec::with_capacity(fields.len());
+                for field in fields {
+                    let (field_prelude, expr) = self.lower_expr(&field.expr, scope, visited_functions)?;
+                    prelude.extend(field_prelude);
+                    lowered_fields.push(StateFieldExpr {
+                        name: field.name.clone(),
+                        expr,
+                        span: field.span,
+                        name_span: field.name_span,
+                    });
+                }
+                Ok((prelude, Expr::new(ExprKind::StateObject(lowered_fields), span)))
+            }
+            ExprKind::FieldAccess { source, field, field_span } => {
+                let (prelude, source) = self.lower_expr(source, scope, visited_functions)?;
+                Ok((
+                    prelude,
+                    Expr::new(ExprKind::FieldAccess { source: Box::new(source), field: field.clone(), field_span: *field_span }, span),
+                ))
+            }
+            ExprKind::NumberWithUnit { value, unit } => {
+                Ok((Vec::new(), Expr::new(ExprKind::NumberWithUnit { value: *value, unit: unit.clone() }, span)))
+            }
+            ExprKind::UnarySuffix { source, kind, span: suffix_span } => {
+                let (prelude, source) = self.lower_expr(source, scope, visited_functions)?;
+                Ok((
+                    prelude,
+                    Expr::new(
+                        ExprKind::UnarySuffix { source: Box::new(source), kind: *kind, span: *suffix_span },
+                        span,
+                    ),
+                ))
+            }
+        }
+    }
+
     fn push_lowered_statement(&mut self, lowered: &mut Vec<Statement<'i>>, statement: Statement<'i>) {
         self.debug_recorder.record_lowered_source_statement(&statement);
         lowered.push(statement);
@@ -454,86 +643,5 @@ impl<'i, 'd> Inliner<'i, 'd> {
 
     fn rename_name(&self, name: &str, scope: &HashMap<String, String>) -> String {
         scope.get(name).cloned().unwrap_or_else(|| name.to_string())
-    }
-
-    fn rename_expr(&mut self, expr: &Expr<'i>, scope: &HashMap<String, String>) -> Result<Expr<'i>, CompilerError> {
-        let span = expr.span;
-        Ok(Expr::new(
-            match &expr.kind {
-                ExprKind::Int(value) => ExprKind::Int(*value),
-                ExprKind::Bool(value) => ExprKind::Bool(*value),
-                ExprKind::Byte(value) => ExprKind::Byte(*value),
-                ExprKind::String(value) => ExprKind::String(value.clone()),
-                ExprKind::DateLiteral(value) => ExprKind::DateLiteral(*value),
-                ExprKind::Identifier(name) => ExprKind::Identifier(self.rename_name(name, scope)),
-                ExprKind::Array(values) => {
-                    ExprKind::Array(values.iter().map(|value| self.rename_expr(value, scope)).collect::<Result<Vec<_>, _>>()?)
-                }
-                ExprKind::Call { name, args, name_span } => ExprKind::Call {
-                    name: name.clone(),
-                    args: args.iter().map(|arg| self.rename_expr(arg, scope)).collect::<Result<Vec<_>, _>>()?,
-                    name_span: *name_span,
-                },
-                ExprKind::New { name, args, name_span } => ExprKind::New {
-                    name: name.clone(),
-                    args: args.iter().map(|arg| self.rename_expr(arg, scope)).collect::<Result<Vec<_>, _>>()?,
-                    name_span: *name_span,
-                },
-                ExprKind::Split { source, index, part, span } => ExprKind::Split {
-                    source: Box::new(self.rename_expr(source, scope)?),
-                    index: Box::new(self.rename_expr(index, scope)?),
-                    part: *part,
-                    span: *span,
-                },
-                ExprKind::Slice { source, start, end, span } => ExprKind::Slice {
-                    source: Box::new(self.rename_expr(source, scope)?),
-                    start: Box::new(self.rename_expr(start, scope)?),
-                    end: Box::new(self.rename_expr(end, scope)?),
-                    span: *span,
-                },
-                ExprKind::ArrayIndex { source, index } => ExprKind::ArrayIndex {
-                    source: Box::new(self.rename_expr(source, scope)?),
-                    index: Box::new(self.rename_expr(index, scope)?),
-                },
-                ExprKind::Unary { op, expr } => ExprKind::Unary { op: *op, expr: Box::new(self.rename_expr(expr, scope)?) },
-                ExprKind::Binary { op, left, right } => ExprKind::Binary {
-                    op: *op,
-                    left: Box::new(self.rename_expr(left, scope)?),
-                    right: Box::new(self.rename_expr(right, scope)?),
-                },
-                ExprKind::IfElse { condition, then_expr, else_expr } => ExprKind::IfElse {
-                    condition: Box::new(self.rename_expr(condition, scope)?),
-                    then_expr: Box::new(self.rename_expr(then_expr, scope)?),
-                    else_expr: Box::new(self.rename_expr(else_expr, scope)?),
-                },
-                ExprKind::Nullary(op) => ExprKind::Nullary(*op),
-                ExprKind::Introspection { kind, index, field_span } => {
-                    ExprKind::Introspection { kind: *kind, index: Box::new(self.rename_expr(index, scope)?), field_span: *field_span }
-                }
-                ExprKind::StateObject(fields) => ExprKind::StateObject(
-                    fields
-                        .iter()
-                        .map(|field| {
-                            Ok(StateFieldExpr {
-                                name: field.name.clone(),
-                                expr: self.rename_expr(&field.expr, scope)?,
-                                span: field.span,
-                                name_span: field.name_span,
-                            })
-                        })
-                        .collect::<Result<Vec<_>, CompilerError>>()?,
-                ),
-                ExprKind::FieldAccess { source, field, field_span } => ExprKind::FieldAccess {
-                    source: Box::new(self.rename_expr(source, scope)?),
-                    field: field.clone(),
-                    field_span: *field_span,
-                },
-                ExprKind::NumberWithUnit { value, unit } => ExprKind::NumberWithUnit { value: *value, unit: unit.clone() },
-                ExprKind::UnarySuffix { source, kind, span } => {
-                    ExprKind::UnarySuffix { source: Box::new(self.rename_expr(source, scope)?), kind: *kind, span: *span }
-                }
-            },
-            span,
-        ))
     }
 }

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -229,9 +229,17 @@ fn validate_variable_definition_statement_shape<'i>(
         validate_array_initializer(expr, &effective_type_ref, ctx.types, ctx.constants)?;
     }
     if let Some(expr) = expr {
-        validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
-        validate_expr_assignable_to_type(expr, type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields).map_err(
-            |err| {
+        validate_expr_semantics(
+            expr,
+            ctx.env,
+            ctx.prefer_env_for_comparison,
+            ctx.types,
+            ctx.structs,
+            ctx.functions,
+            ctx.contract_fields,
+        )?;
+        validate_expr_assignable_to_type(expr, type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
+            .map_err(|err| {
                 map_declared_type_error(
                     err,
                     "variable",
@@ -243,8 +251,7 @@ fn validate_variable_definition_statement_shape<'i>(
                     ctx.structs,
                     ctx.constants,
                 )
-            },
-        )?;
+            })?;
         ctx.env.insert(name.to_string(), expr.clone());
         ctx.prefer_env_for_comparison.remove(name);
     }
@@ -325,7 +332,15 @@ fn validate_state_function_call_assign_statement_shape<'i>(
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
     for arg in args {
-        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
+        validate_expr_semantics(
+            arg,
+            ctx.env,
+            ctx.prefer_env_for_comparison,
+            ctx.types,
+            ctx.structs,
+            ctx.functions,
+            ctx.contract_fields,
+        )?;
     }
     validate_state_function_call_assign(bindings, name, args, ctx.structs, ctx.contract_fields)?;
     for binding in bindings {
@@ -355,7 +370,15 @@ fn validate_function_call_statement_shape<'i>(
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
     for arg in args {
-        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
+        validate_expr_semantics(
+            arg,
+            ctx.env,
+            ctx.prefer_env_for_comparison,
+            ctx.types,
+            ctx.structs,
+            ctx.functions,
+            ctx.contract_fields,
+        )?;
     }
     if ctx.functions.contains_key(name) {
         validate_internal_call(name, args, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)?;
@@ -370,7 +393,15 @@ fn validate_function_call_assign_statement_shape<'i>(
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
     for arg in args {
-        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
+        validate_expr_semantics(
+            arg,
+            ctx.env,
+            ctx.prefer_env_for_comparison,
+            ctx.types,
+            ctx.structs,
+            ctx.functions,
+            ctx.contract_fields,
+        )?;
     }
     let function = validate_internal_call(name, args, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)?;
     if bindings.len() != function.return_types.len() {
@@ -394,7 +425,15 @@ fn validate_return_statement_shape<'i>(
     exprs: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
     for expr in exprs {
-        validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
+        validate_expr_semantics(
+            expr,
+            ctx.env,
+            ctx.prefer_env_for_comparison,
+            ctx.types,
+            ctx.structs,
+            ctx.functions,
+            ctx.contract_fields,
+        )?;
     }
     validate_return_types(exprs, ctx.return_types, ctx.types, ctx.structs, ctx.constants)
 }
@@ -418,7 +457,15 @@ fn validate_console_statement_shape<'i>(
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
     for arg in args {
-        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
+        validate_expr_semantics(
+            arg,
+            ctx.env,
+            ctx.prefer_env_for_comparison,
+            ctx.types,
+            ctx.structs,
+            ctx.functions,
+            ctx.contract_fields,
+        )?;
     }
     Ok(())
 }
@@ -431,9 +478,10 @@ fn validate_assign_statement_shape<'i>(
     validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
     if let Some(type_name) = ctx.types.get(name).cloned() {
         let type_ref = parse_type_ref(&type_name)?;
-        validate_expr_assignable_to_type(expr, &type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields).map_err(
-            |err| map_declared_type_error(err, "variable", name, &type_name, expr, &type_ref, ctx.types, ctx.structs, ctx.constants),
-        )?;
+        validate_expr_assignable_to_type(expr, &type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
+            .map_err(|err| {
+            map_declared_type_error(err, "variable", name, &type_name, expr, &type_ref, ctx.types, ctx.structs, ctx.constants)
+        })?;
     }
     ctx.env.insert(name.to_string(), expr.clone());
     ctx.prefer_env_for_comparison.remove(name);
@@ -518,7 +566,15 @@ fn validate_for_statement_shape<'i>(
     max_iterations: &Expr<'i>,
     body: &[Statement<'i>],
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(start, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
+    validate_expr_semantics(
+        start,
+        ctx.env,
+        ctx.prefer_env_for_comparison,
+        ctx.types,
+        ctx.structs,
+        ctx.functions,
+        ctx.contract_fields,
+    )?;
     validate_expr_semantics(end, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
     validate_expr_semantics(
         max_iterations,
@@ -698,8 +754,15 @@ fn validate_expr_semantics<'i>(
                 return Err(CompilerError::Unsupported("byte values do not support '+'".to_string()));
             }
             if matches!(op, BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge) {
-                let left_type =
-                    infer_expr_type_ref_for_comparison_ref(left, env, prefer_env_for_comparison, types, structs, functions, contract_fields);
+                let left_type = infer_expr_type_ref_for_comparison_ref(
+                    left,
+                    env,
+                    prefer_env_for_comparison,
+                    types,
+                    structs,
+                    functions,
+                    contract_fields,
+                );
                 let coerced_right = coerce_rhs_byte_literal_for_comparison_ref(left_type.as_ref(), right);
                 let right_type = infer_expr_type_ref_for_comparison_ref(
                     &coerced_right,
@@ -816,8 +879,15 @@ fn infer_expr_type_ref_for_comparison_ref<'i>(
             }
         }
         ExprKind::FieldAccess { source, field, .. } => {
-            let source_type =
-                infer_expr_type_ref_for_comparison_ref(source, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
+            let source_type = infer_expr_type_ref_for_comparison_ref(
+                source,
+                env,
+                prefer_env_for_comparison,
+                types,
+                structs,
+                functions,
+                contract_fields,
+            )?;
             let struct_name = struct_name_from_type_ref(&source_type, structs)?;
             let struct_ast = structs.get(struct_name)?;
             struct_ast.fields.iter().find(|candidate| candidate.name == *field).map(|candidate| candidate.type_ref.clone())
@@ -1008,13 +1078,15 @@ fn validate_internal_call<'i>(
             ));
         }
         let param_type_name = type_name_from_ref(&param.type_ref);
-        validate_expr_assignable_to_type(arg, &param.type_ref, types, structs, constants, functions, contract_fields).map_err(|err| {
-            if matches!(&arg.kind, ExprKind::Call { name, .. } if name == "readInputStateWithTemplate") {
-                err
-            } else {
-                CompilerError::Unsupported(format!("function argument '{}' expects {}", param.name, param_type_name))
-            }
-        })?;
+        validate_expr_assignable_to_type(arg, &param.type_ref, types, structs, constants, functions, contract_fields).map_err(
+            |err| {
+                if matches!(&arg.kind, ExprKind::Call { name, .. } if name == "readInputStateWithTemplate") {
+                    err
+                } else {
+                    CompilerError::Unsupported(format!("function argument '{}' expects {}", param.name, param_type_name))
+                }
+            },
+        )?;
     }
 
     Ok(function)

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -134,9 +134,9 @@ fn validate_contract_field_initializers<'i>(
 
     for field in &contract.fields {
         let type_name = type_name_from_ref(&field.type_ref);
-        validate_expr_semantics(&field.expr, constants, &HashSet::new(), &types, structs, &contract.fields)?;
+        validate_expr_semantics(&field.expr, constants, &HashSet::new(), &types, structs, &HashMap::new(), &contract.fields)?;
         ensure_array_elements_have_known_size(&field.type_ref, structs, &type_name)?;
-        validate_expr_assignable_to_type(&field.expr, &field.type_ref, &types, structs, constants, &contract.fields)
+        validate_expr_assignable_to_type(&field.expr, &field.type_ref, &types, structs, constants, &HashMap::new(), &contract.fields)
             .map_err(|_| CompilerError::Unsupported(format!("contract field '{}' expects {}", field.name, type_name)))?;
         types.insert(field.name.clone(), type_name);
     }
@@ -229,8 +229,8 @@ fn validate_variable_definition_statement_shape<'i>(
         validate_array_initializer(expr, &effective_type_ref, ctx.types, ctx.constants)?;
     }
     if let Some(expr) = expr {
-        validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
-        validate_expr_assignable_to_type(expr, type_ref, ctx.types, ctx.structs, ctx.constants, ctx.contract_fields).map_err(
+        validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
+        validate_expr_assignable_to_type(expr, type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields).map_err(
             |err| {
                 map_declared_type_error(
                     err,
@@ -297,7 +297,7 @@ fn validate_tuple_assignment_statement_shape<'i>(
     right_name: &str,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
+    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
     ensure_array_elements_have_known_size(left_type_ref, ctx.structs, &type_name_from_ref(left_type_ref))?;
     ensure_array_elements_have_known_size(right_type_ref, ctx.structs, &type_name_from_ref(right_type_ref))?;
     if let ExprKind::Split { source, index, span: split_span, .. } = &expr.kind {
@@ -325,7 +325,7 @@ fn validate_state_function_call_assign_statement_shape<'i>(
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
     for arg in args {
-        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
+        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
     }
     validate_state_function_call_assign(bindings, name, args, ctx.structs, ctx.contract_fields)?;
     for binding in bindings {
@@ -340,7 +340,7 @@ fn validate_struct_destructure_statement_shape<'i>(
     bindings: &[StateBindingAst<'i>],
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
+    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
     validate_struct_destructure_bindings(bindings, expr, ctx.types, ctx.structs, ctx.contract_fields)?;
     for binding in bindings {
         ensure_array_elements_have_known_size(&binding.type_ref, ctx.structs, &type_name_from_ref(&binding.type_ref))?;
@@ -355,7 +355,7 @@ fn validate_function_call_statement_shape<'i>(
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
     for arg in args {
-        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
+        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
     }
     if ctx.functions.contains_key(name) {
         validate_internal_call(name, args, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)?;
@@ -370,7 +370,7 @@ fn validate_function_call_assign_statement_shape<'i>(
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
     for arg in args {
-        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
+        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
     }
     let function = validate_internal_call(name, args, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)?;
     if bindings.len() != function.return_types.len() {
@@ -394,7 +394,7 @@ fn validate_return_statement_shape<'i>(
     exprs: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
     for expr in exprs {
-        validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
+        validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
     }
     validate_return_types(exprs, ctx.return_types, ctx.types, ctx.structs, ctx.constants)
 }
@@ -403,14 +403,14 @@ fn validate_require_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)
+    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)
 }
 
 fn validate_time_op_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)
+    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)
 }
 
 fn validate_console_statement_shape<'i>(
@@ -418,7 +418,7 @@ fn validate_console_statement_shape<'i>(
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
     for arg in args {
-        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
+        validate_expr_semantics(arg, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
     }
     Ok(())
 }
@@ -428,10 +428,10 @@ fn validate_assign_statement_shape<'i>(
     name: &str,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
+    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
     if let Some(type_name) = ctx.types.get(name).cloned() {
         let type_ref = parse_type_ref(&type_name)?;
-        validate_expr_assignable_to_type(expr, &type_ref, ctx.types, ctx.structs, ctx.constants, ctx.contract_fields).map_err(
+        validate_expr_assignable_to_type(expr, &type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields).map_err(
             |err| map_declared_type_error(err, "variable", name, &type_name, expr, &type_ref, ctx.types, ctx.structs, ctx.constants),
         )?;
     }
@@ -447,7 +447,15 @@ fn validate_if_statement_shape<'i>(
     else_branch: Option<&[Statement<'i>]>,
 ) -> Result<(), CompilerError> {
     if let Statement::If { condition, .. } = stmt {
-        validate_expr_semantics(condition, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
+        validate_expr_semantics(
+            condition,
+            ctx.env,
+            ctx.prefer_env_for_comparison,
+            ctx.types,
+            ctx.structs,
+            ctx.functions,
+            ctx.contract_fields,
+        )?;
     }
     let mut then_types = ctx.types.clone();
     let mut then_env = ctx.env.clone();
@@ -510,9 +518,17 @@ fn validate_for_statement_shape<'i>(
     max_iterations: &Expr<'i>,
     body: &[Statement<'i>],
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(start, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
-    validate_expr_semantics(end, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
-    validate_expr_semantics(max_iterations, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)?;
+    validate_expr_semantics(start, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
+    validate_expr_semantics(end, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)?;
+    validate_expr_semantics(
+        max_iterations,
+        ctx.env,
+        ctx.prefer_env_for_comparison,
+        ctx.types,
+        ctx.structs,
+        ctx.functions,
+        ctx.contract_fields,
+    )?;
     let mut body_types = ctx.types.clone();
     let mut body_env = ctx.env.clone();
     let mut body_prefer_env = ctx.prefer_env_for_comparison.clone();
@@ -534,7 +550,7 @@ fn validate_array_push_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.contract_fields)
+    validate_expr_semantics(expr, ctx.env, ctx.prefer_env_for_comparison, ctx.types, ctx.structs, ctx.functions, ctx.contract_fields)
 }
 
 fn validate_struct_destructure_bindings<'i>(
@@ -667,12 +683,13 @@ fn validate_expr_semantics<'i>(
     prefer_env_for_comparison: &HashSet<String>,
     types: &HashMap<String, String>,
     structs: &StructRegistry,
+    functions: &HashMap<String, &FunctionAst<'i>>,
     contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
     match &expr.kind {
         ExprKind::Binary { op, left, right } => {
-            validate_expr_semantics(left, env, prefer_env_for_comparison, types, structs, contract_fields)?;
-            validate_expr_semantics(right, env, prefer_env_for_comparison, types, structs, contract_fields)?;
+            validate_expr_semantics(left, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
+            validate_expr_semantics(right, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
             let left_value_type = super::debug_value_types::infer_debug_expr_value_type(left, env, types, &mut HashSet::new()).ok();
             let right_value_type = super::debug_value_types::infer_debug_expr_value_type(right, env, types, &mut HashSet::new()).ok();
             if matches!(op, BinaryOp::Add)
@@ -682,7 +699,7 @@ fn validate_expr_semantics<'i>(
             }
             if matches!(op, BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge) {
                 let left_type =
-                    infer_expr_type_ref_for_comparison_ref(left, env, prefer_env_for_comparison, types, structs, contract_fields);
+                    infer_expr_type_ref_for_comparison_ref(left, env, prefer_env_for_comparison, types, structs, functions, contract_fields);
                 let coerced_right = coerce_rhs_byte_literal_for_comparison_ref(left_type.as_ref(), right);
                 let right_type = infer_expr_type_ref_for_comparison_ref(
                     &coerced_right,
@@ -690,6 +707,7 @@ fn validate_expr_semantics<'i>(
                     prefer_env_for_comparison,
                     types,
                     structs,
+                    functions,
                     contract_fields,
                 );
                 if let (Some(left_type), Some(right_type)) = (left_type, right_type)
@@ -704,48 +722,67 @@ fn validate_expr_semantics<'i>(
             }
             Ok(())
         }
-        ExprKind::Unary { expr, .. } => validate_expr_semantics(expr, env, prefer_env_for_comparison, types, structs, contract_fields),
+        ExprKind::Unary { expr, .. } => {
+            validate_expr_semantics(expr, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
+        }
         ExprKind::IfElse { condition, then_expr, else_expr } => {
-            validate_expr_semantics(condition, env, prefer_env_for_comparison, types, structs, contract_fields)?;
-            validate_expr_semantics(then_expr, env, prefer_env_for_comparison, types, structs, contract_fields)?;
-            validate_expr_semantics(else_expr, env, prefer_env_for_comparison, types, structs, contract_fields)
+            validate_expr_semantics(condition, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
+            validate_expr_semantics(then_expr, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
+            validate_expr_semantics(else_expr, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
         }
         ExprKind::Array(values) => {
             for value in values {
-                validate_expr_semantics(value, env, prefer_env_for_comparison, types, structs, contract_fields)?;
+                validate_expr_semantics(value, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
             }
             Ok(())
         }
-        ExprKind::Call { args, .. } | ExprKind::New { args, .. } => {
+        ExprKind::Call { name, args, .. } => {
             for arg in args {
-                validate_expr_semantics(arg, env, prefer_env_for_comparison, types, structs, contract_fields)?;
+                validate_expr_semantics(arg, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
+            }
+            if let Some(function) = functions.get(name) {
+                if function.entrypoint {
+                    return Err(CompilerError::Unsupported(format!("entrypoint function '{}' cannot be called", name)));
+                }
+                if function.return_types.len() != 1 {
+                    return Err(CompilerError::Unsupported(format!(
+                        "function '{}' with multiple return values cannot be used in expressions",
+                        name
+                    )));
+                }
+            }
+            Ok(())
+        }
+        ExprKind::New { args, .. } => {
+            for arg in args {
+                validate_expr_semantics(arg, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
             }
             Ok(())
         }
         ExprKind::Split { source, index, .. } => {
-            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, contract_fields)?;
-            validate_expr_semantics(index, env, prefer_env_for_comparison, types, structs, contract_fields)
+            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
+            validate_expr_semantics(index, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
         }
         ExprKind::Slice { source, start, end, .. } => {
-            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, contract_fields)?;
-            validate_expr_semantics(start, env, prefer_env_for_comparison, types, structs, contract_fields)?;
-            validate_expr_semantics(end, env, prefer_env_for_comparison, types, structs, contract_fields)
+            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
+            validate_expr_semantics(start, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
+            validate_expr_semantics(end, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
         }
         ExprKind::ArrayIndex { source, index } => {
-            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, contract_fields)?;
-            validate_expr_semantics(index, env, prefer_env_for_comparison, types, structs, contract_fields)
+            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
+            validate_expr_semantics(index, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
         }
         ExprKind::Introspection { index, .. } => {
-            validate_expr_semantics(index, env, prefer_env_for_comparison, types, structs, contract_fields)
+            validate_expr_semantics(index, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
         }
         ExprKind::StateObject(fields) => {
             for field in fields {
-                validate_expr_semantics(&field.expr, env, prefer_env_for_comparison, types, structs, contract_fields)?;
+                validate_expr_semantics(&field.expr, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
             }
             Ok(())
         }
         ExprKind::FieldAccess { source, .. } | ExprKind::UnarySuffix { source, .. } => {
-            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, contract_fields)
+            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
         }
         ExprKind::Identifier(name) => {
             if types.contains_key(name) || env.contains_key(name) {
@@ -764,6 +801,7 @@ fn infer_expr_type_ref_for_comparison_ref<'i>(
     prefer_env_for_comparison: &HashSet<String>,
     types: &HashMap<String, String>,
     structs: &StructRegistry,
+    functions: &HashMap<String, &FunctionAst<'i>>,
     contract_fields: &[ContractFieldAst<'i>],
 ) -> Option<TypeRef> {
     match &expr.kind {
@@ -779,17 +817,24 @@ fn infer_expr_type_ref_for_comparison_ref<'i>(
         }
         ExprKind::FieldAccess { source, field, .. } => {
             let source_type =
-                infer_expr_type_ref_for_comparison_ref(source, env, prefer_env_for_comparison, types, structs, contract_fields)?;
+                infer_expr_type_ref_for_comparison_ref(source, env, prefer_env_for_comparison, types, structs, functions, contract_fields)?;
             let struct_name = struct_name_from_type_ref(&source_type, structs)?;
             let struct_ast = structs.get(struct_name)?;
             struct_ast.fields.iter().find(|candidate| candidate.name == *field).map(|candidate| candidate.type_ref.clone())
         }
         ExprKind::ArrayIndex { source, .. } => {
-            infer_expr_type_ref_for_comparison_ref(source, env, prefer_env_for_comparison, types, structs, contract_fields)
+            infer_expr_type_ref_for_comparison_ref(source, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
                 .and_then(|type_ref| type_ref.element_type())
         }
         ExprKind::Call { name, .. } if name == "readInputState" && !contract_fields.is_empty() => {
             Some(TypeRef { base: TypeBase::Custom("State".to_string()), array_dims: Vec::new() })
+        }
+        ExprKind::Call { name, .. } => {
+            let function = functions.get(name)?;
+            if function.entrypoint || function.return_types.len() != 1 {
+                return None;
+            }
+            Some(function.return_types[0].clone())
         }
         _ => {
             let type_name = super::debug_value_types::infer_debug_expr_value_type(expr, env, types, &mut HashSet::new()).ok()?;
@@ -963,7 +1008,7 @@ fn validate_internal_call<'i>(
             ));
         }
         let param_type_name = type_name_from_ref(&param.type_ref);
-        validate_expr_assignable_to_type(arg, &param.type_ref, types, structs, constants, contract_fields).map_err(|err| {
+        validate_expr_assignable_to_type(arg, &param.type_ref, types, structs, constants, functions, contract_fields).map_err(|err| {
             if matches!(&arg.kind, ExprKind::Call { name, .. } if name == "readInputStateWithTemplate") {
                 err
             } else {
@@ -981,8 +1026,27 @@ fn validate_expr_assignable_to_type<'i>(
     types: &HashMap<String, String>,
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
+    functions: &HashMap<String, &FunctionAst<'i>>,
     contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
+    if let ExprKind::Call { name, .. } = &expr.kind
+        && let Some(function) = functions.get(name)
+    {
+        if function.entrypoint {
+            return Err(CompilerError::Unsupported(format!("entrypoint function '{}' cannot be called", name)));
+        }
+        if function.return_types.len() != 1 {
+            return Err(CompilerError::Unsupported(format!(
+                "function '{}' with multiple return values cannot be used in expressions",
+                name
+            )));
+        }
+        if is_type_assignable_ref(&function.return_types[0], type_ref, constants) {
+            return Ok(());
+        }
+        return Err(CompilerError::Unsupported("type mismatch".to_string()));
+    }
+
     if matches!(type_ref.base, TypeBase::Byte)
         && type_ref.array_dims.is_empty()
         && matches!(expr.kind, ExprKind::Int(value) if (0..=255).contains(&value))
@@ -1080,7 +1144,7 @@ fn validate_struct_literal_matches_type<'i>(
         let Some(value) = provided.remove(&field.name) else {
             return Err(CompilerError::Unsupported(format!("struct field '{}' must be initialized", field.name)));
         };
-        validate_expr_assignable_to_type(value, &field.type_ref, types, structs, constants, &[]).map_err(|_| {
+        validate_expr_assignable_to_type(value, &field.type_ref, types, structs, constants, &HashMap::new(), &[]).map_err(|_| {
             CompilerError::Unsupported(format!("struct field '{}' expects {}", field.name, field.type_ref.type_name()))
         })?;
     }
@@ -1420,7 +1484,7 @@ fn expr_matches_return_type_ref_hint<'i>(
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
 ) -> Option<String> {
-    if validate_expr_assignable_to_type(expr, type_ref, types, structs, constants, &[]).is_ok() {
+    if validate_expr_assignable_to_type(expr, type_ref, types, structs, constants, &HashMap::new(), &[]).is_ok() {
         return None;
     }
     match (&expr.kind, &type_ref.base, type_ref.array_dims.is_empty()) {

--- a/silverscript-lang/src/silverscript.pest
+++ b/silverscript-lang/src/silverscript.pest
@@ -22,7 +22,7 @@ contract_field_definition = { type_name ~ Identifier ~ "=" ~ expression ~ ";" }
 
 parameter_list = { "(" ~ (parameter ~ ("," ~ parameter)* ~ ","?)? ~ ")" }
 parameter = { type_name ~ Identifier }
-return_type_list = { ":" ~ "(" ~ (type_name ~ ("," ~ type_name)* ~ ","?)? ~ ")" }
+return_type_list = { ":" ~ (type_name | "(" ~ (type_name ~ ("," ~ type_name)* ~ ","?)? ~ ")") }
 
 block = { braced_block | statement }
 braced_block = { "{" ~ statement* ~ "}" }

--- a/silverscript-lang/src/silverscript.pest
+++ b/silverscript-lang/src/silverscript.pest
@@ -55,7 +55,7 @@ typed_binding = { type_name ~ Identifier }
 state_typed_binding = { Identifier ~ ":" ~ type_name ~ Identifier }
 call_statement = { function_call ~ ";" }
 assign_statement = { Identifier ~ "=" ~ expression ~ ";" }
-return_statement = { "return" ~ expression_list ~ ";" }
+return_statement = { "return" ~ (expression_list | expression) ~ ";" }
 
 time_op_statement = { "require" ~ "(" ~ TxVar ~ ">=" ~ expression ~ ("," ~ require_message)? ~ ")" ~ ";" }
 require_statement = { "require" ~ "(" ~ expression ~ ("," ~ require_message)? ~ ")" ~ ";" }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -3354,7 +3354,7 @@ fn rejects_omitting_parentheses_in_tuple_function_call_assignment() {
     let err = compile_contract(source, &[], CompileOptions::default())
         .expect_err("tuple-returning function should require parenthesized call assignment");
     let err_msg = err.to_string();
-    assert!(err_msg.contains("tuple assignment only supports split()"), "unexpected error: {err_msg}");
+    assert!(err_msg.contains("multiple return values cannot be used in expressions"), "unexpected error: {err_msg}");
 }
 
 #[test]

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -3234,6 +3234,27 @@ fn single_return_signature_without_parentheses_supports_direct_variable_definiti
 }
 
 #[test]
+fn single_return_statement_without_parentheses_compiles_and_runs() {
+    let source = r#"
+        contract C() {
+            function calcInAmount() : int {
+                return 41;
+            }
+
+            entrypoint function main() {
+                int amount = calcInAmount();
+                require(amount == 41);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let selector = selector_for(&compiled, "main");
+    let result = run_script_with_selector(compiled.script, selector);
+    assert!(result.is_ok(), "single bare return statement should execute successfully: {}", result.unwrap_err());
+}
+
+#[test]
 fn compiles_int_array_length_to_expected_script() {
     let source = r#"
         contract Arrays() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -2936,7 +2936,7 @@ fn recursive_fibonacci_inlining_behavior() {
 }
 
 #[test]
-fn non_recursive_helper_call_in_expression_position_regresses_to_byte_array_type() {
+fn function_call_in_require_statement() {
     let source = r#"
         contract Calls() {
             function plus_one(int n) : (int) {
@@ -2949,9 +2949,50 @@ fn non_recursive_helper_call_in_expression_position_regresses_to_byte_array_type
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("expression-position helper call should fail");
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("expression-position helper call should compile");
+    let sigscript = compiled.build_sig_script("main", vec![Expr::int(4)]).expect("sigscript builds");
+    let result = run_script_with_sigscript(compiled.script, sigscript);
+    assert!(result.is_ok(), "expression-position helper call should execute successfully: {}", result.unwrap_err());
+}
+
+#[test]
+fn single_return_helper_call_can_participate_in_expression() {
+    let source = r#"
+        contract Calls() {
+            function plus_one(int n) : (int) {
+                return(n + 1);
+            }
+
+            entrypoint function main(int n) {
+                require(plus_one(n) == n + 1);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("single-return helper call should compile");
+    let sigscript = compiled.build_sig_script("main", vec![Expr::int(4)]).expect("sigscript builds");
+    let result = run_script_with_sigscript(compiled.script, sigscript);
+    assert!(result.is_ok(), "single-return helper call should execute successfully: {}", result.unwrap_err());
+}
+
+#[test]
+fn single_return_helper_call_in_expression_respects_type_checking() {
+    let source = r#"
+        contract Calls() {
+            function f() : int {
+                return(5);
+            }
+
+            entrypoint function main() {
+                byte[_] x = 0x1234;
+                require(f() == x);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("type mismatch should be rejected");
     let err_msg = err.to_string();
-    assert!(err_msg.contains("type mismatch: cannot compare byte[] and int"), "unexpected error: {err_msg}");
+    assert!(err_msg.contains("type mismatch: cannot compare int and byte[2]"), "unexpected error: {err_msg}");
 }
 
 #[test]
@@ -3010,6 +3051,47 @@ fn rejects_mutually_recursive_helper_calls() {
     let err = compile_contract(source, &[], CompileOptions::default()).expect_err("mutual recursion should fail");
     let err_msg = err.to_string();
     assert!(err_msg.contains("recursive function call"), "expected recursion error, got: {err_msg}");
+}
+
+#[test]
+fn rejects_multi_return_helper_call_in_expression() {
+    let source = r#"
+        contract Calls() {
+            function pair() : (int, int) {
+                return(6, 7);
+            }
+
+            entrypoint function main() {
+                require(pair() > 5);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("multi-return helper call should be rejected in expressions");
+    let err_msg = err.to_string();
+    assert!(err_msg.contains("multiple return values cannot be used in expressions"), "unexpected error: {err_msg}");
+}
+
+#[test]
+fn multi_return_helper_call_assignment_remains_valid() {
+    let source = r#"
+        contract Calls() {
+            function pair() : (int, int) {
+                return(6, 7);
+            }
+
+            entrypoint function main() {
+                (int a, int b) = pair();
+                require(a == 6);
+                require(b == 7);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("tuple call assignment should compile");
+    let selector = selector_for(&compiled, "main");
+    let result = run_script_with_selector(compiled.script, selector);
+    assert!(result.is_ok(), "tuple call assignment should execute successfully: {}", result.unwrap_err());
 }
 
 #[test]

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -3067,7 +3067,8 @@ fn rejects_multi_return_helper_call_in_expression() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("multi-return helper call should be rejected in expressions");
+    let err = compile_contract(source, &[], CompileOptions::default())
+        .expect_err("multi-return helper call should be rejected in expressions");
     let err_msg = err.to_string();
     assert!(err_msg.contains("multiple return values cannot be used in expressions"), "unexpected error: {err_msg}");
 }
@@ -3350,7 +3351,8 @@ fn rejects_omitting_parentheses_in_tuple_function_call_assignment() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("tuple-returning function should require parenthesized call assignment");
+    let err = compile_contract(source, &[], CompileOptions::default())
+        .expect_err("tuple-returning function should require parenthesized call assignment");
     let err_msg = err.to_string();
     assert!(err_msg.contains("tuple assignment only supports split()"), "unexpected error: {err_msg}");
 }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -3255,6 +3255,25 @@ fn single_return_statement_without_parentheses_compiles_and_runs() {
 }
 
 #[test]
+fn rejects_omitting_parentheses_in_tuple_function_call_assignment() {
+    let source = r#"
+        contract Returns() {
+            function pair() : (int, int) {
+                return(1, 2);
+            }
+
+            entrypoint function main() {
+                int a, int b = pair();
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("tuple-returning function should require parenthesized call assignment");
+    let err_msg = err.to_string();
+    assert!(err_msg.contains("tuple assignment only supports split()"), "unexpected error: {err_msg}");
+}
+
+#[test]
 fn compiles_int_array_length_to_expected_script() {
     let source = r#"
         contract Arrays() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -3192,6 +3192,27 @@ fn rejects_return_type_mismatch() {
 }
 
 #[test]
+fn single_return_signature_without_parentheses_compiles_and_runs() {
+    let source = r#"
+        contract C() {
+            function calcInAmount() : int {
+                return(41);
+            }
+
+            entrypoint function main() {
+                (int amount) = calcInAmount();
+                require(amount == 41);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let selector = selector_for(&compiled, "main");
+    let result = run_script_with_selector(compiled.script, selector);
+    assert!(result.is_ok(), "single bare return type should execute successfully: {}", result.unwrap_err());
+}
+
+#[test]
 fn compiles_int_array_length_to_expected_script() {
     let source = r#"
         contract Arrays() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -3213,6 +3213,27 @@ fn single_return_signature_without_parentheses_compiles_and_runs() {
 }
 
 #[test]
+fn single_return_signature_without_parentheses_supports_direct_variable_definition_assignment() {
+    let source = r#"
+        contract C() {
+            function calcInAmount() : int {
+                return(41);
+            }
+
+            entrypoint function main() {
+                int amount = calcInAmount();
+                require(amount == 41);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let selector = selector_for(&compiled, "main");
+    let result = run_script_with_selector(compiled.script, selector);
+    assert!(result.is_ok(), "direct variable definition assignment should execute successfully: {}", result.unwrap_err());
+}
+
+#[test]
 fn compiles_int_array_length_to_expected_script() {
     let source = r#"
         contract Arrays() {

--- a/silverscript-lang/tests/parser_tests.rs
+++ b/silverscript-lang/tests/parser_tests.rs
@@ -219,3 +219,46 @@ fn rejects_invalid_for_arities() {
     "#;
     assert!(parse_source_file(too_few_args).is_err());
 }
+
+#[test]
+fn rejects_omitting_parentheses_in_tuple_return_signature() {
+    let input = r#"
+        contract Returns() {
+            function pair() : int, int {
+                return(1, 2);
+            }
+        }
+    "#;
+
+    assert!(parse_contract_ast(input).is_err());
+}
+
+#[test]
+fn rejects_omitting_parentheses_in_tuple_return_statement() {
+    let input = r#"
+        contract Returns() {
+            function pair() : (int, int) {
+                return 1, 2;
+            }
+        }
+    "#;
+
+    assert!(parse_contract_ast(input).is_err());
+}
+
+#[test]
+fn parses_tuple_variable_declaration_without_parentheses_as_tuple_assignment_syntax() {
+    let input = r#"
+        contract Returns() {
+            function pair() : (int, int) {
+                return(1, 2);
+            }
+
+            entrypoint function main() {
+                int a, int b = pair();
+            }
+        }
+    "#;
+
+    assert!(parse_contract_ast(input).is_ok());
+}


### PR DESCRIPTION
  This PR expands SilverScript support for single-return functions.

  It allows simpler syntax for single-return signatures and single-value `return` statements, and it allows single-return helper calls to participate in normal expressions. At the same time,
  tuple-returning functions keep their stricter syntax and cannot be used as ordinary expression values.

  ## Language Behavior Changes

  - Single-return function signatures can now omit parentheses.

    Example:

    ```sil
    function calcInAmount() : int {
        return(41);
    }
    ```

    This is now valid in addition to:

    ```sil
    function calcInAmount() : (int) {
        return(41);
    }
    ```

  - Single-value `return` statements can now omit parentheses.

    Example:

    ```sil
    function calcInAmount() : int {
        return 41;
    }
    ```

    This is now valid in addition to:

    ```sil
    function calcInAmount() : int {
        return(41);
    }
    ```

  - Single-return helper calls can now be used directly in variable definitions.

    Example:

    ```sil
    function calcInAmount() : int {
        return 41;
    }

    entrypoint function main() {
        int amount = calcInAmount();
        require(amount == 41);
    }
    ```

  - Single-return helper calls can now participate in expressions.

    Example:

    ```sil
    function plus_one(int n) : int {
        return n + 1;
    }

    entrypoint function main(int n) {
        require(plus_one(n) == n + 1);
    }
    ```

  - Type checking now applies normally when single-return helper calls are used in expressions.

    Example:

    ```sil
    function f() : int {
        return 5;
    }

    entrypoint function main() {
        byte[_] x = 0x1234;
        require(f() == x);
    }
    ```

    This is rejected because `f()` produces an `int`, while `x` is a byte array.

  - Functions with multiple return values still cannot be used as ordinary expression values.

    Example:

    ```sil
    function pair() : (int, int) {
        return(6, 7);
    }

    entrypoint function main() {
        require(pair() > 5);
    }
    ```

    This remains invalid.

  - Tuple-returning functions still require parentheses in their signature and return statement syntax.

    Examples that remain invalid:

    ```sil
    function pair() : int, int {
        return(1, 2);
    }
    ```

    ```sil
    function pair() : (int, int) {
        return 1, 2;
    }
    ```

  - Multi-return calls remain valid only in explicit multi-binding forms.

    Example:

    ```sil
    function pair() : (int, int) {
        return(6, 7);
    }

    entrypoint function main() {
        (int a, int b) = pair();
        require(a == 6);
        require(b == 7);
    }
    ```
