### PR TITLE
 Fix State[] field access for array fields

### DIFF
--- a/debugger/session/src/session.rs
+++ b/debugger/session/src/session.rs
@@ -2040,12 +2040,13 @@ fn flatten_contract_type_leaves<'i>(contract: &ContractAst<'i>, type_ref: &TypeR
         let Some(element_type) = type_ref.element_type() else {
             return Ok(Vec::new());
         };
+        let outer_dim = type_ref.array_size().cloned().ok_or_else(|| "array type missing outer dimension".to_string())?;
         let nested = flatten_contract_type_leaves(contract, &element_type)?;
         return Ok(nested
             .into_iter()
             .map(|(path, leaf_type)| {
                 let mut array_leaf = leaf_type;
-                array_leaf.array_dims.insert(0, type_ref.array_dims[0].clone());
+                array_leaf.array_dims.push(outer_dim.clone());
                 (path, array_leaf)
             })
             .collect());


### PR DESCRIPTION
 Fixes an issue where State[] field access for fields that are themselves arrays returned:                                                                               
                                                                                                           
  ERROR: unsupported feature: array element type must have known size                                      
                                                                                                           
 This was due to incorrect order when the debugger flattens State[] into hidden bindings.
 
The fix is to append outer dimension instead of inserting at 0 index, which results in correct bidings -
- int num → int[]                                                                                      
- byte[32] anArray → byte[32][]
