### PR TITLE
feat(debugger): handle terminal covenant transitions with non-covenant outputs

### DIFF
--- a/debugger/cli/src/main.rs
+++ b/debugger/cli/src/main.rs
@@ -844,9 +844,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let active_authorized_output_states = tx
         .outputs
         .iter()
+        .zip(output_covenant_ids.iter())
         .zip(output_covenant_states.iter())
-        .filter_map(|(output, output_state)| {
-            (output.authorizing_input.unwrap_or(tx.active_input_index as u16) == tx.active_input_index as u16)
+        .filter_map(|((output, output_covenant_id), output_state)| {
+            (output_covenant_id.is_some()
+                && output.authorizing_input.unwrap_or(tx.active_input_index as u16) == tx.active_input_index as u16)
                 .then_some(output_state.clone())
         })
         .collect::<Option<Vec<_>>>();

--- a/debugger/cli/tests/cli_tests.rs
+++ b/debugger/cli/tests/cli_tests.rs
@@ -1136,6 +1136,69 @@ q
 }
 
 #[test]
+fn cli_debugger_supports_singleton_terminal_transition_to_plain_p2pk_output() {
+    let (script_path, test_file_path) = write_fixture_files(
+        "terminal-singleton.sil",
+        "terminal-singleton.test.json",
+        r#"pragma silverscript ^0.1.0;
+
+contract TerminalSingleton(int initial_amount) {
+    int amount = initial_amount;
+
+    #[covenant.singleton(mode = transition, termination = allowed)]
+    function release(State prev_state, State[] next_states) : (State[]) {
+        require(prev_state.amount == amount);
+        require(next_states.length == 0);
+        return(next_states);
+    }
+}
+"#,
+        r#"{
+  "tests": [
+    {
+      "name": "terminal_release_to_plain_p2pk_output",
+      "function": "release",
+      "constructor_args": [100000],
+      "args": [],
+      "expect": "pass",
+      "tx": {
+        "active_input_index": 0,
+        "inputs": [
+          {
+            "utxo_value": 100000,
+            "covenant_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "state": { "amount": 100000 }
+          }
+        ],
+        "outputs": [
+          {
+            "value": 99000,
+            "p2pk_pubkey": "0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+          }
+        ]
+      }
+    }
+  ]
+}
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_cli-debugger"))
+        .arg(&script_path)
+        .arg("--run")
+        .arg("--test-file")
+        .arg(&test_file_path)
+        .arg("--test-name")
+        .arg("terminal_release_to_plain_p2pk_output")
+        .output()
+        .expect("run terminal singleton fixture");
+
+    assert!(output.status.success(), "expected terminal singleton fixture to pass: {}", String::from_utf8_lossy(&output.stderr));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("PASS"), "missing PASS output: {stdout}");
+}
+
+#[test]
 fn cli_debugger_supports_state_first_auth_transition_fixtures() {
     let (script_path, test_file_path) = write_state_first_auth_transition_fixture();
 


### PR DESCRIPTION
## Summary

The synthesized output state collection in `debugger/cli/src/main.rs` included
outputs without covenant binding, e.g. plain P2PK outputs. For terminal
covenant transitions following the singleton lowering pattern, this caused
`next_states` to have synthesized non-zero length, breaking
`require(next_states.length == 0)` at script execution.

This patch filters synthesized output states by `output_covenant_id.is_some()`,
ensuring only covenant-bound outputs contribute to the synthesized `next_states`
array passed to the user policy function.

## Motivation

Singleton covenant patterns commonly use terminal transitions where the user
policy function returns an empty `State[]` - releasing locked funds to a P2PK
recipient with no continuing covenant state.

Without this fix, JSON-driven test fixtures for these patterns produce script
execution failures at the length check, even though the fixture correctly
describes a terminal transition with no covenant outputs. The failure
originates earlier in CLI output state synthesis but surfaces at the
length assertion.

Reference: `silverscript-lang/tests/covenant_declaration_ast_fixtures/lowers_singleton_sugar_transition_termination_allowed_two_field_state.sil`

## Testing

- `cargo test -p cli-debugger`

Added a regression test covering a singleton terminal transition with a plain
P2PK output: the JSON fixture executes the release path and reaches the
terminal length check correctly with `next_states.length == 0`.

27/27 CLI tests pass (was 26, +1 new regression test).
