### PR TITLE
Allow contract state to include different 

### DIFF
--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -61,27 +61,27 @@ pub(super) fn read_input_state_with_template_values<'i>(
         ));
     };
 
-    let layout_fields = flattened_struct_field_specs_for_type(expected_type, structs)?;
-    if layout_fields.is_empty() {
+    let layout_field_types = flattened_struct_field_specs_for_type(expected_type, structs)?;
+    if layout_field_types.is_empty() {
         return Err(CompilerError::Unsupported("readInputStateWithTemplate requires a struct type".to_string()));
     }
 
     let script_size_expr =
-        templated_input_script_size_expr(template_prefix_len, template_suffix_len, &layout_fields, contract_constants)?;
+        templated_input_script_size_expr(template_prefix_len, template_suffix_len, &layout_field_types, contract_constants)?;
     let state_start_offset_expr = template_prefix_len.clone();
     let mut field_chunk_offset = 0usize;
-    let mut lowered = Vec::with_capacity(layout_fields.len());
-    for field in &layout_fields {
+    let mut lowered = Vec::with_capacity(layout_field_types.len());
+    for type_ref in &layout_field_types {
         lowered.push(read_input_state_field_expr_with_type(
             input_idx,
-            &field.type_ref,
+            type_ref,
             state_start_offset_expr.clone(),
             field_chunk_offset,
             script_size_expr.clone(),
             contract_constants,
             "readInputStateWithTemplate",
         )?);
-        field_chunk_offset += encoded_field_chunk_size_for_type_ref(&field.type_ref, contract_constants)?;
+        field_chunk_offset += encoded_field_chunk_size_for_type_ref(type_ref, contract_constants)?;
     }
     Ok(lowered)
 }
@@ -1586,13 +1586,13 @@ fn encoded_state_len<'i>(
     contract_fields.iter().try_fold(0usize, |acc, field| Ok(acc + encoded_field_chunk_size(field, contract_constants)?))
 }
 
-fn encoded_state_len_for_layout_fields<'i>(
-    layout_fields: &[StructLeafSpec],
+fn encoded_state_len_for_layout_field_types<'i>(
+    layout_field_types: &[TypeRef],
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<usize, CompilerError> {
-    layout_fields
+    layout_field_types
         .iter()
-        .try_fold(0usize, |acc, field| Ok(acc + encoded_field_chunk_size_for_type_ref(&field.type_ref, contract_constants)?))
+        .try_fold(0usize, |acc, type_ref| Ok(acc + encoded_field_chunk_size_for_type_ref(type_ref, contract_constants)?))
 }
 
 fn state_start_offset<'i>(
@@ -1609,10 +1609,10 @@ fn state_start_offset<'i>(
 fn templated_input_script_size_expr<'i>(
     template_prefix_len: &Expr<'i>,
     template_suffix_len: &Expr<'i>,
-    layout_fields: &[StructLeafSpec],
+    layout_field_types: &[TypeRef],
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<Expr<'i>, CompilerError> {
-    let total_state_len = encoded_state_len_for_layout_fields(layout_fields, contract_constants)?;
+    let total_state_len = encoded_state_len_for_layout_field_types(layout_field_types, contract_constants)?;
     Ok(binary_expr(
         BinaryOp::Add,
         binary_expr(BinaryOp::Add, template_prefix_len.clone(), Expr::int(total_state_len as i64)),
@@ -1772,7 +1772,7 @@ fn compile_read_input_state_statement<'i>(
                 ));
             }
 
-            let layout_fields = flattened_struct_field_specs_for_type(
+            let layout_field_types = flattened_struct_field_specs_for_type(
                 &TypeRef { base: TypeBase::Custom(struct_name.clone()), array_dims: Vec::new() },
                 structs,
             )?;
@@ -1782,15 +1782,19 @@ fn compile_read_input_state_statement<'i>(
                 ctx.types,
                 ctx.builder,
                 ctx.options,
-                &layout_fields,
+                &layout_field_types,
                 ctx.script_size,
                 ctx.contract_constants,
             )?;
 
             let input_idx = input_idx.clone();
             let state_start_offset_expr = template_prefix_len.clone();
-            let script_size_expr =
-                templated_input_script_size_expr(template_prefix_len, template_suffix_len, &layout_fields, ctx.contract_constants)?;
+            let script_size_expr = templated_input_script_size_expr(
+                template_prefix_len,
+                template_suffix_len,
+                &layout_field_types,
+                ctx.contract_constants,
+            )?;
             let mut field_chunk_offset = 0usize;
 
             for field in &struct_spec.fields {
@@ -1866,13 +1870,13 @@ fn struct_name_for_state_bindings<'i>(bindings: &[StateBindingAst<'i>], structs:
 ///   args = (input_idx, template_prefix_len, template_suffix_len, expected_template_hash)
 ///   require target state layout is a non-empty flattened struct
 ///
-///   script_size = template_prefix_len + encoded_state_len(layout_fields) + template_suffix_len
+///   script_size = template_prefix_len + encoded_state_len(layout_field_types) + template_suffix_len
 ///   script_base = input_sigscript_len(input_idx) - script_size
 ///
 ///   actual_redeem_script = input_sigscript[script_base .. script_base + script_size]
 ///   prefix = input_sigscript[script_base .. script_base + template_prefix_len]
 ///   suffix = input_sigscript[
-///       script_base + template_prefix_len + encoded_state_len(layout_fields)
+///       script_base + template_prefix_len + encoded_state_len(layout_field_types)
 ///       ..
 ///       script_base + script_size
 ///   ]
@@ -1893,7 +1897,7 @@ fn compile_read_input_state_with_template_validation(
     types: &HashMap<String, String>,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
-    layout_fields: &[StructLeafSpec],
+    layout_field_types: &[TypeRef],
     current_script_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'_>>,
 ) -> Result<(), CompilerError> {
@@ -1904,18 +1908,18 @@ fn compile_read_input_state_with_template_validation(
                 .to_string(),
         ));
     };
-    if layout_fields.is_empty() {
+    if layout_field_types.is_empty() {
         return Err(CompilerError::Unsupported("readInputStateWithTemplate requires a struct type".to_string()));
     }
 
     let script_size_expr =
-        templated_input_script_size_expr(template_prefix_len, template_suffix_len, layout_fields, contract_constants)?;
+        templated_input_script_size_expr(template_prefix_len, template_suffix_len, layout_field_types, contract_constants)?;
     let prefix_len_expr = template_prefix_len.clone();
     let suffix_len_expr = template_suffix_len.clone();
     let script_base_expr = input_sigscript_base_expr(input_idx, script_size_expr.clone());
     let prefix_end_expr = binary_expr(BinaryOp::Add, script_base_expr.clone(), prefix_len_expr.clone());
     let script_end_expr = binary_expr(BinaryOp::Add, script_base_expr.clone(), script_size_expr.clone());
-    let state_len = encoded_state_len_for_layout_fields(layout_fields, contract_constants)?;
+    let state_len = encoded_state_len_for_layout_field_types(layout_field_types, contract_constants)?;
     let suffix_start_expr = binary_expr(BinaryOp::Add, prefix_end_expr.clone(), Expr::int(state_len as i64));
     let suffix_end_expr = binary_expr(BinaryOp::Add, suffix_start_expr.clone(), suffix_len_expr);
 

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -104,7 +104,8 @@ pub(super) fn compile_contract_impl<'i>(
     let covenant_lowered_contract = lower_covenant_declarations(&inferred_lowered_contract, &constants)?;
     let inline_lowered_contract = lower_inline_functions(&covenant_lowered_contract, &mut debug_recorder)?;
     let structs = build_struct_registry(&inline_lowered_contract)?;
-    let struct_lowered_contract = lower_structs_contract(&inline_lowered_contract, &structs, &constants)?;
+    let validate_output_state_lowered_contract = lower_validate_output_state(&inline_lowered_contract, &structs)?;
+    let struct_lowered_contract = lower_structs_contract(&validate_output_state_lowered_contract, &structs, &constants)?;
     let append_lowered_contract = lower_array_appends(&struct_lowered_contract)?;
     let for_lowered_contract = lower_for_loops(&append_lowered_contract, &constants)?;
     let lowered_contract = if options.record_debug_infos { for_lowered_contract } else { lower_local_aliases(&for_lowered_contract)? };
@@ -353,7 +354,11 @@ fn statement_uses_script_size(stmt: &Statement<'_>) -> bool {
         Statement::VariableDefinition { expr, .. } => expr.as_ref().is_some_and(expr_uses_script_size),
         Statement::TupleAssignment { expr, .. } => expr_uses_script_size(expr),
         Statement::FunctionCall { name, args, .. } => {
-            name == "validateOutputState" || name == "validateOutputStateWithTemplate" || args.iter().any(expr_uses_script_size)
+            name == "validateOutputState"
+                || name == super::validate_output_state::VALIDATE_OUTPUT_STATE_INNER
+                || name == "validateOutputStateWithTemplate"
+                || name == super::validate_output_state::VALIDATE_OUTPUT_STATE_WITH_TEMPLATE_INNER
+                || args.iter().any(expr_uses_script_size)
         }
         Statement::FunctionCallAssign { args, .. } => args.iter().any(expr_uses_script_size),
         Statement::StateFunctionCallAssign { name, args, .. } => name == "readInputState" || args.iter().any(expr_uses_script_size),
@@ -1450,8 +1455,8 @@ fn compile_function_call_statement<'i>(
     name: &str,
     args: &[Expr<'i>],
 ) -> Result<Vec<String>, CompilerError> {
-    if name == "validateOutputState" {
-        return compile_validate_output_state_statement(
+    if name == super::validate_output_state::VALIDATE_OUTPUT_STATE_INNER {
+        return compile_validate_output_state_inner_statement(
             args,
             ctx.contract_constants,
             ctx.stack_bindings,
@@ -1465,22 +1470,14 @@ fn compile_function_call_statement<'i>(
         )
         .map(|_| Vec::new());
     }
-    if name == "validateOutputStateWithTemplate" {
-        let state_arg = args.get(1).ok_or_else(|| {
-            CompilerError::Unsupported(
-                "validateOutputStateWithTemplate(output_idx, new_state, template_prefix, template_suffix, expected_template_hash) expects 5 arguments"
-                    .to_string(),
-            )
-        })?;
-        let layout_fields = layout_fields_for_state_object_expr(state_arg, ctx.contract_fields, ctx.structs)?;
-        return compile_validate_output_state_with_template_statement(
+    if name == super::validate_output_state::VALIDATE_OUTPUT_STATE_WITH_TEMPLATE_INNER {
+        return compile_validate_output_state_with_template_inner_statement(
             args,
             ctx.contract_constants,
             ctx.stack_bindings,
             ctx.types,
             ctx.builder,
             ctx.options,
-            &layout_fields,
             ctx.script_size,
             ctx.contract_constants,
         )
@@ -1590,7 +1587,7 @@ fn encoded_state_len<'i>(
 }
 
 fn encoded_state_len_for_layout_fields<'i>(
-    layout_fields: &[StructFieldSpec],
+    layout_fields: &[StructLeafSpec],
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<usize, CompilerError> {
     layout_fields
@@ -1612,7 +1609,7 @@ fn state_start_offset<'i>(
 fn templated_input_script_size_expr<'i>(
     template_prefix_len: &Expr<'i>,
     template_suffix_len: &Expr<'i>,
-    layout_fields: &[StructFieldSpec],
+    layout_fields: &[StructLeafSpec],
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<Expr<'i>, CompilerError> {
     let total_state_len = encoded_state_len_for_layout_fields(layout_fields, contract_constants)?;
@@ -1896,7 +1893,7 @@ fn compile_read_input_state_with_template_validation(
     types: &HashMap<String, String>,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
-    layout_fields: &[StructFieldSpec],
+    layout_fields: &[StructLeafSpec],
     current_script_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'_>>,
 ) -> Result<(), CompilerError> {
@@ -1999,7 +1996,7 @@ fn compile_read_input_state_with_template_validation(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn compile_validate_output_state_statement(
+fn compile_validate_output_state_inner_statement(
     args: &[Expr<'_>],
     constants: &HashMap<String, Expr<'_>>,
     stack_bindings: &StackBindings,
@@ -2011,21 +2008,37 @@ fn compile_validate_output_state_statement(
     script_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'_>>,
 ) -> Result<(), CompilerError> {
-    let Ok([output_idx, state_expr]): Result<&[Expr<'_>; 2], _> = args.try_into() else {
-        return Err(CompilerError::Unsupported("validateOutputState(output_idx, new_state) expects 2 arguments".to_string()));
-    };
+    if args.len() != contract_fields.len() + 1 {
+        return Err(CompilerError::Unsupported(format!(
+            "{}(output_idx, ..state_fields) expects {} state field argument(s)",
+            super::validate_output_state::VALIDATE_OUTPUT_STATE_INNER,
+            contract_fields.len()
+        )));
+    }
+    let output_idx = args
+        .first()
+        .ok_or_else(|| CompilerError::Unsupported("validateOutputState(output_idx, new_state) expects 2 arguments".to_string()))?;
+    let state_fields = contract_fields
+        .iter()
+        .zip(args.iter().skip(1))
+        .map(|(field, expr)| StateFieldExpr {
+            name: field.name.clone(),
+            expr: expr.clone(),
+            span: expr.span,
+            name_span: span::Span::default(),
+        })
+        .collect::<Vec<_>>();
     if contract_fields.is_empty() {
         return Err(CompilerError::Unsupported("validateOutputState requires contract fields".to_string()));
     }
 
     let mut stack_depth = compile_encoded_state_object(
-        state_expr,
+        &state_fields,
         constants,
         stack_bindings,
         types,
         builder,
         options,
-        contract_fields,
         script_size,
         contract_constants,
         "validateOutputState",
@@ -2132,65 +2145,28 @@ fn compile_validate_output_state_statement(
     Ok(())
 }
 
-fn layout_fields_for_state_object_expr<'i>(
-    state_expr: &Expr<'i>,
-    contract_fields: &[ContractFieldAst<'i>],
-    structs: &StructRegistry,
-) -> Result<Vec<StructFieldSpec>, CompilerError> {
-    let ExprKind::StateObject(state_entries) = &state_expr.kind else {
-        return Err(CompilerError::Unsupported("state object layout inference requires an object literal".to_string()));
-    };
-
-    let entry_names = state_entries.iter().map(|entry| entry.name.as_str()).collect::<HashSet<_>>();
-    let local_layout = contract_fields
-        .iter()
-        .map(|field| StructFieldSpec { name: field.name.clone(), type_ref: field.type_ref.clone() })
-        .collect::<Vec<_>>();
-    let local_names = local_layout.iter().map(|field| field.name.as_str()).collect::<HashSet<_>>();
-    if entry_names.len() == local_names.len() && entry_names == local_names {
-        return Ok(local_layout);
-    }
-
-    let matches = structs
-        .keys()
-        .filter_map(|name| {
-            let layout = flattened_struct_field_specs_for_type(
-                &TypeRef { base: TypeBase::Custom(name.clone()), array_dims: Vec::new() },
-                structs,
-            )
-            .ok()?;
-            let layout_names = layout.iter().map(|field| field.name.as_str()).collect::<HashSet<_>>();
-            (layout_names.len() == entry_names.len() && layout_names == entry_names).then_some(layout)
-        })
-        .collect::<Vec<_>>();
-
-    match matches.as_slice() {
-        [layout] => Ok(layout.clone()),
-        [] => Err(CompilerError::Unsupported("new_state must include all contract fields exactly once".to_string())),
-        _ => Err(CompilerError::Unsupported("state object layout is ambiguous".to_string())),
-    }
-}
-
-fn compile_validate_output_state_with_template_statement(
+fn compile_validate_output_state_with_template_inner_statement(
     args: &[Expr<'_>],
     constants: &HashMap<String, Expr<'_>>,
     stack_bindings: &StackBindings,
     types: &HashMap<String, String>,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
-    layout_fields: &[StructFieldSpec],
     script_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'_>>,
 ) -> Result<(), CompilerError> {
-    let Ok([output_idx, state_expr, template_prefix, template_suffix, expected_template_hash]): Result<&[Expr<'_>; 5], _> =
-        args.try_into()
-    else {
+    if args.len() < 5 {
         return Err(CompilerError::Unsupported(
-            "validateOutputStateWithTemplate(output_idx, new_state, template_prefix, template_suffix, expected_template_hash) expects 5 arguments"
+            "__validateOutputStateWithTemplateInner(output_idx, ..state_fields, template_prefix, template_suffix, expected_template_hash) expects at least 5 arguments"
                 .to_string(),
         ));
-    };
-    if layout_fields.is_empty() {
+    }
+    let output_idx = &args[0];
+    let state_fields = &args[1..args.len() - 3];
+    let template_prefix = &args[args.len() - 3];
+    let template_suffix = &args[args.len() - 2];
+    let expected_template_hash = &args[args.len() - 1];
+    if state_fields.is_empty() {
         return Err(CompilerError::Unsupported("validateOutputStateWithTemplate requires contract fields".to_string()));
     }
 
@@ -2238,14 +2214,13 @@ fn compile_validate_output_state_with_template_statement(
     builder.add_op(OpBlake2b)?;
     builder.add_op(OpEqual)?;
     builder.add_op(OpVerify)?;
-    stack_depth = compile_encoded_object_with_layout(
-        state_expr,
+    stack_depth = compile_encoded_flat_state_fields(
+        state_fields,
         constants,
         stack_bindings,
         types,
         builder,
         options,
-        layout_fields,
         script_size,
         contract_constants,
         "validateOutputStateWithTemplate",
@@ -2320,43 +2295,27 @@ fn compile_validate_output_state_with_template_statement(
     Ok(())
 }
 
-fn compile_encoded_object_with_layout(
-    state_expr: &Expr<'_>,
+fn compile_encoded_state_object(
+    state_entries: &[StateFieldExpr<'_>],
     constants: &HashMap<String, Expr<'_>>,
     stack_bindings: &StackBindings,
     types: &HashMap<String, String>,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
-    layout_fields: &[StructFieldSpec],
     script_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'_>>,
     builtin_name: &str,
 ) -> Result<i64, CompilerError> {
-    let ExprKind::StateObject(state_entries) = &state_expr.kind else {
-        return Err(CompilerError::Unsupported(format!("{builtin_name} second argument must be an object literal")));
-    };
-
-    let mut provided = HashMap::new();
-    for entry in state_entries {
-        if provided.insert(entry.name.as_str(), &entry.expr).is_some() {
-            return Err(CompilerError::Unsupported(format!("duplicate state field '{}'", entry.name)));
-        }
-    }
-    if provided.len() != layout_fields.len() {
-        return Err(CompilerError::Unsupported("new_state must include all contract fields exactly once".to_string()));
-    }
-
     let mut stack_depth = 0i64;
-    for field in layout_fields {
-        let Some(new_value) = provided.remove(field.name.as_str()) else {
-            return Err(CompilerError::Unsupported(format!("missing state field '{}'", field.name)));
-        };
-
-        let field_size = fixed_state_field_payload_len_for_type_ref(&field.type_ref, contract_constants).map_err(|_| {
-            CompilerError::Unsupported(format!("{builtin_name} does not support field type {}", type_name_from_ref(&field.type_ref)))
+    for entry in state_entries {
+        let new_value = &entry.expr;
+        let type_name = infer_debug_expr_value_type(new_value, constants, types, &mut HashSet::new())?;
+        let type_ref = parse_type_ref(&type_name)?;
+        let field_size = fixed_state_field_payload_len_for_type_ref(&type_ref, contract_constants).map_err(|_| {
+            CompilerError::Unsupported(format!("{builtin_name} does not support field type {}", type_name_from_ref(&type_ref)))
         })?;
 
-        if field.type_ref.array_dims.is_empty() && matches!(field.type_ref.base, TypeBase::Int | TypeBase::Bool) {
+        if type_ref.array_dims.is_empty() && matches!(type_ref.base, TypeBase::Int | TypeBase::Bool) {
             compile_expr(
                 new_value,
                 constants,
@@ -2395,7 +2354,7 @@ fn compile_encoded_object_with_layout(
         stack_depth -= 1;
     }
 
-    for _ in 1..layout_fields.len() {
+    for _ in 1..state_entries.len() {
         builder.add_op(OpCat)?;
         stack_depth -= 1;
     }
@@ -2403,34 +2362,69 @@ fn compile_encoded_object_with_layout(
     Ok(stack_depth)
 }
 
-fn compile_encoded_state_object(
-    state_expr: &Expr<'_>,
+fn compile_encoded_flat_state_fields(
+    state_fields: &[Expr<'_>],
     constants: &HashMap<String, Expr<'_>>,
     stack_bindings: &StackBindings,
     types: &HashMap<String, String>,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
-    contract_fields: &[ContractFieldAst<'_>],
     script_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'_>>,
     builtin_name: &str,
 ) -> Result<i64, CompilerError> {
-    let layout_fields = contract_fields
-        .iter()
-        .map(|field| StructFieldSpec { name: field.name.clone(), type_ref: field.type_ref.clone() })
-        .collect::<Vec<_>>();
-    compile_encoded_object_with_layout(
-        state_expr,
-        constants,
-        stack_bindings,
-        types,
-        builder,
-        options,
-        &layout_fields,
-        script_size,
-        contract_constants,
-        builtin_name,
-    )
+    let mut stack_depth = 0i64;
+    for new_value in state_fields {
+        let type_name = infer_debug_expr_value_type(new_value, constants, types, &mut HashSet::new())?;
+        let type_ref = parse_type_ref(&type_name)?;
+        let field_size = fixed_state_field_payload_len_for_type_ref(&type_ref, contract_constants).map_err(|_| {
+            CompilerError::Unsupported(format!("{builtin_name} does not support field type {}", type_name_from_ref(&type_ref)))
+        })?;
+
+        if type_ref.array_dims.is_empty() && matches!(type_ref.base, TypeBase::Int | TypeBase::Bool) {
+            compile_expr(
+                new_value,
+                constants,
+                stack_bindings,
+                types,
+                builder,
+                options,
+                &mut HashSet::new(),
+                &mut stack_depth,
+                script_size,
+                contract_constants,
+            )?;
+            builder.add_i64(field_size as i64)?;
+            stack_depth += 1;
+            builder.add_op(OpNum2Bin)?;
+            stack_depth -= 1;
+        } else {
+            compile_expr(
+                new_value,
+                constants,
+                stack_bindings,
+                types,
+                builder,
+                options,
+                &mut HashSet::new(),
+                &mut stack_depth,
+                script_size,
+                contract_constants,
+            )?;
+        }
+        let prefix = data_prefix(field_size);
+        builder.add_data_with_push_opcode(&prefix)?;
+        stack_depth += 1;
+        builder.add_op(OpSwap)?;
+        builder.add_op(OpCat)?;
+        stack_depth -= 1;
+    }
+
+    for _ in 1..state_fields.len() {
+        builder.add_op(OpCat)?;
+        stack_depth -= 1;
+    }
+    Ok(stack_depth)
 }
 
 fn compile_if_statement<'i>(

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -23,6 +23,7 @@ mod locals;
 mod stack_bindings;
 mod static_check;
 mod structs;
+mod validate_output_state;
 
 use compile::compile_contract_impl;
 pub(crate) use compile::resolve_expr;
@@ -34,10 +35,11 @@ pub(crate) use static_check::expr_matches_declared_type_ref;
 use static_check::value_matches_type_ref;
 pub use structs::flattened_struct_name;
 pub(super) use structs::{
-    StructFieldSpec, StructRegistry, build_struct_registry, ensure_known_or_builtin_type, flatten_constructor_args_env,
-    flatten_type_ref_leaves, flattened_struct_field_specs_for_type, lower_runtime_expr, lower_runtime_struct_expr,
-    lower_structs_contract, struct_array_name_from_type_ref, struct_name_from_type_ref, validate_struct_graph,
+    StructRegistry, build_struct_registry, ensure_known_or_builtin_type, flatten_constructor_args_env, flatten_type_ref_leaves,
+    flattened_struct_field_specs_for_type, lower_runtime_expr, lower_runtime_struct_expr, lower_structs_contract,
+    struct_array_name_from_type_ref, struct_name_from_type_ref, validate_struct_graph,
 };
+use validate_output_state::lower_validate_output_state;
 
 /// Prefix used for synthetic argument bindings during inline function expansion.
 pub const SYNTHETIC_ARG_PREFIX: &str = "__arg";

--- a/silverscript-lang/src/compiler/structs.rs
+++ b/silverscript-lang/src/compiler/structs.rs
@@ -4,8 +4,8 @@ use super::compile::{byte_sequence_cast_size, read_input_state_field_expr_symbol
 use super::debug_value_types::infer_debug_expr_value_type;
 use super::*;
 use crate::ast::{
-    ConstantAst, ContractAst, ContractFieldAst, Expr, ExprKind, FunctionAst, ParamAst, STATE_TYPE_NAME, StateBindingAst,
-    StateFieldExpr, Statement, TypeBase, TypeRef, parse_type_ref,
+    ConstantAst, ContractAst, ContractFieldAst, Expr, ExprKind, FunctionAst, ParamAst, STATE_TYPE_NAME, StateBindingAst, Statement,
+    TypeBase, TypeRef, parse_type_ref,
 };
 use crate::span;
 
@@ -193,13 +193,10 @@ pub(crate) fn resolve_struct_access<'i>(
 pub(crate) fn flattened_struct_field_specs_for_type(
     type_ref: &TypeRef,
     structs: &StructRegistry,
-) -> Result<Vec<StructFieldSpec>, CompilerError> {
+) -> Result<Vec<TypeRef>, CompilerError> {
     let mut leaves = Vec::new();
     flatten_struct_fields(type_ref, structs, &mut Vec::new(), &mut leaves)?;
-    Ok(leaves
-        .into_iter()
-        .map(|(path, type_ref)| StructFieldSpec { name: path.last().cloned().unwrap_or_default(), type_ref })
-        .collect())
+    Ok(leaves.into_iter().map(|(_, type_ref)| type_ref).collect())
 }
 
 fn lower_expr<'i>(expr: &Expr<'i>, scope: &LoweringScope, structs: &StructRegistry) -> Result<Expr<'i>, CompilerError> {
@@ -356,41 +353,6 @@ fn lower_expr<'i>(expr: &Expr<'i>, scope: &LoweringScope, structs: &StructRegist
         }
         _ => Ok(expr.clone()),
     }
-}
-
-pub(crate) fn lower_struct_value_to_state_object_expr<'i>(
-    expr: &Expr<'i>,
-    expected_type: &TypeRef,
-    scope: &LoweringScope,
-    structs: &StructRegistry,
-    contract_fields: &[ContractFieldAst<'i>],
-    contract_constants: &HashMap<String, Expr<'i>>,
-    contract_field_prefix_len: usize,
-) -> Result<Expr<'i>, CompilerError> {
-    let lowered_values =
-        lower_struct_value_expr(expr, expected_type, scope, structs, contract_fields, contract_constants, contract_field_prefix_len)?;
-    let mut paths = Vec::new();
-    flatten_struct_fields(expected_type, structs, &mut Vec::new(), &mut paths)?;
-    let expected_struct_name = struct_name_from_type_ref(expected_type, structs);
-    let fields = paths
-        .into_iter()
-        .zip(lowered_values)
-        .map(|((path, _), value)| StateFieldExpr {
-            name: if expected_struct_name == Some(STATE_TYPE_NAME) {
-                match path.as_slice() {
-                    [root] => root.clone(),
-                    [root, rest @ ..] => flattened_struct_name(root, rest),
-                    [] => String::new(),
-                }
-            } else {
-                path.last().cloned().unwrap_or_default()
-            },
-            expr: value,
-            span: expr.span,
-            name_span: span::Span::default(),
-        })
-        .collect();
-    Ok(Expr::new(ExprKind::StateObject(fields), expr.span))
 }
 
 pub(crate) fn lower_struct_value_expr<'i>(
@@ -927,46 +889,6 @@ fn lower_call_args<'i>(
     contract_constants: &HashMap<String, Expr<'i>>,
     contract_field_prefix_len: usize,
 ) -> Result<Vec<Expr<'i>>, CompilerError> {
-    if name == "validateOutputState" || name == "validateOutputStateWithTemplate" {
-        let mut lowered = Vec::with_capacity(args.len());
-        for (index, arg) in args.iter().enumerate() {
-            if index == 1 {
-                if let ExprKind::StateObject(fields) = &arg.kind {
-                    let lowered_fields = fields
-                        .iter()
-                        .map(|field| {
-                            Ok(StateFieldExpr {
-                                name: field.name.clone(),
-                                expr: lower_runtime_expr(&field.expr, &scope_type_names(scope), structs)?,
-                                span: field.span,
-                                name_span: field.name_span,
-                            })
-                        })
-                        .collect::<Result<Vec<_>, CompilerError>>()?;
-                    lowered.push(Expr::new(ExprKind::StateObject(lowered_fields), arg.span));
-                } else {
-                    let state_type = if name == "validateOutputState" {
-                        TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: Vec::new() }
-                    } else {
-                        infer_struct_expr_type(arg, scope, structs, contract_fields)?
-                    };
-                    lowered.push(lower_struct_value_to_state_object_expr(
-                        arg,
-                        &state_type,
-                        scope,
-                        structs,
-                        contract_fields,
-                        contract_constants,
-                        contract_field_prefix_len,
-                    )?);
-                }
-            } else {
-                lowered.push(lower_runtime_expr(arg, &scope_type_names(scope), structs)?);
-            }
-        }
-        return Ok(lowered);
-    }
-
     let Some(function) = functions.get(name) else {
         return args.iter().map(|arg| lower_runtime_expr(arg, &scope_type_names(scope), structs)).collect();
     };

--- a/silverscript-lang/src/compiler/structs.rs
+++ b/silverscript-lang/src/compiler/structs.rs
@@ -158,6 +158,9 @@ fn flatten_struct_fields(
     Ok(())
 }
 
+/// Resolves a struct field-access chain into the base variable, accessed field path,
+/// and final type. For example, `box.top_left.x` resolves to `("box",
+/// ["top_left", "x"], int)`, which callers can then lower to a flattened name.
 pub(crate) fn resolve_struct_access<'i>(
     expr: &Expr<'i>,
     scope: &LoweringScope,

--- a/silverscript-lang/src/compiler/validate_output_state.rs
+++ b/silverscript-lang/src/compiler/validate_output_state.rs
@@ -1,0 +1,279 @@
+use std::collections::HashMap;
+
+use super::structs::{
+    flatten_type_ref_leaves, flattened_struct_name, resolve_struct_access, struct_array_name_from_type_ref, struct_name_from_type_ref,
+};
+use super::*;
+use crate::ast::{ContractAst, Expr, ExprKind, FunctionAst, STATE_TYPE_NAME, StateFieldExpr, Statement, TypeBase, TypeRef};
+use crate::span;
+
+pub(super) const VALIDATE_OUTPUT_STATE_INNER: &str = "__validateOutputStateInner";
+
+#[derive(Clone, Default)]
+struct ValidationScope {
+    vars: HashMap<String, TypeRef>,
+    temp_index: usize,
+}
+
+pub(super) fn lower_validate_output_state<'i>(
+    contract: &ContractAst<'i>,
+    structs: &StructRegistry,
+) -> Result<ContractAst<'i>, CompilerError> {
+    let functions =
+        contract.functions.iter().map(|function| lower_function(function, contract, structs)).collect::<Result<Vec<_>, _>>()?;
+    Ok(ContractAst { functions, ..contract.clone() })
+}
+
+fn lower_function<'i>(
+    function: &FunctionAst<'i>,
+    contract: &ContractAst<'i>,
+    structs: &StructRegistry,
+) -> Result<FunctionAst<'i>, CompilerError> {
+    let mut scope = ValidationScope::default();
+    for param in &contract.params {
+        scope.vars.insert(param.name.clone(), param.type_ref.clone());
+    }
+    for constant in &contract.constants {
+        scope.vars.insert(constant.name.clone(), constant.type_ref.clone());
+    }
+    for field in &contract.fields {
+        scope.vars.insert(field.name.clone(), field.type_ref.clone());
+    }
+    for param in &function.params {
+        scope.vars.insert(param.name.clone(), param.type_ref.clone());
+    }
+    Ok(FunctionAst { body: lower_statements(&function.body, &mut scope, structs)?, ..function.clone() })
+}
+
+fn lower_statements<'i>(
+    statements: &[Statement<'i>],
+    scope: &mut ValidationScope,
+    structs: &StructRegistry,
+) -> Result<Vec<Statement<'i>>, CompilerError> {
+    let mut lowered = Vec::new();
+    for statement in statements {
+        lowered.extend(lower_statement(statement, scope, structs)?);
+    }
+    Ok(lowered)
+}
+
+fn lower_statement<'i>(
+    statement: &Statement<'i>,
+    scope: &mut ValidationScope,
+    structs: &StructRegistry,
+) -> Result<Vec<Statement<'i>>, CompilerError> {
+    match statement {
+        Statement::FunctionCall { name, args, span, name_span } if name == "validateOutputState" => {
+            let Ok([output_idx, state_expr]): Result<&[Expr<'i>; 2], _> = args.as_slice().try_into() else {
+                return Err(CompilerError::Unsupported("validateOutputState(output_idx, new_state) expects 2 arguments".to_string()));
+            };
+
+            let mut lowered = Vec::new();
+            let state_expr = if matches!(state_expr.kind, ExprKind::Identifier(_)) {
+                state_expr.clone()
+            } else {
+                if matches!(state_expr.kind, ExprKind::StateObject(_)) {
+                    flatten_state_expr(state_expr, scope, structs)?;
+                }
+                let temp_name = unique_state_temp_name(scope);
+                let state_type = state_type_ref();
+                scope.vars.insert(temp_name.clone(), state_type.clone());
+                lowered.push(Statement::VariableDefinition {
+                    type_ref: state_type,
+                    modifiers: Vec::new(),
+                    name: temp_name.clone(),
+                    expr: Some(state_expr.clone()),
+                    span: *span,
+                    type_span: span::Span::default(),
+                    modifier_spans: Vec::new(),
+                    name_span: span::Span::default(),
+                });
+                Expr::identifier(temp_name)
+            };
+
+            let mut lowered_args = vec![output_idx.clone()];
+            lowered_args.extend(flatten_state_expr(&state_expr, scope, structs)?);
+            lowered.push(Statement::FunctionCall {
+                name: VALIDATE_OUTPUT_STATE_INNER.to_string(),
+                args: lowered_args,
+                span: *span,
+                name_span: *name_span,
+            });
+            Ok(lowered)
+        }
+        Statement::VariableDefinition { type_ref, modifiers, name, expr, span, type_span, modifier_spans, name_span } => {
+            let lowered = Statement::VariableDefinition {
+                type_ref: type_ref.clone(),
+                modifiers: modifiers.clone(),
+                name: name.clone(),
+                expr: expr.clone(),
+                span: *span,
+                type_span: *type_span,
+                modifier_spans: modifier_spans.clone(),
+                name_span: *name_span,
+            };
+            scope.vars.insert(name.clone(), type_ref.clone());
+            Ok(vec![lowered])
+        }
+        Statement::TupleAssignment {
+            left_type_ref,
+            left_name,
+            right_type_ref,
+            right_name,
+            expr,
+            span,
+            left_type_span,
+            left_name_span,
+            right_type_span,
+            right_name_span,
+        } => {
+            scope.vars.insert(left_name.clone(), left_type_ref.clone());
+            scope.vars.insert(right_name.clone(), right_type_ref.clone());
+            Ok(vec![Statement::TupleAssignment {
+                left_type_ref: left_type_ref.clone(),
+                left_name: left_name.clone(),
+                right_type_ref: right_type_ref.clone(),
+                right_name: right_name.clone(),
+                expr: expr.clone(),
+                span: *span,
+                left_type_span: *left_type_span,
+                left_name_span: *left_name_span,
+                right_type_span: *right_type_span,
+                right_name_span: *right_name_span,
+            }])
+        }
+        Statement::FunctionCallAssign { bindings, name, args, span, name_span } => {
+            for binding in bindings {
+                scope.vars.insert(binding.name.clone(), binding.type_ref.clone());
+            }
+            Ok(vec![Statement::FunctionCallAssign {
+                bindings: bindings.clone(),
+                name: name.clone(),
+                args: args.clone(),
+                span: *span,
+                name_span: *name_span,
+            }])
+        }
+        Statement::StateFunctionCallAssign { bindings, name, args, span, name_span } => {
+            for binding in bindings {
+                scope.vars.insert(binding.name.clone(), binding.type_ref.clone());
+            }
+            Ok(vec![Statement::StateFunctionCallAssign {
+                bindings: bindings.clone(),
+                name: name.clone(),
+                args: args.clone(),
+                span: *span,
+                name_span: *name_span,
+            }])
+        }
+        Statement::StructDestructure { bindings, expr, span } => {
+            for binding in bindings {
+                scope.vars.insert(binding.name.clone(), binding.type_ref.clone());
+            }
+            Ok(vec![Statement::StructDestructure { bindings: bindings.clone(), expr: expr.clone(), span: *span }])
+        }
+        Statement::Block { body, span } => {
+            let mut block_scope = scope.clone();
+            Ok(vec![Statement::Block { body: lower_statements(body, &mut block_scope, structs)?, span: *span }])
+        }
+        Statement::If { condition, then_branch, else_branch, span, then_span, else_span } => {
+            let mut then_scope = scope.clone();
+            let lowered_then = lower_statements(then_branch, &mut then_scope, structs)?;
+            let lowered_else = if let Some(else_branch) = else_branch {
+                let mut else_scope = scope.clone();
+                Some(lower_statements(else_branch, &mut else_scope, structs)?)
+            } else {
+                None
+            };
+            Ok(vec![Statement::If {
+                condition: condition.clone(),
+                then_branch: lowered_then,
+                else_branch: lowered_else,
+                span: *span,
+                then_span: *then_span,
+                else_span: *else_span,
+            }])
+        }
+        Statement::For { ident, start, end, max_iterations, body, span, ident_span, body_span } => {
+            let mut body_scope = scope.clone();
+            body_scope.vars.insert(ident.clone(), TypeRef { base: TypeBase::Int, array_dims: Vec::new() });
+            Ok(vec![Statement::For {
+                ident: ident.clone(),
+                start: start.clone(),
+                end: end.clone(),
+                max_iterations: max_iterations.clone(),
+                body: lower_statements(body, &mut body_scope, structs)?,
+                span: *span,
+                ident_span: *ident_span,
+                body_span: *body_span,
+            }])
+        }
+        _ => Ok(vec![statement.clone()]),
+    }
+}
+
+fn flatten_state_expr<'i>(expr: &Expr<'i>, scope: &ValidationScope, structs: &StructRegistry) -> Result<Vec<Expr<'i>>, CompilerError> {
+    let state_type = state_type_ref();
+    flatten_struct_expr(expr, &state_type, scope, structs)
+}
+
+fn state_type_ref() -> TypeRef {
+    TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: Vec::new() }
+}
+
+fn unique_state_temp_name(scope: &mut ValidationScope) -> String {
+    loop {
+        let name = format!("__validate_output_state_{}", scope.temp_index);
+        scope.temp_index += 1;
+        if !scope.vars.contains_key(&name) {
+            return name;
+        }
+    }
+}
+
+fn flatten_struct_expr<'i>(
+    expr: &Expr<'i>,
+    expected_type: &TypeRef,
+    scope: &ValidationScope,
+    structs: &StructRegistry,
+) -> Result<Vec<Expr<'i>>, CompilerError> {
+    let expected_struct_name = struct_name_from_type_ref(expected_type, structs)
+        .ok_or_else(|| CompilerError::Unsupported(format!("expected struct type '{}'", expected_type.type_name())))?;
+
+    if !matches!(&expr.kind, ExprKind::Identifier(_)) {
+        return Err(CompilerError::Unsupported("flatten_struct_expr expects an identifier".into()));
+    }
+
+    let struct_scope = super::structs::LoweringScope { vars: scope.vars.clone() };
+    let (base, path, actual_type) = resolve_struct_access(expr, &struct_scope, structs)?;
+    let actual_struct_name = struct_name_from_type_ref(&actual_type, structs)
+        .ok_or_else(|| CompilerError::Unsupported("expression is not a struct".to_string()))?;
+    if actual_struct_name != expected_struct_name {
+        return Err(CompilerError::Unsupported(format!(
+            "struct expression expects {}, got {}",
+            expected_struct_name,
+            actual_type.type_name()
+        )));
+    }
+
+    let leaves = flatten_type_ref_leaves(&actual_type, structs)?;
+    Ok(leaves
+        .into_iter()
+        .map(|(leaf_path, _)| {
+            let mut full_path = path.clone();
+            full_path.extend(leaf_path);
+            field_access_chain(&base, &full_path)
+        })
+        .collect())
+}
+
+fn field_access_chain<'i>(base: &str, path: &[String]) -> Expr<'i> {
+    let mut expr = Expr::identifier(base);
+    for field in path {
+        expr = Expr::new(
+            ExprKind::FieldAccess { source: Box::new(expr), field: field.clone(), field_span: span::Span::default() },
+            span::Span::default(),
+        );
+    }
+    expr
+}

--- a/silverscript-lang/src/compiler/validate_output_state.rs
+++ b/silverscript-lang/src/compiler/validate_output_state.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
 
-use super::structs::{
-    flatten_type_ref_leaves, flattened_struct_name, resolve_struct_access, struct_array_name_from_type_ref, struct_name_from_type_ref,
-};
+use super::structs::{flatten_type_ref_leaves, resolve_struct_access, struct_name_from_type_ref};
 use super::*;
-use crate::ast::{ContractAst, Expr, ExprKind, FunctionAst, STATE_TYPE_NAME, StateFieldExpr, Statement, TypeBase, TypeRef};
+use crate::ast::{ContractAst, Expr, ExprKind, FunctionAst, STATE_TYPE_NAME, Statement, TypeBase, TypeRef};
 use crate::span;
 
 pub(super) const VALIDATE_OUTPUT_STATE_INNER: &str = "__validateOutputStateInner";
@@ -72,9 +70,6 @@ fn lower_statement<'i>(
             let state_expr = if matches!(state_expr.kind, ExprKind::Identifier(_)) {
                 state_expr.clone()
             } else {
-                if matches!(state_expr.kind, ExprKind::StateObject(_)) {
-                    flatten_state_expr(state_expr, scope, structs)?;
-                }
                 let temp_name = unique_state_temp_name(scope);
                 let state_type = state_type_ref();
                 scope.vars.insert(temp_name.clone(), state_type.clone());

--- a/silverscript-lang/src/compiler/validate_output_state.rs
+++ b/silverscript-lang/src/compiler/validate_output_state.rs
@@ -6,6 +6,7 @@ use crate::ast::{ContractAst, Expr, ExprKind, FunctionAst, STATE_TYPE_NAME, Stat
 use crate::span;
 
 pub(super) const VALIDATE_OUTPUT_STATE_INNER: &str = "__validateOutputStateInner";
+pub(super) const VALIDATE_OUTPUT_STATE_WITH_TEMPLATE_INNER: &str = "__validateOutputStateWithTemplateInner";
 
 #[derive(Clone, Default)]
 struct ValidationScope {
@@ -90,6 +91,47 @@ fn lower_statement<'i>(
             lowered_args.extend(flatten_state_expr(&state_expr, scope, structs)?);
             lowered.push(Statement::FunctionCall {
                 name: VALIDATE_OUTPUT_STATE_INNER.to_string(),
+                args: lowered_args,
+                span: *span,
+                name_span: *name_span,
+            });
+            Ok(lowered)
+        }
+        Statement::FunctionCall { name, args, span, name_span } if name == "validateOutputStateWithTemplate" => {
+            let Ok([output_idx, state_expr, template_prefix, template_suffix, expected_template_hash]): Result<&[Expr<'i>; 5], _> =
+                args.as_slice().try_into()
+            else {
+                return Err(CompilerError::Unsupported(
+                    "validateOutputStateWithTemplate(output_idx, new_state, template_prefix, template_suffix, expected_template_hash) expects 5 arguments"
+                        .to_string(),
+                ));
+            };
+
+            let mut lowered = Vec::new();
+            let state_type = infer_template_state_type(state_expr, scope, structs)?;
+            let state_expr = if matches!(state_expr.kind, ExprKind::Identifier(_)) {
+                state_expr.clone()
+            } else {
+                let temp_name = unique_state_temp_name(scope);
+                scope.vars.insert(temp_name.clone(), state_type.clone());
+                lowered.push(Statement::VariableDefinition {
+                    type_ref: state_type.clone(),
+                    modifiers: Vec::new(),
+                    name: temp_name.clone(),
+                    expr: Some(state_expr.clone()),
+                    span: *span,
+                    type_span: span::Span::default(),
+                    modifier_spans: Vec::new(),
+                    name_span: span::Span::default(),
+                });
+                Expr::identifier(temp_name)
+            };
+
+            let mut lowered_args = vec![output_idx.clone()];
+            lowered_args.extend(flatten_struct_expr(&state_expr, &state_type, scope, structs)?);
+            lowered_args.extend([template_prefix.clone(), template_suffix.clone(), expected_template_hash.clone()]);
+            lowered.push(Statement::FunctionCall {
+                name: VALIDATE_OUTPUT_STATE_WITH_TEMPLATE_INNER.to_string(),
                 args: lowered_args,
                 span: *span,
                 name_span: *name_span,
@@ -223,6 +265,32 @@ fn unique_state_temp_name(scope: &mut ValidationScope) -> String {
         if !scope.vars.contains_key(&name) {
             return name;
         }
+    }
+}
+
+fn infer_template_state_type(expr: &Expr<'_>, scope: &ValidationScope, structs: &StructRegistry) -> Result<TypeRef, CompilerError> {
+    let struct_scope = super::structs::LoweringScope { vars: scope.vars.clone() };
+    match &expr.kind {
+        ExprKind::Identifier(_) | ExprKind::FieldAccess { .. } => {
+            let (_, _, type_ref) = resolve_struct_access(expr, &struct_scope, structs)?;
+            Ok(type_ref)
+        }
+        ExprKind::ArrayIndex { source, .. } => {
+            let ExprKind::Identifier(name) = &source.kind else {
+                return Err(CompilerError::Unsupported("validateOutputStateWithTemplate requires a struct value".to_string()));
+            };
+            scope
+                .vars
+                .get(name)
+                .cloned()
+                .ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))?
+                .element_type()
+                .ok_or_else(|| CompilerError::Unsupported("validateOutputStateWithTemplate requires a struct value".to_string()))
+        }
+        ExprKind::StateObject(_) => Err(CompilerError::Unsupported(
+            "validateOutputStateWithTemplate does not support inline state objects; use a struct variable instead".to_string(),
+        )),
+        _ => Err(CompilerError::Unsupported("validateOutputStateWithTemplate requires a struct value".to_string())),
     }
 }
 

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -5422,9 +5422,10 @@ fn run_validate_output_state_with_template_case(
             byte[2] y = initY;
 
             entrypoint function routeToA() {{
+                State s = {{muxHash: muxHash, aHash: aHash, x: x + 1, y: 0x3412}};
                 validateOutputStateWithTemplate(
                     0,
-                    {{muxHash: muxHash, aHash: aHash, x: x + 1, y: 0x3412}},
+                    s,
                     0x{},
                     0x{},
                     0x{}
@@ -5501,9 +5502,10 @@ fn runs_validate_output_state_with_template() {
             byte[2] y = initY;
 
             entrypoint function routeToA() {{
+                State s = {{muxHash: muxHash, aHash: aHash, x: x + 1, y: 0x3412}};
                 validateOutputStateWithTemplate(
                     0,
-                    {{muxHash: muxHash, aHash: aHash, x: x + 1, y: 0x3412}},
+                    s,
                     0x{a_prefix_hex},
                     0x{a_suffix_hex},
                     0x{a_template_hash_hex}
@@ -7077,6 +7079,73 @@ fn rejects_validate_output_state_with_incorrect_state_variable_type() {
 }
 
 #[test]
+fn validate_output_state_lowers_nested_state_literal_in_state_field_order() {
+    let source = r#"
+        contract C(int initA, int initC, int initD) {
+            struct S2 {
+                int c;
+                int d;
+            }
+
+            int a = initA;
+            S2 b = {c: initC, d: initD};
+
+            entrypoint function main() {
+                validateOutputState(0, {b: {d: 8, c: 7}, a: 6});
+            }
+        }
+    "#;
+
+    let input_compiled =
+        compile_contract(source, &[5.into(), 3.into(), 4.into()], CompileOptions::default()).expect("compile succeeds");
+    let output_compiled =
+        compile_contract(source, &[6.into(), 7.into(), 8.into()], CompileOptions::default()).expect("compile succeeds");
+    let input = test_input(0, sigscript_push_script(&input_compiled.script));
+    let input_spk = pay_to_script_hash_script(&input_compiled.script);
+    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
+    let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
+    let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
+
+    let result = execute_input(tx, vec![utxo_entry], 0);
+    assert!(result.is_ok(), "nested state literal should validate in declared state field order: {result:?}");
+}
+
+#[test]
+fn validate_output_state_with_state_identifier() {
+    let source = r#"
+        contract C(int initA, int initC, int initD) {
+            struct S2 {
+                int c;
+                int d;
+            }
+
+            int a = initA;
+            S2 b = {c: initC, d: initD};
+
+            entrypoint function main() {
+                State next = {b: {d: 8, c: 7}, a: 6};
+                validateOutputState(0, next);
+            }
+        }
+    "#;
+
+    let input_compiled =
+        compile_contract(source, &[5.into(), 3.into(), 4.into()], CompileOptions::default()).expect("compile succeeds");
+    let output_compiled =
+        compile_contract(source, &[6.into(), 7.into(), 8.into()], CompileOptions::default()).expect("compile succeeds");
+    let input = test_input(0, sigscript_push_script(&input_compiled.script));
+    let input_spk = pay_to_script_hash_script(&input_compiled.script);
+    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
+    let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
+    let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
+
+    let result = execute_input(tx, vec![utxo_entry], 0);
+    assert!(result.is_ok(), "local State value should lower to validateOutputStateInner leaves: {result:?}");
+}
+
+#[test]
 fn validate_output_state_with_template_uses_passed_struct_layout_not_local_state_layout() {
     let source = r#"
         contract M(int initX, byte[2] initY) {
@@ -7214,7 +7283,7 @@ fn rejects_validate_output_state_with_malformed_state_object() {
 
     let err = compile_contract(source, &[5.into(), vec![1u8, 2u8].into()], CompileOptions::default())
         .expect_err("state object missing fields should fail");
-    assert!(err.to_string().contains("new_state must include all contract fields exactly once"), "unexpected error: {err}");
+    assert!(err.to_string().contains("struct field 'y' must be initialized"), "unexpected error: {err}");
 }
 
 #[test]
@@ -7232,7 +7301,7 @@ fn rejects_validate_output_state_with_duplicate_state_field() {
 
     let err = compile_contract(source, &[5.into(), vec![1u8, 2u8].into()], CompileOptions::default())
         .expect_err("state object duplicate fields should fail");
-    assert!(err.to_string().contains("duplicate state field 'x'"), "unexpected error: {err}");
+    assert!(err.to_string().contains("duplicate struct field 'x'"), "unexpected error: {err}");
 }
 
 #[test]
@@ -7250,7 +7319,7 @@ fn rejects_validate_output_state_with_unknown_state_field() {
 
     let err = compile_contract(source, &[5.into(), vec![1u8, 2u8].into()], CompileOptions::default())
         .expect_err("state object with unknown field should fail");
-    assert!(err.to_string().contains("new_state must include all contract fields exactly once"), "unexpected error: {err}");
+    assert!(err.to_string().contains("unknown struct field 'z'"), "unexpected error: {err}");
 }
 
 fn assert_compiled_body(source: &str, body: Vec<u8>) {
@@ -9898,9 +9967,9 @@ contract StructCounterLoop(int BOUND) {
 }
 
 #[test]
-fn validate_output_state_with_template_preserves_nested_struct_field_paths() {
+fn validate_output_state_preserves_nested_struct_field_paths() {
     let source = r#"
-        contract M() {
+        contract M(int initLeft, int initRight) {
             struct Left {
                 int id;
             }
@@ -9909,29 +9978,117 @@ fn validate_output_state_with_template_preserves_nested_struct_field_paths() {
                 int id;
             }
 
-            struct Pair {
-                Left left;
-                Right right;
-                byte[32] targetHash;
-            }
+            Left left = {id: initLeft};
+            Right right = {id: initRight};
 
-            entrypoint function route(byte[32] targetHash) {
-                Pair next = {
-                    left: {id: 1},
-                    right: {id: 2},
-                    targetHash: targetHash
+            entrypoint function route() {
+                State next = {
+                    left: {id: 3},
+                    right: {id: 4}
                 };
-                validateOutputStateWithTemplate(
-                    0,
-                    next,
-                    0x51,
-                    0x52,
-                    0x0000000000000000000000000000000000000000000000000000000000000000
-                );
+                validateOutputState(0, next);
             }
         }
     "#;
 
-    let result = compile_contract(source, &[], CompileOptions::default());
+    let input_compiled = compile_contract(source, &[1.into(), 2.into()], CompileOptions::default()).expect("compile succeeds");
+    let output_compiled = compile_contract(source, &[3.into(), 4.into()], CompileOptions::default()).expect("compile succeeds");
+    let input = test_input(0, sigscript_push_script(&input_compiled.script));
+    let input_spk = pay_to_script_hash_script(&input_compiled.script);
+    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
+    let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
+    let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
+
+    let result = execute_input(tx, vec![utxo_entry], 0);
+    assert!(result.is_ok(), "nested state fields with the same leaf name should remain distinct by path: {result:?}");
+}
+
+#[test]
+fn validate_output_state_with_template_preserves_nested_struct_field_paths() {
+    let target_hash = vec![0x44u8; 32];
+    let target_hash_hex = target_hash.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    let target_source = format!(
+        r#"
+        contract Target(byte[32] initTargetHash, int initLeft, int initRight) {{
+            struct Left {{
+                int id;
+            }}
+
+            struct Right {{
+                int id;
+            }}
+
+            Left left = {{id: initLeft}};
+            Right right = {{id: initRight}};
+            byte[32] targetHash = initTargetHash;
+
+            entrypoint function noop() {{
+                require(left.id == 1);
+                require(right.id == 2);
+                require(targetHash == 0x{target_hash_hex});
+            }}
+        }}
+    "#
+    );
+
+    let target_template_compiled =
+        compile_contract(&target_source, &[vec![0x33u8; 32].into(), 0.into(), 0.into()], CompileOptions::default())
+            .expect("compile target template succeeds");
+    let (template_prefix, template_suffix, template_hash) = compiled_template_parts_and_hash(&target_template_compiled);
+    let template_prefix_hex = template_prefix.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    let template_suffix_hex = template_suffix.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    let template_hash_hex = template_hash.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+
+    let target_output_compiled =
+        compile_contract(&target_source, &[target_hash.clone().into(), 1.into(), 2.into()], CompileOptions::default())
+            .expect("compile target output succeeds");
+
+    let source = format!(
+        r#"
+        contract M() {{
+            struct Left {{
+                int id;
+            }}
+
+            struct Right {{
+                int id;
+            }}
+
+            struct Pair {{
+                Left left;
+                Right right;
+                byte[32] targetHash;
+            }}
+
+            entrypoint function route(byte[32] targetHash) {{
+                Pair next = {{
+                    left: {{id: 1}},
+                    right: {{id: 2}},
+                    targetHash: targetHash
+                }};
+                validateOutputStateWithTemplate(
+                    0,
+                    next,
+                    0x{template_prefix_hex},
+                    0x{template_suffix_hex},
+                    0x{template_hash_hex}
+                );
+            }}
+        }}
+    "#
+    );
+
+    let input_compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile router succeeds");
+    let sigscript = input_compiled.build_sig_script("route", vec![target_hash.into()]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(input_compiled.script.clone(), sigscript).unwrap();
+    let input = test_input(0, sigscript);
+    let input_spk = pay_to_script_hash_script(&input_compiled.script);
+    let output_spk = pay_to_script_hash_script(&target_output_compiled.script);
+    let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
+    let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
+    let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
+
+    let result = execute_input(tx, vec![utxo_entry], 0);
     assert!(result.is_ok(), "nested struct fields with the same leaf name should remain distinct by path: {result:?}");
 }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -9896,3 +9896,42 @@ contract StructCounterLoop(int BOUND) {
     assert!(d2 <= d1 * 2, "unexpected superlinear growth: lens={lens:?} d1={d1} d2={d2}");
     assert!(lens[2] < 10_000, "unexpected script size: lens={lens:?}");
 }
+
+#[test]
+fn validate_output_state_with_template_preserves_nested_struct_field_paths() {
+    let source = r#"
+        contract M() {
+            struct Left {
+                int id;
+            }
+
+            struct Right {
+                int id;
+            }
+
+            struct Pair {
+                Left left;
+                Right right;
+                byte[32] targetHash;
+            }
+
+            entrypoint function route(byte[32] targetHash) {
+                Pair next = {
+                    left: {id: 1},
+                    right: {id: 2},
+                    targetHash: targetHash
+                };
+                validateOutputStateWithTemplate(
+                    0,
+                    next,
+                    0x51,
+                    0x52,
+                    0x0000000000000000000000000000000000000000000000000000000000000000
+                );
+            }
+        }
+    "#;
+
+    let result = compile_contract(source, &[], CompileOptions::default());
+    assert!(result.is_ok(), "nested struct fields with the same leaf name should remain distinct by path: {result:?}");
+}


### PR DESCRIPTION
  ## Language Behavior Changes

  - `validateOutputStateWithTemplate` no longer accepts inline state object literals directly. Assign the value to a typed struct variable first so the compiler can use that struct layout.

  ```silverscript
  TargetState next = {y: 0x3412, x: x + 1, targetHash: targetHash};
  validateOutputStateWithTemplate(0, next, prefix, suffix, templateHash);
  ```

  - Nested struct field paths are preserved during template validation, so fields with the same leaf name under different nested structs remain distinct.

  ```silverscript
        contract M(int initLeft, int initRight) {
            struct Left {
                int id;
            }

            struct Right {
                int id;
            }

            Left left = {id: initLeft};
            Right right = {id: initRight};

            entrypoint function route() {
                State next = {
                    left: {id: 3},
                    right: {id: 4}
                };
                validateOutputState(0, next);
            }
        }
  ```
