### PR TITLE
Add g16.verify Groth16 verifier builtin

### DIFF
--- a/debugger/session/src/session.rs
+++ b/debugger/session/src/session.rs
@@ -1681,7 +1681,7 @@ impl<'a, 'i> DebugSession<'a, 'i> {
     }
 
     fn build_shadow_bytecode(&self, bindings: &[ShadowBindingValue], expr_bytecode: &[u8]) -> Result<Vec<u8>, String> {
-        let mut builder = ScriptBuilder::new();
+        let mut builder = ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() });
         for binding in bindings {
             builder.add_data(&binding.value).map_err(|err| err.to_string())?;
         }
@@ -2468,6 +2468,21 @@ mod tests {
         let scope_state = session.scope_state(StepId::ROOT).unwrap();
         let value = session.evaluate_scope_expr_as(&scope_state, &update.expr, &update.type_name).unwrap();
         assert!(matches!(value, DebugValue::Int(12)));
+    }
+
+    #[test]
+    fn shadow_vm_evaluates_large_runtime_byte_array_param() {
+        let payload = vec![0x42; 800];
+        let mut sig_builder = ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() });
+        sig_builder.add_data(&payload).unwrap();
+        let sigscript = sig_builder.drain();
+
+        let session = make_session(vec![scalar_param("payload", "byte[]", 0)], vec![], &sigscript).unwrap();
+        let expr = parse_expression_ast("payload == payload").expect("parse equality expression");
+        let scope_state = session.scope_state(StepId::ROOT).unwrap();
+        let value = session.evaluate_scope_expr_as(&scope_state, &expr, "bool").unwrap();
+
+        assert!(matches!(value, DebugValue::Bool(true)));
     }
 
     #[test]

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -889,6 +889,17 @@ entry verify(datasig oracleSig, byte[] oracleMessage, byte[33] oraclePk) {
 }
 ```
 
+**`g16.verify(byte[] verifyingKey, byte[] proof, byte[32] ...publicInputs)`**
+
+Verify a Groth16 proof with a compressed verifying key, compressed proof, and
+zero or more 32-byte public inputs. Verification failure aborts script execution:
+
+```javascript
+entry verify(byte[] verifyingKey, byte[] proof, byte[32] publicInput0, byte[32] publicInput1) {
+    g16.verify(verifyingKey, proof, publicInput0, publicInput1);
+}
+```
+
 ### Type Conversions
 
 Use `as byte[N]` to convert an integer to a fixed-size byte array:

--- a/extensions/silverscript.nvim/queries/silverscript/highlights.scm
+++ b/extensions/silverscript.nvim/queries/silverscript/highlights.scm
@@ -82,6 +82,14 @@
   .
   (call_suffix))
 
+(postfix
+  (postfix_op
+    (member_access
+      name: (identifier) @function.builtin))
+  .
+  (postfix_op
+    (call_suffix)))
+
 (unary_suffix) @property
 
 (split_call

--- a/extensions/vscode/queries/highlights.scm
+++ b/extensions/vscode/queries/highlights.scm
@@ -82,6 +82,14 @@
   .
   (call_suffix))
 
+(postfix
+  (postfix_op
+    (member_access
+      name: (identifier) @function.builtin))
+  .
+  (postfix_op
+    (call_suffix)))
+
 (unary_suffix) @property
 
 (split_call

--- a/extensions/zed/languages/silverscript/highlights.scm
+++ b/extensions/zed/languages/silverscript/highlights.scm
@@ -82,6 +82,14 @@
   .
   (call_suffix))
 
+(postfix
+  (postfix_op
+    (member_access
+      name: (identifier) @function.builtin))
+  .
+  (postfix_op
+    (call_suffix)))
+
 (unary_suffix) @property
 
 (split_call

--- a/silverscript-lang/src/ast/mod.rs
+++ b/silverscript-lang/src/ast/mod.rs
@@ -2409,7 +2409,9 @@ fn parse_function_name<'i>(pair: Pair<'i, Rule>) -> Result<Identifier<'i>, Compi
             let name_pair = pair.into_inner().next().ok_or_else(|| CompilerError::Unsupported("missing function name".to_string()))?;
             parse_function_name(name_pair)
         }
-        Rule::r0_groth16_verify_name | Rule::r0_succinct_verify_name => Ok(Identifier { name: pair.as_str().to_string(), span }),
+        Rule::r0_groth16_verify_name | Rule::r0_succinct_verify_name | Rule::g16_verify_name => {
+            Ok(Identifier { name: pair.as_str().to_string(), span })
+        }
         _ => Err(CompilerError::Unsupported(format!("unexpected function name: {:?}", pair.as_rule())).with_span(&span)),
     }
 }

--- a/silverscript-lang/src/compiler/builtin_types.rs
+++ b/silverscript-lang/src/compiler/builtin_types.rs
@@ -16,6 +16,20 @@ pub(super) enum BuiltinReturn {
     Void,
 }
 
+pub(super) struct G16VerifyParameterTypes {
+    pub(super) verifying_key: TypeRef,
+    pub(super) proof: TypeRef,
+    pub(super) public_input: TypeRef,
+}
+
+pub(super) fn g16_verify_parameter_types() -> G16VerifyParameterTypes {
+    G16VerifyParameterTypes {
+        verifying_key: byte_array(ArrayDim::Dynamic),
+        proof: byte_array(ArrayDim::Dynamic),
+        public_input: byte_array(ArrayDim::Fixed(32)),
+    }
+}
+
 pub(super) fn introspection_type(op: IntrospectionKind) -> TypeRef {
     match op {
         IntrospectionKind::ActiveScriptPubKey | IntrospectionKind::ThisBytecodeSizeDataPrefix => byte_array(ArrayDim::Dynamic),
@@ -67,7 +81,8 @@ pub(super) fn builtin_return(name: &str) -> Option<BuiltinReturn> {
         | "OpCovOutputIdx" => scalar(TypeBase::Int),
         "length" => scalar(TypeBase::Int),
         "OpTxInputIsCoinbase" | "checkSig" | "checkMsgSig" | "checkSigFromStackECDSA" => scalar(TypeBase::Bool),
-        "r0.g16.verify"
+        "g16.verify"
+        | "r0.g16.verify"
         | "r0.succinct.verify"
         | "r0.succinct.blake2b.verify"
         | "r0.succinct.poseidon2.verify"

--- a/silverscript-lang/src/compiler/compile/expression/builtin.rs
+++ b/silverscript-lang/src/compiler/compile/expression/builtin.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::compiler::builtin_types::builtin_parameters;
+use crate::compiler::builtin_types::{builtin_parameters, g16_verify_parameter_types};
 use kaspa_txscript::zk_precompiles::tags::ZkTag;
 use kaspa_txscript_zk_sdk::append_r0_groth16_verifier_dynamic_image_id;
 
@@ -34,6 +34,7 @@ pub(super) fn compile_call_expr<'i>(
         "checkSig" => compile_checksig_call(ctx, args),
         "checkMsgSig" => compile_checksigfromstack_call(ctx, name, args, OpCheckSigFromStack),
         "checkSigFromStackECDSA" => compile_checksigfromstack_call(ctx, name, args, OpCheckSigFromStackECDSA),
+        "g16.verify" => compile_g16_verify_call(ctx, args),
         "r0.g16.verify" => compile_r0_groth16_verify_call(ctx, args),
         "r0.succinct.verify" | "r0.succinct.blake2b.verify" | "r0.succinct.poseidon2.verify" | "r0.succinct.sha256.verify" => {
             compile_r0_succinct_verify_call(ctx, name, args)
@@ -247,6 +248,26 @@ fn compile_checksigfromstack_call<'i>(
     }
     compile_typed_builtin_args(ctx, name, args)?;
     ctx.emit_op(opcode, -2)?;
+    Ok(())
+}
+
+fn compile_g16_verify_call<'i>(ctx: &mut CompileExprContext<'_, '_, 'i>, args: &[Expr<'i>]) -> Result<(), CompilerError> {
+    if args.len() < 2 {
+        return Err(CompilerError::Unsupported("g16.verify() expects at least 2 arguments".to_string()));
+    }
+
+    let parameters = g16_verify_parameter_types();
+    let public_inputs = &args[2..];
+    // The precompile pops public inputs in source order, so push them in reverse.
+    for public_input in public_inputs.iter().rev() {
+        compile_expr_with_context(ctx, public_input, Some(&parameters.public_input))?;
+    }
+    ctx.push_int(public_inputs.len() as i64)?;
+    compile_expr_with_context(ctx, &args[1], Some(&parameters.proof))?;
+    compile_expr_with_context(ctx, &args[0], Some(&parameters.verifying_key))?;
+    ctx.push_data(&[ZkTag::Groth16 as u8])?;
+    ctx.emit_op(OpZkPrecompile, -(public_inputs.len() as i64 + 3))?;
+    ctx.emit_op(OpDrop, -1)?; // Drop the OpTrue pushed after successful verification.
     Ok(())
 }
 

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -292,6 +292,7 @@ pub(super) fn check_call<'i>(
         return Err(CompilerError::Unsupported(format!("function '{name}' not found")));
     };
     if name == "g16.verify" {
+        // g16.verify requires special treatment since it has variable amount of arguments
         check_g16_verify_args(args, ctx)?;
     } else {
         let parameters = builtin_parameters(name)

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -5,8 +5,8 @@ use crate::ast::{
 };
 
 use super::builtin_types::{
-    BuiltinReturn, builtin_parameters, builtin_return, constructor_parameters, constructor_return_type, indexed_introspection_type,
-    introspection_type,
+    BuiltinReturn, builtin_parameters, builtin_return, constructor_parameters, constructor_return_type, g16_verify_parameter_types,
+    indexed_introspection_type, introspection_type,
 };
 use super::structs::{StructRegistry, flattened_struct_field_specs_for_type, is_struct, struct_name};
 use super::{CompilerError, STATE_TYPE_NAME, TypeMap, append_type, array_type_size, concat_types, parse_type_ref, type_refs_equal};
@@ -291,13 +291,31 @@ pub(super) fn check_call<'i>(
     let Some(return_type) = builtin_return(name) else {
         return Err(CompilerError::Unsupported(format!("function '{name}' not found")));
     };
-    let parameters = builtin_parameters(name)
-        .ok_or_else(|| CompilerError::Unsupported(format!("builtin function '{name}' has no parameter types")))?;
-    check_builtin_args(name, args, parameters, ctx)?;
+    if name == "g16.verify" {
+        check_g16_verify_args(args, ctx)?;
+    } else {
+        let parameters = builtin_parameters(name)
+            .ok_or_else(|| CompilerError::Unsupported(format!("builtin function '{name}' has no parameter types")))?;
+        check_builtin_args(name, args, parameters, ctx)?;
+    }
     match return_type {
         BuiltinReturn::Value(type_ref) => Ok(Some(type_ref)),
         BuiltinReturn::Void => Ok(None),
     }
+}
+
+fn check_g16_verify_args<'i>(args: &[Expr<'i>], ctx: &TypeCheckContext<'_, 'i>) -> Result<(), CompilerError> {
+    if args.len() < 2 {
+        return Err(CompilerError::Unsupported("g16.verify() expects at least 2 arguments".to_string()));
+    }
+
+    let parameters = g16_verify_parameter_types();
+    check_builtin_arg("g16.verify", "verifyingKey", &args[0], &parameters.verifying_key, ctx)?;
+    check_builtin_arg("g16.verify", "proof", &args[1], &parameters.proof, ctx)?;
+    for (index, arg) in args[2..].iter().enumerate() {
+        check_builtin_arg("g16.verify", &format!("publicInput{index}"), arg, &parameters.public_input, ctx)?;
+    }
+    Ok(())
 }
 
 fn check_builtin_args<'i>(
@@ -310,13 +328,24 @@ fn check_builtin_args<'i>(
         return Err(CompilerError::Unsupported(format!("{name}() expects {} arguments", parameters.len())));
     }
     for (arg, (parameter, expected)) in args.iter().zip(parameters) {
-        if check_expr(arg, Some(&expected), ctx).is_err() {
-            let actual = check_expr(arg, None, ctx).map(|type_ref| type_ref.type_name()).unwrap_or_else(|_| "unknown".to_string());
-            return Err(CompilerError::Unsupported(format!(
-                "{name}() argument '{parameter}' expects {}, got {actual}",
-                expected.type_name()
-            )));
-        }
+        check_builtin_arg(name, parameter, arg, &expected, ctx)?;
+    }
+    Ok(())
+}
+
+fn check_builtin_arg<'i>(
+    name: &str,
+    parameter: &str,
+    arg: &Expr<'i>,
+    expected: &TypeRef,
+    ctx: &TypeCheckContext<'_, 'i>,
+) -> Result<(), CompilerError> {
+    if check_expr(arg, Some(expected), ctx).is_err() {
+        let actual = check_expr(arg, None, ctx).map(|type_ref| type_ref.type_name()).unwrap_or_else(|_| "unknown".to_string());
+        return Err(CompilerError::Unsupported(format!(
+            "{name}() argument '{parameter}' expects {}, got {actual}",
+            expected.type_name()
+        )));
     }
     Ok(())
 }

--- a/silverscript-lang/src/silverscript.pest
+++ b/silverscript-lang/src/silverscript.pest
@@ -66,11 +66,12 @@ require_message = { StringLiteral }
 console_parameter_list = { "(" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ ")" }
 
 function_call = { function_name ~ expression_list }
-function_name = { r0_groth16_verify_name | r0_succinct_verify_name | Identifier }
+function_name = { r0_groth16_verify_name | r0_succinct_verify_name | g16_verify_name | Identifier }
 r0_groth16_verify_name = { "r0.g16.verify" }
 r0_succinct_verify_name = {
     "r0.succinct" ~ ("." ~ ("blake2b" | "poseidon2" | "sha256"))? ~ ".verify"
 }
+g16_verify_name = { "g16.verify" }
 expression_list = { "(" ~ (expression ~ ("," ~ expression)* ~ ","?)? ~ ")" }
 
 expression = _{ conditional }

--- a/silverscript-lang/tests/ast_format_tests.rs
+++ b/silverscript-lang/tests/ast_format_tests.rs
@@ -114,6 +114,21 @@ contract Advanced(int limit, pubkey owner) {
 }
 
 #[test]
+fn formats_g16_verify_call() {
+    let source = r#"contract Groth16(byte[] verifying_key, byte[] proof, byte[32] public_input) {
+    entry verify() {
+        g16.verify(verifying_key, proof, public_input);
+    }
+}
+"#;
+
+    let ast = parse_contract_ast(source).expect("parse succeeds");
+    let formatted = format_contract_ast(&ast);
+
+    assert!(formatted.contains("g16.verify(verifying_key, proof, public_input);"));
+}
+
+#[test]
 fn compiled_formatted_contract_preserves_exact_ast_for_basic_contract() {
     let source = r#"contract ExactBasic() {
     int constant LIMIT = 3;

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -8722,6 +8722,158 @@ fn checksigfromstack_requires_datasig_and_32_byte_digest_types() {
 }
 
 #[test]
+fn g16_verify_lowers_to_groth16_precompile() {
+    let source = r#"
+        contract Groth16(byte[] verifying_key, byte[] proof, byte[32] public_input0, byte[32] public_input1) {
+            entry verify() {
+                g16.verify(verifying_key, proof, public_input0, public_input1);
+            }
+        }
+    "#;
+    let (verifying_key, proof, public_inputs) = kaspa_txscript::zk_precompiles::tests::helpers::load_groth_fields();
+    let compiled = compile_contract(
+        source,
+        &[
+            Expr::dynamic_bytes(verifying_key.clone()),
+            Expr::dynamic_bytes(proof.clone()),
+            public_inputs[0].clone().into(),
+            public_inputs[1].clone().into(),
+        ],
+        CompileOptions::default(),
+    )
+    .expect("compile succeeds");
+
+    let body = script_builder()
+        .add_data_with_push_opcode(&public_inputs[1])
+        .unwrap()
+        .add_data_with_push_opcode(&public_inputs[0])
+        .unwrap()
+        .add_i64(2)
+        .unwrap()
+        .add_data_with_push_opcode(&proof)
+        .unwrap()
+        .add_data_with_push_opcode(&verifying_key)
+        .unwrap()
+        .add_data_with_push_opcode(&[kaspa_txscript::zk_precompiles::tags::ZkTag::Groth16 as u8])
+        .unwrap()
+        .add_op(OpZkPrecompile)
+        .unwrap()
+        .add_op(OpDrop)
+        .unwrap()
+        .add_op(OpTrue)
+        .unwrap()
+        .drain();
+    assert_eq!(compiled.bytecode, wrap_with_dispatch(body, selector_for(&compiled, "verify")));
+}
+
+#[test]
+fn g16_verify_validates_arity_and_argument_types() {
+    let missing_proof = r#"
+        contract Groth16() {
+            entry verify(byte[] verifying_key) {
+                g16.verify(verifying_key);
+            }
+        }
+    "#;
+    let err = compile_contract(missing_proof, &[], CompileOptions::default()).expect_err("proof is required");
+    assert!(err.to_string().contains("expects at least 2 arguments"), "unexpected error: {err}");
+
+    let cases = [
+        ("1, bytes_arg, public_input", "argument 'verifyingKey' expects byte[], got int"),
+        ("bytes_arg, 1, public_input", "argument 'proof' expects byte[], got int"),
+        ("bytes_arg, bytes_arg, bytes_arg", "argument 'publicInput0' expects byte[32], got byte[]"),
+    ];
+    for (args, expected) in cases {
+        let source = format!(
+            r#"
+                contract Groth16() {{
+                    entry verify(byte[] bytes_arg, byte[32] public_input) {{
+                        g16.verify({args});
+                    }}
+                }}
+            "#
+        );
+        let err = compile_contract(&source, &[], CompileOptions::default()).expect_err("invalid argument should fail");
+        assert!(err.to_string().contains(expected), "unexpected error for {args}: {err}");
+    }
+
+    let constant_sized_public_input = r#"
+        contract Groth16() {
+            int constant INPUT_SIZE = 32;
+
+            entry verify(byte[] verifying_key, byte[] proof, byte[INPUT_SIZE] public_input) {
+                g16.verify(verifying_key, proof, public_input);
+            }
+        }
+    "#;
+    compile_contract(constant_sized_public_input, &[], CompileOptions::default()).expect("contract constants should satisfy byte[32]");
+}
+
+#[test]
+fn g16_verify_is_void_and_accepts_zero_public_inputs() {
+    let direct_call = r#"
+        contract Groth16() {
+            entry verify(byte[] verifying_key, byte[] proof) {
+                g16.verify(verifying_key, proof);
+            }
+        }
+    "#;
+    compile_contract(direct_call, &[], CompileOptions::default()).expect("zero-public-input call should compile");
+
+    let expression_use = r#"
+        contract Groth16() {
+            entry verify(byte[] verifying_key, byte[] proof) {
+                require(g16.verify(verifying_key, proof));
+            }
+        }
+    "#;
+    let err = compile_contract(expression_use, &[], CompileOptions::default()).expect_err("g16.verify should not return a value");
+    assert!(err.to_string().contains("does not return a value"), "unexpected error: {err}");
+}
+
+#[test]
+fn g16_verify_executes_with_fixture_and_rejects_tampered_input() {
+    let source = r#"
+        contract Groth16() {
+            entry verify(
+                byte[] verifying_key,
+                byte[] proof,
+                byte[32] public_input0,
+                byte[32] public_input1,
+                byte[32] public_input2,
+                byte[32] public_input3,
+                byte[32] public_input4,
+            ) {
+                g16.verify(
+                    verifying_key,
+                    proof,
+                    public_input0,
+                    public_input1,
+                    public_input2,
+                    public_input3,
+                    public_input4,
+                );
+            }
+        }
+    "#;
+    let (verifying_key, proof, public_inputs) = kaspa_txscript::zk_precompiles::tests::helpers::load_groth_fields();
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let build_args = |inputs: &[Vec<u8>]| -> Vec<Expr<'static>> {
+        let mut args = vec![Expr::dynamic_bytes(verifying_key.clone()), Expr::dynamic_bytes(proof.clone())];
+        args.extend(inputs.iter().cloned().map(Into::into));
+        args
+    };
+
+    let sigscript = compiled.build_sig_script("verify", build_args(&public_inputs)).expect("sigscript builds");
+    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript).is_ok(), "valid Groth16 proof should pass");
+
+    let mut tampered_inputs = public_inputs;
+    tampered_inputs[0][0] ^= 0x01;
+    let sigscript = compiled.build_sig_script("verify", build_args(&tampered_inputs)).expect("sigscript builds");
+    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript).is_err(), "tampered public input should fail");
+}
+
+#[test]
 fn r0_succinct_verify_lowers_hash_aliases_to_zk_precompile() {
     let cases = ["r0.succinct.poseidon2.verify", "r0.succinct.verify"];
 

--- a/silverscript-lang/tests/examples/g16_verify.sil
+++ b/silverscript-lang/tests/examples/g16_verify.sil
@@ -1,0 +1,23 @@
+pragma silverscript ^0.1.0;
+
+contract Groth16Verify() {
+    entry verify(
+        byte[] verifying_key,
+        byte[] proof,
+        byte[32] public_input0,
+        byte[32] public_input1,
+        byte[32] public_input2,
+        byte[32] public_input3,
+        byte[32] public_input4,
+    ) {
+        g16.verify(
+            verifying_key,
+            proof,
+            public_input0,
+            public_input1,
+            public_input2,
+            public_input3,
+            public_input4,
+        );
+    }
+}

--- a/silverscript-lang/tests/examples_tests.rs
+++ b/silverscript-lang/tests/examples_tests.rs
@@ -384,6 +384,28 @@ fn compiles_r0_g16_example_and_verifies() {
 }
 
 #[test]
+fn compiles_g16_verify_example_and_verifies() {
+    let source = load_example_source("g16_verify.sil");
+    let (verifying_key, proof, public_inputs) = kaspa_txscript::zk_precompiles::tests::helpers::load_groth_fields();
+    let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    let mut args: Vec<Expr<'static>> = vec![Expr::dynamic_bytes(verifying_key), Expr::dynamic_bytes(proof)];
+    args.extend(public_inputs.into_iter().map(Into::into));
+    let sigscript = compiled.build_sig_script("verify", args).expect("sigscript builds");
+
+    let result = run_contract_with_tx(
+        compiled.bytecode.clone(),
+        compiled.bytecode.clone(),
+        compiled.bytecode.clone(),
+        2000,
+        500,
+        500,
+        sigscript,
+        0,
+    );
+    assert!(result.is_ok(), "Groth16 example failed: {}", result.unwrap_err());
+}
+
+#[test]
 fn compiles_r0_succinct_example_and_verifies() {
     let source = load_example_source("r0_succinct.sil");
     let (control_id, seal, claim, hashfn, control_index, control_digests, journal, image_id) =

--- a/silverscript-lang/tests/parser_tests.rs
+++ b/silverscript-lang/tests/parser_tests.rs
@@ -371,6 +371,18 @@ fn parses_qualified_r0_verifier_calls() {
 }
 
 #[test]
+fn parses_g16_verify_call() {
+    let input = r#"
+        contract Groth16(byte[] verifying_key, byte[] proof, byte[32] public_input) {
+            entry verify() {
+                g16.verify(verifying_key, proof, public_input);
+            }
+        }
+    "#;
+    assert!(parse_source_file(input).is_ok());
+}
+
+#[test]
 fn rejects_misspelled_r0_succinct_verifier_call() {
     let input = r#"
         contract R0(byte[32] image_id, byte[32] control_id) {

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -82,6 +82,14 @@
   .
   (call_suffix))
 
+(postfix
+  (postfix_op
+    (member_access
+      name: (identifier) @function.builtin))
+  .
+  (postfix_op
+    (call_suffix)))
+
 (unary_suffix) @property
 
 (split_call


### PR DESCRIPTION
## Summary

Adds `g16.verify(...)` as the low-level SilverScript intrinsic for verifying Groth16 proofs through the Rusty Kaspa ZK precompile.

The builtin signature is:

```silverscript
g16.verify(byte[] verifyingKey, byte[] proof, byte[32] ...publicInputs)
```

This PR now builds on merged #137 and reuses its qualified builtin, parser, compiler, and tree-sitter patterns.

This PR includes:

- parser, AST, formatter, and syntax-highlighting support for `g16.verify`
- static validation for `byte[]` verifying key/proof arguments and variadic `byte[32]` public inputs
- compiler lowering to `OpZkPrecompile` with `ZkTag::Groth16` using the Rusty Kaspa stack convention
- void statement semantics: verification failure aborts script execution and the success value is discarded
- documentation, an executable example, valid/tampered proof coverage, and debugger support for post-Toccata-sized runtime parameters

## Scope

This is the raw Groth16 intrinsic discussed in #137. It intentionally leaves the merged `r0.*` verifier behavior unchanged.

The possibility of implementing `r0.g16.verify(...)` as a SilverScript standard function on top of this intrinsic can be evaluated separately, including the cross-path R0 fixture test suggested in the [#137 discussion](https://github.com/kaspanet/silverscript/pull/137#issuecomment-4830700055).

## Tests

```bash
cargo test --workspace
cargo clippy --workspace --tests --benches --examples -- -D warnings
cargo test --manifest-path tree-sitter/Cargo.toml
(cd tree-sitter && npm test)
cargo fmt --all -- --check
git diff --check upstream/master...HEAD
```