### PR TITLE
Template hash hardening (breaking change)

### DIFF
--- a/extensions/silverscript.nvim/queries/silverscript/highlights.scm
+++ b/extensions/silverscript.nvim/queries/silverscript/highlights.scm
@@ -72,7 +72,7 @@
 (function_call
   (identifier) @function.builtin
   (#match? @function.builtin
-    "^(readInputState|readInputStateWithTemplate|validateOutputState|validateOutputStateWithTemplate|verifyOutputState|verifyOutputStates|OpSha256|sha256|OpTxSubnetId|OpTxGas|OpTxPayloadLen|OpTxPayloadSubstr|OpOutpointTxId|OpOutpointIndex|OpTxInputScriptSigLen|OpTxInputScriptSigSubstr|OpTxInputSeq|OpTxInputIsCoinbase|OpTxInputSpkLen|OpTxInputSpkSubstr|OpTxOutputSpkLen|OpTxOutputSpkSubstr|OpAuthOutputCount|OpAuthOutputIdx|OpInputCovenantId|OpOutputCovenantId|OpCovInputCount|OpCovInputIdx|OpCovOutputCount|OpCovOutputIdx|OpNum2Bin|OpBin2Num|OpChainblockSeqCommit|checkSigFromStack|checkSigFromStackECDSA|checkSig|checkMultiSig|blake2b)$"))
+    "^(readInputState|readInputStateWithTemplate|validateOutputState|validateOutputStateWithTemplate|verifyOutputState|verifyOutputStates|OpSha256|sha256|OpTxSubnetId|OpTxGas|OpTxPayloadLen|OpTxPayloadSubstr|OpOutpointTxId|OpOutpointIndex|OpTxInputScriptSigLen|OpTxInputScriptSigSubstr|OpTxInputSeq|OpTxInputIsCoinbase|OpTxInputSpkLen|OpTxInputSpkSubstr|OpTxOutputSpkLen|OpTxOutputSpkSubstr|OpAuthOutputCount|OpAuthOutputIdx|OpInputCovenantId|OpOutputCovenantId|OpCovInputCount|OpCovInputIdx|OpCovOutputCount|OpCovOutputIdx|OpNum2Bin|OpBin2Num|OpChainblockSeqCommit|checkSigFromStack|checkSigFromStackECDSA|checkSig|checkMultiSig|blake2b|templateHash)$"))
 
 (unary_suffix) @property
 

--- a/extensions/vscode/queries/highlights.scm
+++ b/extensions/vscode/queries/highlights.scm
@@ -72,7 +72,7 @@
 (function_call
   (identifier) @function.builtin
   (#match? @function.builtin
-    "^(readInputState|readInputStateWithTemplate|validateOutputState|validateOutputStateWithTemplate|verifyOutputState|verifyOutputStates|OpSha256|sha256|OpTxSubnetId|OpTxGas|OpTxPayloadLen|OpTxPayloadSubstr|OpOutpointTxId|OpOutpointIndex|OpTxInputScriptSigLen|OpTxInputScriptSigSubstr|OpTxInputSeq|OpTxInputIsCoinbase|OpTxInputSpkLen|OpTxInputSpkSubstr|OpTxOutputSpkLen|OpTxOutputSpkSubstr|OpAuthOutputCount|OpAuthOutputIdx|OpInputCovenantId|OpOutputCovenantId|OpCovInputCount|OpCovInputIdx|OpCovOutputCount|OpCovOutputIdx|OpNum2Bin|OpBin2Num|OpChainblockSeqCommit|checkSigFromStack|checkSigFromStackECDSA|checkSig|checkMultiSig|blake2b)$"))
+    "^(readInputState|readInputStateWithTemplate|validateOutputState|validateOutputStateWithTemplate|verifyOutputState|verifyOutputStates|OpSha256|sha256|OpTxSubnetId|OpTxGas|OpTxPayloadLen|OpTxPayloadSubstr|OpOutpointTxId|OpOutpointIndex|OpTxInputScriptSigLen|OpTxInputScriptSigSubstr|OpTxInputSeq|OpTxInputIsCoinbase|OpTxInputSpkLen|OpTxInputSpkSubstr|OpTxOutputSpkLen|OpTxOutputSpkSubstr|OpAuthOutputCount|OpAuthOutputIdx|OpInputCovenantId|OpOutputCovenantId|OpCovInputCount|OpCovInputIdx|OpCovOutputCount|OpCovOutputIdx|OpNum2Bin|OpBin2Num|OpChainblockSeqCommit|checkSigFromStack|checkSigFromStackECDSA|checkSig|checkMultiSig|blake2b|templateHash)$"))
 
 (unary_suffix) @property
 

--- a/extensions/zed/languages/silverscript/highlights.scm
+++ b/extensions/zed/languages/silverscript/highlights.scm
@@ -72,7 +72,7 @@
 (function_call
   (identifier) @function.builtin
   (#match? @function.builtin
-    "^(readInputState|readInputStateWithTemplate|validateOutputState|validateOutputStateWithTemplate|verifyOutputState|verifyOutputStates|OpSha256|sha256|OpTxSubnetId|OpTxGas|OpTxPayloadLen|OpTxPayloadSubstr|OpOutpointTxId|OpOutpointIndex|OpTxInputScriptSigLen|OpTxInputScriptSigSubstr|OpTxInputSeq|OpTxInputIsCoinbase|OpTxInputSpkLen|OpTxInputSpkSubstr|OpTxOutputSpkLen|OpTxOutputSpkSubstr|OpAuthOutputCount|OpAuthOutputIdx|OpInputCovenantId|OpOutputCovenantId|OpCovInputCount|OpCovInputIdx|OpCovOutputCount|OpCovOutputIdx|OpNum2Bin|OpBin2Num|OpChainblockSeqCommit|checkSigFromStack|checkSigFromStackECDSA|checkSig|checkMultiSig|blake2b)$"))
+    "^(readInputState|readInputStateWithTemplate|validateOutputState|validateOutputStateWithTemplate|verifyOutputState|verifyOutputStates|OpSha256|sha256|OpTxSubnetId|OpTxGas|OpTxPayloadLen|OpTxPayloadSubstr|OpOutpointTxId|OpOutpointIndex|OpTxInputScriptSigLen|OpTxInputScriptSigSubstr|OpTxInputSeq|OpTxInputIsCoinbase|OpTxInputSpkLen|OpTxInputSpkSubstr|OpTxOutputSpkLen|OpTxOutputSpkSubstr|OpAuthOutputCount|OpAuthOutputIdx|OpInputCovenantId|OpOutputCovenantId|OpCovInputCount|OpCovInputIdx|OpCovOutputCount|OpCovOutputIdx|OpNum2Bin|OpBin2Num|OpChainblockSeqCommit|checkSigFromStack|checkSigFromStackECDSA|checkSig|checkMultiSig|blake2b|templateHash)$"))
 
 (unary_suffix) @property
 

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -456,6 +456,7 @@ fn infer_expr_type_ref_for_comparison<'i>(
                 | "datasig"
                 | "bytes"
                 | "blake2b"
+                | "templateHash"
                 | "sha256"
                 | "OpSha256"
                 | "OpTxSubnetId"
@@ -3431,6 +3432,7 @@ fn expr_is_bytes_inner<'i>(expr: &Expr<'i>, types: &HashMap<String, String>, vis
                 name,
                 "bytes"
                     | "blake2b"
+                    | "templateHash"
                     | "sha256"
                     | "OpSha256"
                     | "OpTxSubnetId"
@@ -3594,6 +3596,7 @@ fn compile_call_expr<'i>(
             compile_array_cast_call(&mut ctx, name, args)
         }
         "blake2b" => compile_blake2b_call(&mut ctx, args),
+        "templateHash" => compile_template_hash_call(&mut ctx, args),
         "checkSig" => compile_checksig_call(&mut ctx, args),
         "checkSigFromStack" => compile_checksigfromstack_call(&mut ctx, name, args, OpCheckSigFromStack),
         "checkSigFromStackECDSA" => compile_checksigfromstack_call(&mut ctx, name, args, OpCheckSigFromStackECDSA),
@@ -3792,6 +3795,23 @@ fn compile_blake2b_call<'i>(ctx: &mut CompileCallContext<'_, 'i>, args: &[Expr<'
         return Err(CompilerError::Unsupported("blake2b() expects a single argument".to_string()));
     }
     compile_call_arg_with_context(ctx, &args[0])?;
+    ctx.builder.add_op(OpBlake2b)?;
+    Ok(())
+}
+
+fn compile_template_hash_call<'i>(ctx: &mut CompileCallContext<'_, 'i>, args: &[Expr<'i>]) -> Result<(), CompilerError> {
+    let Ok([prefix, suffix]): Result<&[Expr<'i>; 2], _> = args.try_into() else {
+        return Err(CompilerError::Unsupported("templateHash() expects 2 arguments".to_string()));
+    };
+
+    let encoded_prefix_len = Expr::call("bytes", vec![Expr::call("length", vec![prefix.clone()]), Expr::int(8)]);
+    let encoded_suffix_len = Expr::call("bytes", vec![Expr::call("length", vec![suffix.clone()]), Expr::int(8)]);
+    let preimage = binary_expr(
+        BinaryOp::Add,
+        binary_expr(BinaryOp::Add, encoded_prefix_len, prefix.clone()),
+        binary_expr(BinaryOp::Add, encoded_suffix_len, suffix.clone()),
+    );
+    compile_call_arg_with_context(ctx, &preimage)?;
     ctx.builder.add_op(OpBlake2b)?;
     Ok(())
 }

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -1888,7 +1888,7 @@ fn struct_name_for_state_bindings<'i>(bindings: &[StateBindingAst<'i>], structs:
 ///       script_base + script_size
 ///   ]
 ///
-///   actual_template = prefix || suffix
+///   actual_template = i64le(prefix.length) || prefix || i64le(suffix.length) || suffix
 ///   require blake2b(actual_template) == expected_template_hash
 ///
 ///   expected_input_spk = ScriptPubKeyP2SHFromRedeemScript(actual_redeem_script)
@@ -1928,12 +1928,18 @@ fn compile_read_input_state_with_template_validation(
     let script_end_expr = binary_expr(BinaryOp::Add, script_base_expr.clone(), script_size_expr.clone());
     let state_len = encoded_state_len_for_layout_field_types(layout_field_types, contract_constants)?;
     let suffix_start_expr = binary_expr(BinaryOp::Add, prefix_end_expr.clone(), Expr::int(state_len as i64));
-    let suffix_end_expr = binary_expr(BinaryOp::Add, suffix_start_expr.clone(), suffix_len_expr);
+    let suffix_end_expr = binary_expr(BinaryOp::Add, suffix_start_expr.clone(), suffix_len_expr.clone());
 
     let actual_redeem_script_expr = input_sigscript_substr_expr(input_idx, script_base_expr.clone(), script_end_expr);
     let actual_prefix_expr = input_sigscript_substr_expr(input_idx, script_base_expr, prefix_end_expr);
     let actual_suffix_expr = input_sigscript_substr_expr(input_idx, suffix_start_expr, suffix_end_expr);
-    let actual_template_expr = binary_expr(BinaryOp::Add, actual_prefix_expr, actual_suffix_expr);
+    let encoded_prefix_len_expr = Expr::call("bytes", vec![prefix_len_expr, Expr::int(8)]);
+    let encoded_suffix_len_expr = Expr::call("bytes", vec![suffix_len_expr, Expr::int(8)]);
+    let actual_template_expr = binary_expr(
+        BinaryOp::Add,
+        binary_expr(BinaryOp::Add, encoded_prefix_len_expr, actual_prefix_expr),
+        binary_expr(BinaryOp::Add, encoded_suffix_len_expr, actual_suffix_expr),
+    );
     let expected_input_spk_expr = Expr::new(
         ExprKind::New {
             name: "ScriptPubKeyP2SHFromRedeemScript".to_string(),
@@ -2183,8 +2189,15 @@ fn compile_validate_output_state_with_template_inner_statement(
 
     let mut stack_depth = 0i64;
 
+    let encoded_prefix_len = Expr::call("bytes", vec![Expr::call("length", vec![template_prefix.clone()]), Expr::int(8)]);
+    let encoded_suffix_len = Expr::call("bytes", vec![Expr::call("length", vec![template_suffix.clone()]), Expr::int(8)]);
+    let template_preimage = binary_expr(
+        BinaryOp::Add,
+        binary_expr(BinaryOp::Add, encoded_prefix_len, template_prefix.clone()),
+        binary_expr(BinaryOp::Add, encoded_suffix_len, template_suffix.clone()),
+    );
     compile_expr(
-        template_prefix,
+        &template_preimage,
         constants,
         stack_bindings,
         types,
@@ -2195,20 +2208,6 @@ fn compile_validate_output_state_with_template_inner_statement(
         script_size,
         contract_constants,
     )?;
-    compile_expr(
-        template_suffix,
-        constants,
-        stack_bindings,
-        types,
-        builder,
-        options,
-        &mut HashSet::new(),
-        &mut stack_depth,
-        script_size,
-        contract_constants,
-    )?;
-    builder.add_op(OpCat)?;
-    stack_depth -= 1;
     compile_expr(
         expected_template_hash,
         constants,

--- a/silverscript-lang/src/compiler/debug_value_types.rs
+++ b/silverscript-lang/src/compiler/debug_value_types.rs
@@ -55,7 +55,7 @@ fn builtin_call_value_type(name: &str) -> &'static str {
         | "OpCovOutputCount"
         | "OpCovOutputIdx" => "int",
         "OpTxInputIsCoinbase" | "checkSig" | "checkSigFromStack" | "checkSigFromStackECDSA" => "bool",
-        "blake2b" | "sha256" | "OpSha256" => "byte[32]",
+        "blake2b" | "templateHash" | "sha256" | "OpSha256" => "byte[32]",
         "bytes"
         | "OpTxSubnetId"
         | "OpTxPayloadSubstr"

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -179,6 +179,12 @@ pub fn struct_object<'i>(fields: Vec<(&str, Expr<'i>)>) -> Expr<'i> {
 }
 
 impl<'i> CompiledContract<'i> {
+    /// Calculate the canonical hash of this contract's state template.
+    pub fn template_hash(&self) -> [u8; 32] {
+        let state_end = self.state_layout.start + self.state_layout.len;
+        crate::template::template_hash(&self.script[..self.state_layout.start], &self.script[state_end..])
+    }
+
     pub fn build_sig_script(&self, function_name: &str, args: Vec<Expr<'i>>) -> Result<Vec<u8>, CompilerError> {
         let structs = build_struct_registry(&self.ast)?;
         let function = self

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -1406,6 +1406,7 @@ fn validate_builtin_call<'i>(
 fn typed_builtin_return_type_ref(name: &str) -> Option<TypeRef> {
     match name {
         "checkSigFromStack" | "checkSigFromStackECDSA" => parse_type_ref("bool").ok(),
+        "templateHash" => parse_type_ref("byte[32]").ok(),
         _ => None,
     }
 }

--- a/silverscript-lang/src/lib.rs
+++ b/silverscript-lang/src/lib.rs
@@ -5,3 +5,4 @@ pub mod diagnostic;
 pub mod errors;
 pub mod parser;
 pub mod span;
+pub mod template;

--- a/silverscript-lang/src/template.rs
+++ b/silverscript-lang/src/template.rs
@@ -1,0 +1,37 @@
+use blake2b_simd::Params as Blake2bParams;
+use kaspa_txscript::serialize_i64;
+
+const TEMPLATE_PART_LENGTH_BYTES: usize = 8;
+
+/// Calculate the canonical hash of a state-bearing contract template.
+///
+/// The fixed-width part lengths bind the boundary where serialized state is
+/// inserted between the template prefix and suffix.
+pub fn template_hash(prefix: &[u8], suffix: &[u8]) -> [u8; 32] {
+    let prefix_len = i64::try_from(prefix.len()).unwrap();
+    let suffix_len = i64::try_from(suffix.len()).unwrap();
+    let encoded_prefix_len = serialize_i64(prefix_len, Some(TEMPLATE_PART_LENGTH_BYTES)).unwrap();
+    let encoded_suffix_len = serialize_i64(suffix_len, Some(TEMPLATE_PART_LENGTH_BYTES)).unwrap();
+
+    Blake2bParams::new()
+        .hash_length(32)
+        .to_state()
+        .update(encoded_prefix_len.as_ref())
+        .update(prefix)
+        .update(encoded_suffix_len.as_ref())
+        .update(suffix)
+        .finalize()
+        .as_bytes()
+        .try_into()
+        .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::template_hash;
+
+    #[test]
+    fn binds_template_part_boundary() {
+        assert_ne!(template_hash(b"a", b"bc"), template_hash(b"ab", b"c"));
+    }
+}

--- a/silverscript-lang/std/builtins.sil
+++ b/silverscript-lang/std/builtins.sil
@@ -22,7 +22,7 @@
  * Pseudo logic:
  *   1. Encode `newState` using this contract's own `State` layout.
  *   2. Keep the current contract's non-state prefix and suffix.
- *   3. Rebuild the redeem script as `prefix || encoded_state || suffix`.
+ *   3. Rebuild the redeem script as `prefix || encodedState || suffix`.
  *   4. Require `tx.outputs[outputIndex]` to use the matching P2SH `scriptPubKey`.
  *
  * Security notes:
@@ -42,14 +42,14 @@ function validateOutputState(int outputIndex, object newState);
  *
  * Example:
  * ```js
- * Receipt receipt = { order_id: order_id, buyer: buyer, amount: amount };
- * validateOutputStateWithTemplate(1, receipt, receipt_prefix, receipt_suffix, receipt_hash);
+ * Receipt receipt = { orderId: orderId, buyer: buyer, amount: amount };
+ * validateOutputStateWithTemplate(1, receipt, receiptPrefix, receiptSuffix, receiptHash);
  * ```
  *
  * Pseudo logic:
- *   1. Check that `blake2b(templatePrefix || templateSuffix)` matches `expectedTemplateHash`.
+ *   1. Check that `templateHash(templatePrefix, templateSuffix)` matches `expectedTemplateHash`.
  *   2. Encode `newState` using its static struct layout.
- *   3. Rebuild the foreign redeem script as `templatePrefix || encoded_state || templateSuffix`.
+ *   3. Rebuild the foreign redeem script as `templatePrefix || encodedState || templateSuffix`.
  *   4. Require `tx.outputs[outputIndex]` to use the matching P2SH `scriptPubKey`.
  *
  * Security notes:
@@ -75,8 +75,8 @@ function validateOutputStateWithTemplate(
  *
  * Example:
  * ```js
- * {x: int in_x, y: byte[2] in_y} = readInputState(1);
- * require(in_x > 7);
+ * {x: int inX, y: byte[2] inY} = readInputState(1);
+ * require(inX > 7);
  * ```
  *
  * Pseudo logic:
@@ -112,19 +112,19 @@ function readInputState(int inputIndex) : (State);
  *
  * Example:
  * ```js
- * Receipt receipt = readInputStateWithTemplate(2, receipt_prefix_len, receipt_suffix_len, receipt_hash);
- * require(receipt.amount == expected_amount);
+ * Receipt receipt = readInputStateWithTemplate(2, receiptPrefixLen, receiptSuffixLen, receiptHash);
+ * require(receipt.amount == expectedAmount);
  * ```
  *
  * Pseudo logic:
  *   1. Determine the encoded byte size of the struct layout you want to read.
  *   2. Use `templatePrefixLen`, that state size, and `templateSuffixLen` to
  *      slice a claimed redeem script out of the foreign input sigscript.
- *   3. Split the claimed redeem script into `claimed_prefix`, `claimed_state`, and `claimed_suffix`.
- *   4. Check that `blake2b(claimed_prefix || claimed_suffix)` matches `expectedTemplateHash`.
+ *   3. Split the claimed redeem script into `claimedPrefix`, `claimedState`, and `claimedSuffix`.
+ *   4. Check that `templateHash(claimedPrefix, claimedSuffix)` matches `expectedTemplateHash`.
  *   5. Require the claimed redeem script to match the foreign input's actual
  *      P2SH `scriptPubKey`.
- *   6. Decode `claimed_state` using the passed struct layout and return the result.
+ *   6. Decode `claimedState` using the passed struct layout and return the result.
  *
  * Security notes:
  *   - `expectedTemplateHash` should be trusted protocol data.
@@ -137,3 +137,30 @@ function readInputStateWithTemplate(
     int templateSuffixLen,
     byte[32] expectedTemplateHash
 ) : (object);
+
+/**
+ * Role:
+ *      Calculate the canonical hash of a contract template.
+ *
+ * Definition:
+ *      Hash a redeem script's non-state prefix and suffix while committing to
+ *      their exact lengths. Each length is encoded as an eight-byte Script
+ *      integer before its corresponding template part.
+ *
+ * Example:
+ * ```js
+ * byte[32] receiptHash = templateHash(receiptPrefix, receiptSuffix);
+ * ```
+ *
+ * Pseudo logic:
+ *   1. Encode `templatePrefix.length` and `templateSuffix.length` with
+ *      `bytes(length, 8)`.
+ *   2. Build `prefixLen || templatePrefix || suffixLen || templateSuffix`.
+ *   3. Return `blake2b` of that preimage.
+ *
+ * Security notes:
+ *   - The encoded lengths bind the location where state is inserted.
+ *   - `blake2b(templatePrefix || templateSuffix)` is not a valid template hash
+ *     because it does not commit to the prefix/suffix boundary.
+ */
+function templateHash(byte[] templatePrefix, byte[] templateSuffix) : (byte[32]);

--- a/silverscript-lang/tests/apps/chess/chess_castle.sil
+++ b/silverscript-lang/tests/apps/chess/chess_castle.sil
@@ -225,7 +225,7 @@ contract ChessCastle(
             next_status = 1 /*WWIN*/;
         }
 
-        byte[32] settle_template = blake2b(settle_prefix + settle_suffix);
+        byte[32] settle_template = templateHash(settle_prefix, settle_suffix);
         require(blake2b(settle_template + player_template) == byte[32](route_templates.slice(256, 288)));
 
         SettleState next_state = {

--- a/silverscript-lang/tests/apps/chess/chess_castle_challenge.sil
+++ b/silverscript-lang/tests/apps/chess/chess_castle_challenge.sil
@@ -251,7 +251,7 @@ contract ChessCastleChallengePrep(
             next_status = 1 /*WWIN*/;
         }
 
-        byte[32] settle_template = blake2b(settle_prefix + settle_suffix);
+        byte[32] settle_template = templateHash(settle_prefix, settle_suffix);
         require(blake2b(settle_template + player_template) == byte[32](route_templates.slice(256, 288)));
 
         SettleState next_state = {

--- a/silverscript-lang/tests/apps/chess/chess_diag.sil
+++ b/silverscript-lang/tests/apps/chess/chess_diag.sil
@@ -244,7 +244,7 @@ contract ChessDiag(
             next_status = 1 /*WWIN*/;
         }
 
-        byte[32] settle_template = blake2b(settle_prefix + settle_suffix);
+        byte[32] settle_template = templateHash(settle_prefix, settle_suffix);
         require(blake2b(settle_template + player_template) == byte[32](route_templates.slice(256, 288)));
 
         SettleState next_state = {

--- a/silverscript-lang/tests/apps/chess/chess_horiz.sil
+++ b/silverscript-lang/tests/apps/chess/chess_horiz.sil
@@ -259,7 +259,7 @@ contract ChessHoriz(
             next_status = 1 /*WWIN*/;
         }
 
-        byte[32] settle_template = blake2b(settle_prefix + settle_suffix);
+        byte[32] settle_template = templateHash(settle_prefix, settle_suffix);
         require(blake2b(settle_template + player_template) == byte[32](route_templates.slice(256, 288)));
 
         SettleState next_state = {

--- a/silverscript-lang/tests/apps/chess/chess_king.sil
+++ b/silverscript-lang/tests/apps/chess/chess_king.sil
@@ -244,7 +244,7 @@ contract ChessKing(
             next_status = 1 /*WWIN*/;
         }
 
-        byte[32] settle_template = blake2b(settle_prefix + settle_suffix);
+        byte[32] settle_template = templateHash(settle_prefix, settle_suffix);
         require(blake2b(settle_template + player_template) == byte[32](route_templates.slice(256, 288)));
 
         SettleState next_state = {

--- a/silverscript-lang/tests/apps/chess/chess_knight.sil
+++ b/silverscript-lang/tests/apps/chess/chess_knight.sil
@@ -230,7 +230,7 @@ contract ChessKnight(
             next_status = 1 /*WWIN*/;
         }
 
-        byte[32] settle_template = blake2b(settle_prefix + settle_suffix);
+        byte[32] settle_template = templateHash(settle_prefix, settle_suffix);
         require(blake2b(settle_template + player_template) == byte[32](route_templates.slice(256, 288)));
 
         SettleState next_state = {

--- a/silverscript-lang/tests/apps/chess/chess_mux.sil
+++ b/silverscript-lang/tests/apps/chess/chess_mux.sil
@@ -260,7 +260,7 @@ contract ChessMux(
             next_status = 3 /*DRAW*/;
         }
 
-        byte[32] settle_template = blake2b(settle_prefix + settle_suffix);
+        byte[32] settle_template = templateHash(settle_prefix, settle_suffix);
         require(blake2b(settle_template + player_template) == byte[32](route_templates.slice(256, 288)));
 
         SettleState next_state = {
@@ -277,7 +277,7 @@ contract ChessMux(
 
     entrypoint function settle(byte[32] player_template, byte[] settle_prefix, byte[] settle_suffix) {
         require(status != 0 /*LIVE*/);
-        byte[32] settle_template = blake2b(settle_prefix + settle_suffix);
+        byte[32] settle_template = templateHash(settle_prefix, settle_suffix);
         require(blake2b(settle_template + player_template) == byte[32](route_templates.slice(256, 288)));
 
         SettleState next_state = {

--- a/silverscript-lang/tests/apps/chess/chess_pawn.sil
+++ b/silverscript-lang/tests/apps/chess/chess_pawn.sil
@@ -342,7 +342,7 @@ contract ChessPawn(
             next_status = 1 /*WWIN*/;
         }
 
-        byte[32] settle_template = blake2b(settle_prefix + settle_suffix);
+        byte[32] settle_template = templateHash(settle_prefix, settle_suffix);
         require(blake2b(settle_template + player_template) == byte[32](route_templates.slice(256, 288)));
 
         SettleState next_state = {

--- a/silverscript-lang/tests/apps/chess/chess_vert.sil
+++ b/silverscript-lang/tests/apps/chess/chess_vert.sil
@@ -259,7 +259,7 @@ contract ChessVert(
             next_status = 1 /*WWIN*/;
         }
 
-        byte[32] settle_template = blake2b(settle_prefix + settle_suffix);
+        byte[32] settle_template = templateHash(settle_prefix, settle_suffix);
         require(blake2b(settle_template + player_template) == byte[32](route_templates.slice(256, 288)));
 
         SettleState next_state = {

--- a/silverscript-lang/tests/chess_apps_tests.rs
+++ b/silverscript-lang/tests/chess_apps_tests.rs
@@ -318,7 +318,7 @@ fn template_fixture(source: &'static str, ctor: &[Expr<'static>]) -> TemplateFix
     let layout = compiled.state_layout;
     let prefix = compiled.script[..layout.start].to_vec();
     let suffix = compiled.script[layout.start + layout.len..].to_vec();
-    let hash = blake2b_bytes(&[prefix.as_slice(), suffix.as_slice()].concat());
+    let hash = Hash::from_bytes(compiled.template_hash());
     TemplateFixture { source, prefix, suffix, hash }
 }
 
@@ -435,8 +435,7 @@ fn player_template_hash(fix: &MuxChessFixture) -> Hash {
             losses: 0,
         },
     );
-    let layout = compiled.state_layout;
-    blake2b_bytes(&[compiled.script[..layout.start].as_ref(), compiled.script[layout.start + layout.len..].as_ref()].concat())
+    Hash::from_bytes(compiled.template_hash())
 }
 
 fn entry_sigscript(compiled: &CompiledContract<'_>, function: &str, args: Vec<Expr<'_>>) -> Vec<u8> {
@@ -658,86 +657,86 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "league.sil",
             ctor: league_constructor_args,
-            expected_script_len: 468,
-            expected_instruction_count: 269,
-            expected_charged_op_count: 199,
+            expected_script_len: 488,
+            expected_instruction_count: 289,
+            expected_charged_op_count: 213,
         },
         SizeSnapshot {
             name: "player.sil",
             ctor: player_constructor_args,
-            expected_script_len: 3382,
-            expected_instruction_count: 2482,
-            expected_charged_op_count: 1618,
+            expected_script_len: 3444,
+            expected_instruction_count: 2538,
+            expected_charged_op_count: 1650,
         },
         SizeSnapshot {
             name: "chess_mux.sil",
             ctor: mux_constructor_args,
-            expected_script_len: 1644,
-            expected_instruction_count: 986,
-            expected_charged_op_count: 666,
+            expected_script_len: 1754,
+            expected_instruction_count: 1086,
+            expected_charged_op_count: 736,
         },
         SizeSnapshot {
             name: "chess_settle.sil",
             ctor: settle_constructor_args,
-            expected_script_len: 2591,
-            expected_instruction_count: 2007,
-            expected_charged_op_count: 1307,
+            expected_script_len: 2656,
+            expected_instruction_count: 2068,
+            expected_charged_op_count: 1347,
         },
         SizeSnapshot {
             name: "chess_pawn.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 1906,
-            expected_instruction_count: 1272,
-            expected_charged_op_count: 830,
+            expected_script_len: 1972,
+            expected_instruction_count: 1332,
+            expected_charged_op_count: 872,
         },
         SizeSnapshot {
             name: "chess_knight.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 1430,
-            expected_instruction_count: 831,
-            expected_charged_op_count: 552,
+            expected_script_len: 1496,
+            expected_instruction_count: 891,
+            expected_charged_op_count: 594,
         },
         SizeSnapshot {
             name: "chess_vert.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 2038,
-            expected_instruction_count: 1409,
-            expected_charged_op_count: 969,
+            expected_script_len: 2104,
+            expected_instruction_count: 1469,
+            expected_charged_op_count: 1011,
         },
         SizeSnapshot {
             name: "chess_horiz.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 2038,
-            expected_instruction_count: 1409,
-            expected_charged_op_count: 969,
+            expected_script_len: 2104,
+            expected_instruction_count: 1469,
+            expected_charged_op_count: 1011,
         },
         SizeSnapshot {
             name: "chess_diag.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 2005,
-            expected_instruction_count: 1383,
-            expected_charged_op_count: 951,
+            expected_script_len: 2071,
+            expected_instruction_count: 1443,
+            expected_charged_op_count: 993,
         },
         SizeSnapshot {
             name: "chess_king.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 1516,
-            expected_instruction_count: 898,
-            expected_charged_op_count: 595,
+            expected_script_len: 1582,
+            expected_instruction_count: 958,
+            expected_charged_op_count: 637,
         },
         SizeSnapshot {
             name: "chess_castle.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 1564,
-            expected_instruction_count: 959,
-            expected_charged_op_count: 628,
+            expected_script_len: 1630,
+            expected_instruction_count: 1019,
+            expected_charged_op_count: 670,
         },
         SizeSnapshot {
             name: "chess_castle_challenge.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 1663,
-            expected_instruction_count: 1060,
-            expected_charged_op_count: 691,
+            expected_script_len: 1729,
+            expected_instruction_count: 1120,
+            expected_charged_op_count: 733,
         },
     ]
 }
@@ -873,7 +872,7 @@ fn league_register_player_runtime_matches_expected_output_state() {
     let layout = player_template_contract.state_layout;
     let player_prefix = player_template_contract.script[..layout.start].to_vec();
     let player_suffix = player_template_contract.script[layout.start + layout.len..].to_vec();
-    let player_template = blake2b_bytes(&[player_prefix.as_slice(), player_suffix.as_slice()].concat());
+    let player_template = Hash::from_bytes(player_template_contract.template_hash());
 
     let league_ctor = vec![
         hash_expr(league_template),
@@ -968,13 +967,7 @@ fn player_start_game_runtime_matches_expected_output_states() {
         },
     );
     let player_layout = player_contract.state_layout;
-    let player_template = blake2b_bytes(
-        &[
-            player_contract.script[..player_layout.start].as_ref(),
-            player_contract.script[player_layout.start + player_layout.len..].as_ref(),
-        ]
-        .concat(),
-    );
+    let player_template = Hash::from_bytes(player_contract.template_hash());
     let player_prefix_len = player_layout.start as i64;
     let player_suffix_len = (player_contract.script.len() - (player_layout.start + player_layout.len)) as i64;
 
@@ -1636,13 +1629,7 @@ fn settle_runtime_matches_expected_output_states() {
         },
     );
     let player_layout = player_contract.state_layout;
-    let player_template = blake2b_bytes(
-        &[
-            player_contract.script[..player_layout.start].as_ref(),
-            player_contract.script[player_layout.start + player_layout.len..].as_ref(),
-        ]
-        .concat(),
-    );
+    let player_template = Hash::from_bytes(player_contract.template_hash());
     let white_player = compile_player_state(
         player_source(),
         PlayerStateArgs {

--- a/silverscript-lang/tests/common.rs
+++ b/silverscript-lang/tests/common.rs
@@ -93,7 +93,6 @@ pub fn compiled_template_parts_and_hash(compiled: &CompiledContract) -> (Vec<u8>
     let layout = compiled.state_layout;
     let prefix = compiled.script[..layout.start].to_vec();
     let suffix = compiled.script[layout.start + layout.len..].to_vec();
-    let template_hash =
-        blake2b_simd::Params::new().hash_length(32).to_state().update(&prefix).update(&suffix).finalize().as_bytes().to_vec();
+    let template_hash = compiled.template_hash().to_vec();
     (prefix, suffix, template_hash)
 }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -8618,6 +8618,22 @@ fn executes_opcode_builtins_basic() {
 }
 
 #[test]
+fn template_hash_binds_prefix_suffix_boundary() {
+    let source = r#"
+        contract Test() {
+            entrypoint function main() {
+                require(templateHash(bytes("a"), bytes("bc")) == templateHash(bytes("a"), bytes("bc")));
+                require(templateHash(bytes("a"), bytes("bc")) != templateHash(bytes("ab"), bytes("c")));
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("templateHash should compile");
+    let result = run_script_with_selector(compiled.script, None);
+    assert!(result.is_ok(), "templateHash should commit to the prefix/suffix boundary: {result:?}");
+}
+
+#[test]
 fn executes_opcode_builtins_covenants() {
     let source = r#"
         contract Test() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -22,6 +22,7 @@ use silverscript_lang::compiler::{
     compile_contract_ast, function_branch_index, generated_covenant_auth_entrypoint_name, struct_object,
 };
 use silverscript_lang::debug_info::StepKind;
+use silverscript_lang::template::template_hash;
 
 use crate::common::compiled_template_parts_and_hash;
 
@@ -5552,6 +5553,76 @@ fn runs_validate_output_state_with_template() {
 }
 
 #[test]
+fn template_hash_matches_both_with_template_builtins() {
+    let target_source = r#"
+        contract Target(int initX) {
+            int x = initX;
+
+            entrypoint function noop() {
+                require(true);
+            }
+        }
+    "#;
+    let target_input = compile_contract(target_source, &[7.into()], CompileOptions::default()).expect("compile target input succeeds");
+    let target_output =
+        compile_contract(target_source, &[8.into()], CompileOptions::default()).expect("compile target output succeeds");
+    let layout = target_input.state_layout;
+    let prefix = &target_input.script[..layout.start];
+    let suffix = &target_input.script[layout.start + layout.len..];
+    let prefix_hex = prefix.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    let suffix_hex = suffix.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+
+    let verifier_source = format!(
+        r#"
+        contract Verifier() {{
+            struct RemoteState {{
+                int x;
+            }}
+
+            entrypoint function main() {{
+                byte[] templatePrefix = 0x{prefix_hex};
+                byte[] templateSuffix = 0x{suffix_hex};
+                byte[32] expectedTemplateHash = templateHash(templatePrefix, templateSuffix);
+
+                RemoteState prev = readInputStateWithTemplate(
+                    1,
+                    {},
+                    {},
+                    expectedTemplateHash
+                );
+                require(prev.x == 7);
+
+                RemoteState next = {{x: 8}};
+                validateOutputStateWithTemplate(
+                    0,
+                    next,
+                    templatePrefix,
+                    templateSuffix,
+                    expectedTemplateHash
+                );
+            }}
+        }}
+    "#,
+        prefix.len(),
+        suffix.len(),
+    );
+    let verifier = compile_contract(&verifier_source, &[], CompileOptions::default()).expect("compile verifier succeeds");
+    let verifier_sigscript = verifier.build_sig_script("main", vec![]).expect("verifier sigscript builds");
+    let verifier_sigscript = pay_to_script_hash_signature_script(verifier.script.clone(), verifier_sigscript).unwrap();
+
+    let verifier_input = test_input(0, verifier_sigscript);
+    let target_input_tx = test_input(1, sigscript_push_script(&target_input.script));
+    let output =
+        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&target_output.script), covenant: None };
+    let tx = Transaction::new(1, vec![verifier_input, target_input_tx], vec![output.clone()], 0, Default::default(), 0, vec![]);
+    let verifier_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&verifier.script), 0, tx.is_coinbase(), None);
+    let target_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&target_input.script), 0, tx.is_coinbase(), None);
+
+    let result = execute_input(tx, vec![verifier_utxo, target_utxo], 0);
+    assert!(result.is_ok(), "templateHash should match both state template builtins: {}", result.unwrap_err());
+}
+
+#[test]
 fn runs_validate_output_state_with_template_using_passed_struct_layout() {
     let target_hash_value = vec![0x44u8; 32];
     let target_hash_hex = target_hash_value.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
@@ -8618,11 +8689,50 @@ fn executes_opcode_builtins_basic() {
 }
 
 #[test]
+fn template_hash_matches_canonical_rust_and_sil_vectors() {
+    let cases: &[(&[u8], &[u8], &str)] = &[
+        (b"", b"", "94c1c088cc9453996779630ad3af45cbd92814828dd784cf2aa12df95d1b8afe"),
+        (b"a", b"bc", "77bbcab7072b897c548327378f11776f4853104c71bdb95a12ded5d2783523bf"),
+        (b"ab", b"c", "20263e794775e4edf2b306c0f306af9e50175c831c857604b481e847f790bf95"),
+        (&[0x00, 0xff], &[0x10, 0x00, 0x80], "81485678b557bcd4a836c2db54ee268e1dc08549f1b8e4d8d67960321b765f25"),
+    ];
+
+    let sil_bytes = |bytes: &[u8]| {
+        if bytes.is_empty() {
+            "bytes(\"\")".to_string()
+        } else {
+            format!("0x{}", bytes.iter().map(|byte| format!("{byte:02x}")).collect::<String>())
+        }
+    };
+
+    for (prefix, suffix, expected_hex) in cases {
+        let mut expected = [0u8; 32];
+        faster_hex::hex_decode(expected_hex.as_bytes(), &mut expected).unwrap();
+        assert_eq!(template_hash(prefix, suffix), expected);
+
+        let prefix = sil_bytes(prefix);
+        let suffix = sil_bytes(suffix);
+        let source = format!(
+            r#"
+            contract Test() {{
+                entrypoint function main() {{
+                    require(templateHash({prefix}, {suffix}) == 0x{expected_hex});
+                }}
+            }}
+        "#
+        );
+
+        let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("templateHash should compile");
+        let result = run_script_with_selector(compiled.script, None);
+        assert!(result.is_ok(), "templateHash should match canonical vector {expected_hex}: {result:?}");
+    }
+}
+
+#[test]
 fn template_hash_binds_prefix_suffix_boundary() {
     let source = r#"
         contract Test() {
             entrypoint function main() {
-                require(templateHash(bytes("a"), bytes("bc")) == templateHash(bytes("a"), bytes("bc")));
                 require(templateHash(bytes("a"), bytes("bc")) != templateHash(bytes("ab"), bytes("c")));
             }
         }

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -72,7 +72,7 @@
 (function_call
   (identifier) @function.builtin
   (#match? @function.builtin
-    "^(readInputState|readInputStateWithTemplate|validateOutputState|validateOutputStateWithTemplate|verifyOutputState|verifyOutputStates|OpSha256|sha256|OpTxSubnetId|OpTxGas|OpTxPayloadLen|OpTxPayloadSubstr|OpOutpointTxId|OpOutpointIndex|OpTxInputScriptSigLen|OpTxInputScriptSigSubstr|OpTxInputSeq|OpTxInputIsCoinbase|OpTxInputSpkLen|OpTxInputSpkSubstr|OpTxOutputSpkLen|OpTxOutputSpkSubstr|OpAuthOutputCount|OpAuthOutputIdx|OpInputCovenantId|OpOutputCovenantId|OpCovInputCount|OpCovInputIdx|OpCovOutputCount|OpCovOutputIdx|OpNum2Bin|OpBin2Num|OpChainblockSeqCommit|checkSigFromStack|checkSigFromStackECDSA|checkSig|checkMultiSig|blake2b)$"))
+    "^(readInputState|readInputStateWithTemplate|validateOutputState|validateOutputStateWithTemplate|verifyOutputState|verifyOutputStates|OpSha256|sha256|OpTxSubnetId|OpTxGas|OpTxPayloadLen|OpTxPayloadSubstr|OpOutpointTxId|OpOutpointIndex|OpTxInputScriptSigLen|OpTxInputScriptSigSubstr|OpTxInputSeq|OpTxInputIsCoinbase|OpTxInputSpkLen|OpTxInputSpkSubstr|OpTxOutputSpkLen|OpTxOutputSpkSubstr|OpAuthOutputCount|OpAuthOutputIdx|OpInputCovenantId|OpOutputCovenantId|OpCovInputCount|OpCovInputIdx|OpCovOutputCount|OpCovOutputIdx|OpNum2Bin|OpBin2Num|OpChainblockSeqCommit|checkSigFromStack|checkSigFromStackECDSA|checkSig|checkMultiSig|blake2b|templateHash)$"))
 
 (unary_suffix) @property
 


### PR DESCRIPTION
This PR changes the canonical template hash from:

`H(prefix || suffix)`

to:

`H(i64le(prefix.length) || prefix || i64le(suffix.length) || suffix)`

Lengths are encoded as fixed-width 8-byte little-endian integers.

This is a breaking change for contracts using `readInputStateWithTemplate` or `validateOutputStateWithTemplate`. Existing template hashes must be recalculated.

The new `templateHash(prefix, suffix)` builtin exposes the canonical calculation to Silverscript contracts. Rust callers can use `template::template_hash(prefix, suffix)` or `CompiledContract::template_hash()`.