### PR TITLE
Expose keyed Blake2b and Blake3 hash builtins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,6 +2942,7 @@ name = "silverscript-lang"
 version = "0.1.0"
 dependencies = [
  "blake2b_simd",
+ "blake3",
  "chrono",
  "clap",
  "faster-hex 0.10.0",

--- a/silverscript-lang/Cargo.toml
+++ b/silverscript-lang/Cargo.toml
@@ -30,5 +30,6 @@ faster-hex = "0.10"
 semver = "1.0"
 
 [dev-dependencies]
+blake3 = "1.8.5"
 kaspa-addresses.workspace = true
 sha2 = "0.10"

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -457,6 +457,9 @@ fn infer_expr_type_ref_for_comparison<'i>(
                 | "datasig"
                 | "bytes"
                 | "blake2b"
+                | "blake2bWithKey"
+                | "blake3"
+                | "blake3WithKey"
                 | "templateHash"
                 | "sha256"
                 | "OpSha256"
@@ -3433,6 +3436,9 @@ fn expr_is_bytes_inner<'i>(expr: &Expr<'i>, types: &HashMap<String, String>, vis
                 name,
                 "bytes"
                     | "blake2b"
+                    | "blake2bWithKey"
+                    | "blake3"
+                    | "blake3WithKey"
                     | "templateHash"
                     | "sha256"
                     | "OpSha256"
@@ -3597,6 +3603,9 @@ fn compile_call_expr<'i>(
             compile_array_cast_call(&mut ctx, name, args)
         }
         "blake2b" => compile_blake2b_call(&mut ctx, args),
+        "blake2bWithKey" => compile_blake2b_with_key_call(&mut ctx, args),
+        "blake3" => compile_blake3_call(&mut ctx, args),
+        "blake3WithKey" => compile_blake3_with_key_call(&mut ctx, args),
         "templateHash" => compile_template_hash_call(&mut ctx, args),
         "checkSig" => compile_checksig_call(&mut ctx, args),
         "checkSigFromStack" => compile_checksigfromstack_call(&mut ctx, name, args, OpCheckSigFromStack),
@@ -3797,6 +3806,37 @@ fn compile_blake2b_call<'i>(ctx: &mut CompileCallContext<'_, 'i>, args: &[Expr<'
     }
     compile_call_arg_with_context(ctx, &args[0])?;
     ctx.builder.add_op(OpBlake2b)?;
+    Ok(())
+}
+
+fn compile_blake2b_with_key_call<'i>(ctx: &mut CompileCallContext<'_, 'i>, args: &[Expr<'i>]) -> Result<(), CompilerError> {
+    let Ok([data, key]): Result<&[Expr<'i>; 2], _> = args.try_into() else {
+        return Err(CompilerError::Unsupported("blake2bWithKey() expects 2 arguments".to_string()));
+    };
+    compile_call_arg_with_context(ctx, data)?;
+    compile_call_arg_with_context(ctx, key)?;
+    ctx.builder.add_op(OpBlake2bWithKey)?;
+    *ctx.stack_depth -= 1;
+    Ok(())
+}
+
+fn compile_blake3_call<'i>(ctx: &mut CompileCallContext<'_, 'i>, args: &[Expr<'i>]) -> Result<(), CompilerError> {
+    if args.len() != 1 {
+        return Err(CompilerError::Unsupported("blake3() expects a single argument".to_string()));
+    }
+    compile_call_arg_with_context(ctx, &args[0])?;
+    ctx.builder.add_op(OpBlake3)?;
+    Ok(())
+}
+
+fn compile_blake3_with_key_call<'i>(ctx: &mut CompileCallContext<'_, 'i>, args: &[Expr<'i>]) -> Result<(), CompilerError> {
+    let Ok([data, key]): Result<&[Expr<'i>; 2], _> = args.try_into() else {
+        return Err(CompilerError::Unsupported("blake3WithKey() expects 2 arguments".to_string()));
+    };
+    compile_call_arg_with_context(ctx, data)?;
+    compile_call_arg_with_context(ctx, key)?;
+    ctx.builder.add_op(OpBlake3WithKey)?;
+    *ctx.stack_depth -= 1;
     Ok(())
 }
 

--- a/silverscript-lang/src/compiler/debug_value_types.rs
+++ b/silverscript-lang/src/compiler/debug_value_types.rs
@@ -55,7 +55,7 @@ fn builtin_call_value_type(name: &str) -> &'static str {
         | "OpCovOutputCount"
         | "OpCovOutputIdx" => "int",
         "OpTxInputIsCoinbase" | "checkSig" | "checkSigFromStack" | "checkSigFromStackECDSA" => "bool",
-        "blake2b" | "templateHash" | "sha256" | "OpSha256" => "byte[32]",
+        "blake2b" | "blake2bWithKey" | "blake3" | "blake3WithKey" | "templateHash" | "sha256" | "OpSha256" => "byte[32]",
         "bytes"
         | "OpTxSubnetId"
         | "OpTxPayloadSubstr"

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -1389,10 +1389,7 @@ fn validate_builtin_call<'i>(
         // TODO: Use constants for all builtins
         "checkSigFromStack" => &[("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "pubkey")],
         "checkSigFromStackECDSA" => &[("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "byte[33]")],
-        // TODO: Consider requiring byte[] data for all hash builtins so callers
-        // must make their serialization choices explicit; numeric values currently
-        // hash their minimally encoded Script-number bytes.
-        "blake3WithKey" => &[("data", "*"), ("key", "byte[32]")],
+        "blake3WithKey" => &[("data", "byte[]"), ("key", "byte[32]")],
         _ => return Ok(()),
     };
     if args.len() != expected_args.len() {
@@ -1400,9 +1397,6 @@ fn validate_builtin_call<'i>(
     }
 
     for (arg, &(arg_name, expected_type_name)) in args.iter().zip(expected_args) {
-        if expected_type_name == "*" {
-            continue;
-        }
         let expected_type = parse_type_ref(expected_type_name)?;
         let actual_type =
             infer_expr_type_ref_for_comparison_ref(arg, env, prefer_env_for_comparison, types, structs, functions, contract_fields)

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -1385,17 +1385,24 @@ fn validate_builtin_call<'i>(
     functions: &HashMap<String, &FunctionAst<'i>>,
     contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
-    let expected_args = match name {
+    let expected_args: &[(&str, &str)] = match name {
         // TODO: Use constants for all builtins
-        "checkSigFromStack" => [("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "pubkey")],
-        "checkSigFromStackECDSA" => [("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "byte[33]")],
+        "checkSigFromStack" => &[("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "pubkey")],
+        "checkSigFromStackECDSA" => &[("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "byte[33]")],
+        // TODO: Consider requiring byte[] data for all hash builtins so callers
+        // must make their serialization choices explicit; numeric values currently
+        // hash their minimally encoded Script-number bytes.
+        "blake3WithKey" => &[("data", "*"), ("key", "byte[32]")],
         _ => return Ok(()),
     };
     if args.len() != expected_args.len() {
         return Err(CompilerError::Unsupported(format!("{name}() expects {} arguments", expected_args.len())));
     }
 
-    for (arg, (arg_name, expected_type_name)) in args.iter().zip(expected_args) {
+    for (arg, &(arg_name, expected_type_name)) in args.iter().zip(expected_args) {
+        if expected_type_name == "*" {
+            continue;
+        }
         let expected_type = parse_type_ref(expected_type_name)?;
         let actual_type =
             infer_expr_type_ref_for_comparison_ref(arg, env, prefer_env_for_comparison, types, structs, functions, contract_fields)

--- a/silverscript-lang/std/builtins.sil
+++ b/silverscript-lang/std/builtins.sil
@@ -164,3 +164,54 @@ function readInputStateWithTemplate(
  *     because it does not commit to the prefix/suffix boundary.
  */
 function templateHash(byte[] templatePrefix, byte[] templateSuffix) : (byte[32]);
+
+/**
+ * Role:
+ *      Calculate a Blake2b-256 hash.
+ *
+ * Definition:
+ *      Hash `data` with Blake2b and return 32 bytes.
+ *
+ * Example:
+ * ```js
+ * byte[32] digest = blake2b(message);
+ * ```
+ */
+function blake2b(byte[] data) : (byte[32]);
+
+/**
+ * Role:
+ *      Calculate a keyed Blake2b-256 hash.
+ *
+ * Definition:
+ *      Hash `data` with the supplied Blake2b key and return 32 bytes.
+ *      The key may contain at most 64 bytes.
+ *
+ * Example:
+ * ```js
+ * byte[32] id = blake2bWithKey(preimage, bytes("CovenantID"));
+ * ```
+ *
+ * Security notes:
+ *   - Keyed Blake2b is also used for protocol domain separation. The key must
+ *     exactly match the domain defined by the protocol being reconstructed.
+ */
+function blake2bWithKey(byte[] data, byte[] key) : (byte[32]);
+
+/**
+ * Role:
+ *      Calculate a Blake3 hash.
+ *
+ * Definition:
+ *      Hash `data` with Blake3 and return 32 bytes.
+ */
+function blake3(byte[] data) : (byte[32]);
+
+/**
+ * Role:
+ *      Calculate a keyed Blake3 hash.
+ *
+ * Definition:
+ *      Hash `data` with the supplied 32-byte Blake3 key and return 32 bytes.
+ */
+function blake3WithKey(byte[] data, byte[32] key) : (byte[32]);

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -11036,3 +11036,87 @@ fn validate_output_state_with_template_preserves_nested_struct_field_paths() {
     let result = execute_input(tx, vec![utxo_entry], 0);
     assert!(result.is_ok(), "nested struct fields with the same leaf name should remain distinct by path: {result:?}");
 }
+
+#[test]
+fn blake2b_builtins_lower_and_execute_correctly() {
+    let data = b"genesis covenant";
+    let key = b"CovenantID";
+    let expected = blake2b_simd::Params::new().hash_length(32).hash(data);
+    let expected_keyed = blake2b_simd::Params::new().hash_length(32).key(key).hash(data);
+    let expected_hex = expected.as_bytes().iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    let expected_keyed_hex = expected_keyed.as_bytes().iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    let source = format!(
+        r#"
+        contract Blake2bHashes() {{
+            entrypoint function main() {{
+                require(blake2b(bytes("genesis covenant")) == 0x{expected_hex});
+                require(blake2bWithKey(bytes("genesis covenant"), bytes("CovenantID")) == 0x{expected_keyed_hex});
+            }}
+        }}
+        "#
+    );
+
+    let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("Blake2b builtins compile");
+    assert!(compiled.script.contains(&OpBlake2b));
+    assert!(compiled.script.contains(&OpBlake2bWithKey));
+    let result = run_script_with_selector(compiled.script, None);
+    assert!(result.is_ok(), "Blake2b builtins should execute correctly: {result:?}");
+}
+
+#[test]
+fn blake3_builtins_lower_and_execute_correctly() {
+    let data = b"genesis covenant";
+    let key = std::array::from_fn(|i| i as u8);
+    let expected = blake3::hash(data);
+    let expected_keyed = blake3::keyed_hash(&key, data);
+    let key_hex = key.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
+    let expected_hex = expected.to_hex();
+    let expected_keyed_hex = expected_keyed.to_hex();
+    let source = format!(
+        r#"
+        contract Blake3Hashes() {{
+            entrypoint function main() {{
+                require(blake3(bytes("genesis covenant")) == 0x{expected_hex});
+                require(blake3WithKey(bytes("genesis covenant"), 0x{key_hex}) == 0x{expected_keyed_hex});
+            }}
+        }}
+        "#
+    );
+
+    let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("Blake3 builtins compile");
+    assert!(compiled.script.contains(&OpBlake3));
+    assert!(compiled.script.contains(&OpBlake3WithKey));
+    let result = run_script_with_selector(compiled.script, None);
+    assert!(result.is_ok(), "Blake3 builtins should call the engine correctly: {result:?}");
+}
+
+#[test]
+fn blake3_with_key_requires_a_fixed_32_byte_key() {
+    let dynamic_key = r#"
+        contract Blake3Hash() {
+            entrypoint function main(byte[] key) {
+                require(blake3WithKey(bytes("data"), key).length == 32);
+            }
+        }
+    "#;
+    let err = compile_contract(dynamic_key, &[], CompileOptions::default()).expect_err("dynamic Blake3 key should be rejected");
+    assert!(err.to_string().contains("argument 'key' expects byte[32]"), "unexpected error: {err}");
+
+    let explicit_cast = r#"
+        contract Blake3Hash() {
+            entrypoint function main(byte[] key) {
+                require(blake3WithKey(bytes("data"), byte[32](key)).length == 32);
+            }
+        }
+    "#;
+    compile_contract(explicit_cast, &[], CompileOptions::default()).expect("explicit byte[32] key cast should compile");
+
+    let numeric_data = r#"
+        contract Blake3Hash() {
+            entrypoint function main(byte[32] key) {
+                require(blake3WithKey(5, key).length == 32);
+            }
+        }
+    "#;
+    compile_contract(numeric_data, &[], CompileOptions::default()).expect("key validation should not constrain hash data");
+}

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -11118,5 +11118,6 @@ fn blake3_with_key_requires_a_fixed_32_byte_key() {
             }
         }
     "#;
-    compile_contract(numeric_data, &[], CompileOptions::default()).expect("key validation should not constrain hash data");
+    let err = compile_contract(numeric_data, &[], CompileOptions::default()).expect_err("numeric Blake3 data should be rejected");
+    assert!(err.to_string().contains("argument 'data' expects byte[], got int"), "unexpected error: {err}");
 }

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -72,7 +72,7 @@
 (function_call
   (identifier) @function.builtin
   (#match? @function.builtin
-    "^(readInputState|readInputStateWithTemplate|validateOutputState|validateOutputStateWithTemplate|verifyOutputState|verifyOutputStates|OpSha256|sha256|OpTxSubnetId|OpTxGas|OpTxPayloadLen|OpTxPayloadSubstr|OpOutpointTxId|OpOutpointIndex|OpTxInputScriptSigLen|OpTxInputScriptSigSubstr|OpTxInputSeq|OpTxInputIsCoinbase|OpTxInputSpkLen|OpTxInputSpkSubstr|OpTxOutputSpkLen|OpTxOutputSpkSubstr|OpAuthOutputCount|OpAuthOutputIdx|OpInputCovenantId|OpOutputCovenantId|OpCovInputCount|OpCovInputIdx|OpCovOutputCount|OpCovOutputIdx|OpNum2Bin|OpBin2Num|OpChainblockSeqCommit|checkSigFromStack|checkSigFromStackECDSA|checkSig|checkMultiSig|blake2b|templateHash)$"))
+    "^(readInputState|readInputStateWithTemplate|validateOutputState|validateOutputStateWithTemplate|verifyOutputState|verifyOutputStates|OpSha256|sha256|OpTxSubnetId|OpTxGas|OpTxPayloadLen|OpTxPayloadSubstr|OpOutpointTxId|OpOutpointIndex|OpTxInputScriptSigLen|OpTxInputScriptSigSubstr|OpTxInputSeq|OpTxInputIsCoinbase|OpTxInputSpkLen|OpTxInputSpkSubstr|OpTxOutputSpkLen|OpTxOutputSpkSubstr|OpAuthOutputCount|OpAuthOutputIdx|OpInputCovenantId|OpOutputCovenantId|OpCovInputCount|OpCovInputIdx|OpCovOutputCount|OpCovOutputIdx|OpNum2Bin|OpBin2Num|OpChainblockSeqCommit|checkSigFromStack|checkSigFromStackECDSA|checkSig|checkMultiSig|blake2b|blake2bWithKey|blake3|blake3WithKey|templateHash)$"))
 
 (unary_suffix) @property
 


### PR DESCRIPTION
Adds direct compiler support for:

```js
blake2bWithKey(data, key)
blake3(data)
blake3WithKey(data, key)
```

All return `byte[32]` and lower to the corresponding script-engine opcodes. The existing `blake2b` builtin is documented alongside them.

Type details:

- Hash data follows existing `blake2b` behavior and may be any stack value. Callers remain responsible for serialization; numeric values use minimally encoded Script-number bytes (see TODO in `static_check.rs`)
- Blake2b keys are variable-length `byte[]`, up to the engine’s 64-byte limit.
- Blake3 keys must be `byte[32]`. A dynamic `byte[]` requires an explicit `byte[32](key)` cast.

Tests compare the compiled builtins against reference Blake2b and Blake3 implementations and execute the resulting scripts.