### PR TITLE
Enforce exact type equality during static checking

### DIFF
--- a/debugger/cli/src/main.rs
+++ b/debugger/cli/src/main.rs
@@ -145,21 +145,6 @@ fn is_state_array_type(type_ref: &TypeRef) -> bool {
         && matches!(type_ref.array_dims.as_slice(), [ArrayDim::Dynamic])
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn state_array_type_requires_one_dynamic_dimension() {
-        let state = || TypeBase::Custom("State".to_string());
-
-        assert!(is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Dynamic] }));
-        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: Vec::new() }));
-        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Fixed(2)] }));
-        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Dynamic, ArrayDim::Dynamic] }));
-    }
-}
-
 fn synthesized_covenant_prefix_args(
     compiled: &CompiledContract<'_>,
     entrypoint_name: &str,
@@ -1019,5 +1004,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         show_step_view(&session, &console_output);
         run_repl(&mut session, &mut pending_console_output)?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_array_type_requires_one_dynamic_dimension() {
+        let state = || TypeBase::Custom("State".to_string());
+
+        assert!(is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Dynamic] }));
+        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: Vec::new() }));
+        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Fixed(2)] }));
+        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Dynamic, ArrayDim::Dynamic] }));
     }
 }

--- a/debugger/cli/src/main.rs
+++ b/debugger/cli/src/main.rs
@@ -23,7 +23,7 @@ use kaspa_txscript::caches::Cache;
 use kaspa_txscript::covenants::CovenantsContext;
 use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::{EngineCtx, EngineFlags, pay_to_script_hash_script};
-use silverscript_lang::ast::{ContractAst, Expr, ExprKind, StateFieldExpr, TypeBase, TypeRef, parse_contract_ast};
+use silverscript_lang::ast::{ArrayDim, ContractAst, Expr, ExprKind, StateFieldExpr, TypeBase, TypeRef, parse_contract_ast};
 use silverscript_lang::compiler::{CompileOptions, CompiledContract, compile_contract, compile_contract_ast};
 
 const PROMPT: &str = "(sdb) ";
@@ -136,12 +136,28 @@ fn debug_value_to_expr(value: &DebugValue) -> Option<Expr<'static>> {
     })
 }
 
-fn is_state_type_ref(type_ref: &TypeRef) -> bool {
-    !type_ref.is_array() && matches!(&type_ref.base, TypeBase::Custom(name) if name == "State")
+fn is_state_type(type_ref: &TypeRef) -> bool {
+    type_ref.is_custom() && matches!(&type_ref.base, TypeBase::Custom(name) if name == "State")
 }
 
-fn is_state_array_type_ref(type_ref: &TypeRef) -> bool {
-    type_ref.is_array() && matches!(&type_ref.base, TypeBase::Custom(name) if name == "State")
+fn is_state_array_type(type_ref: &TypeRef) -> bool {
+    matches!(&type_ref.base, TypeBase::Custom(name) if name == "State")
+        && matches!(type_ref.array_dims.as_slice(), [ArrayDim::Dynamic])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_array_type_requires_one_dynamic_dimension() {
+        let state = || TypeBase::Custom("State".to_string());
+
+        assert!(is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Dynamic] }));
+        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: Vec::new() }));
+        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Fixed(2)] }));
+        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Dynamic, ArrayDim::Dynamic] }));
+    }
 }
 
 fn synthesized_covenant_prefix_args(
@@ -165,13 +181,13 @@ fn synthesized_covenant_prefix_args(
     };
 
     let states = output_states.ok_or("missing output states needed to synthesize covenant verification arguments")?;
-    if is_state_type_ref(&first_param.type_ref) {
+    if is_state_type(&first_param.type_ref) {
         if states.len() != 1 {
             return Err(format!("expected exactly 1 output State for '{entrypoint_name}', got {}", states.len()).into());
         }
         return Ok(vec![debug_value_to_expr(&states[0]).ok_or("failed to materialize synthesized output State")?]);
     }
-    if is_state_array_type_ref(&first_param.type_ref) {
+    if is_state_array_type(&first_param.type_ref) {
         return Ok(vec![Expr::new(
             ExprKind::Array(
                 states

--- a/debugger/session/src/args.rs
+++ b/debugger/session/src/args.rs
@@ -139,7 +139,7 @@ fn parse_scalar_arg(type_ref: &TypeRef, raw: &str) -> Result<Expr<'static>, Stri
             }
             Ok(bytes_expr(bytes))
         }
-        TypeBase::Custom(_) => Err(format!("unsupported arg type '{}'", type_ref.type_name())),
+        TypeBase::Tuple(_) | TypeBase::Custom(_) => Err(format!("unsupported arg type '{}'", type_ref.type_name())),
     }
 }
 

--- a/debugger/session/src/args.rs
+++ b/debugger/session/src/args.rs
@@ -120,22 +120,25 @@ fn parse_scalar_arg(type_ref: &TypeRef, raw: &str) -> Result<Expr<'static>, Stri
         }
         TypeBase::Pubkey => {
             let bytes = parse_hex_bytes(raw)?;
-            if bytes.len() != 32 {
-                return Err(format!("pubkey expects 32 bytes, got {}", bytes.len()));
+            let expected = type_ref.base.fixed_byte_sequence_len().expect("pubkey has a fixed byte length");
+            if bytes.len() != expected {
+                return Err(format!("pubkey expects {expected} bytes, got {}", bytes.len()));
             }
             Ok(bytes_expr(bytes))
         }
         TypeBase::Sig => {
             let bytes = parse_hex_bytes(raw)?;
-            if bytes.len() != 65 && bytes.len() != 32 {
-                return Err(format!("sig expects 65 bytes (or 32-byte secret key for auto-sign), got {}", bytes.len()));
+            let expected = type_ref.base.fixed_byte_sequence_len().expect("sig has a fixed byte length");
+            if bytes.len() != expected {
+                return Err(format!("sig expects {expected} bytes, got {}", bytes.len()));
             }
             Ok(bytes_expr(bytes))
         }
         TypeBase::Datasig => {
             let bytes = parse_hex_bytes(raw)?;
-            if bytes.len() != 64 && bytes.len() != 32 {
-                return Err(format!("datasig expects 64 bytes (or 32-byte secret key for auto-sign), got {}", bytes.len()));
+            let expected = type_ref.base.fixed_byte_sequence_len().expect("datasig has a fixed byte length");
+            if bytes.len() != expected {
+                return Err(format!("datasig expects {expected} bytes, got {}", bytes.len()));
             }
             Ok(bytes_expr(bytes))
         }
@@ -205,15 +208,13 @@ fn parse_json_value_for_type(value: &Value, type_ref: &TypeRef, shapes: &StructS
 
     match value {
         Value::String(raw) => parse_scalar_arg(type_ref, raw),
-        Value::Number(raw) if matches!(type_ref.base, TypeBase::Int) => {
-            Ok(Expr::int(raw.as_i64().ok_or_else(|| "invalid int value".to_string())?))
-        }
-        Value::Number(raw) if matches!(type_ref.base, TypeBase::Byte) => {
+        Value::Number(raw) if type_ref.is_int() => Ok(Expr::int(raw.as_i64().ok_or_else(|| "invalid int value".to_string())?)),
+        Value::Number(raw) if type_ref.is_byte() => {
             let byte_value = raw.as_u64().ok_or_else(|| "invalid byte value".to_string())?;
             let byte = u8::try_from(byte_value).map_err(|_| format!("byte expects value in 0..=255, got {byte_value}"))?;
             Ok(Expr::byte(byte))
         }
-        Value::Bool(raw) if matches!(type_ref.base, TypeBase::Bool) => Ok(Expr::bool(*raw)),
+        Value::Bool(raw) if type_ref.is_bool() => Ok(Expr::bool(*raw)),
         _ => Err(format!("unsupported arg value for '{}'", type_ref.type_name())),
     }
 }

--- a/debugger/session/src/session.rs
+++ b/debugger/session/src/session.rs
@@ -190,7 +190,7 @@ type ScopeState<'i> = HashMap<String, ScopeBinding<'i>>;
 type ShadowBindings = Vec<ShadowBindingValue>;
 type EvalEnv<'i> = HashMap<String, Expr<'i>>;
 type StackBindings = HashMap<String, i64>;
-type EvalTypes = HashMap<String, String>;
+type EvalTypes = HashMap<String, TypeRef>;
 type ShadowResolution<'i> = (ShadowBindings, EvalEnv<'i>, StackBindings, EvalTypes);
 
 impl<'a, 'i> DebugSession<'a, 'i> {
@@ -1651,7 +1651,10 @@ impl<'a, 'i> DebugSession<'a, 'i> {
         let mut eval_types = HashMap::new();
 
         for (name, binding) in scope_state {
-            eval_types.insert(name.clone(), binding.type_name.clone());
+            eval_types.insert(
+                name.clone(),
+                parse_type_ref(&binding.type_name).map_err(|err| format!("invalid debug type '{}': {err}", binding.type_name))?,
+            );
             match &binding.source {
                 ScopeValueSource::RuntimeSlot { from_top } => {
                     shadow_by_name.insert(
@@ -2330,7 +2333,7 @@ fn is_inline_synthetic_name(name: &str) -> bool {
 }
 
 fn is_structured_type_name(type_name: &str) -> bool {
-    parse_type_ref(type_name).ok().is_some_and(|type_ref| is_structured_type_ref(&type_ref))
+    parse_type_ref(type_name).ok().is_some_and(|type_ref| is_structured_type(&type_ref))
 }
 
 fn direct_expr_type_name<'i>(scope_state: &ScopeState<'i>, expr: &Expr<'i>) -> Option<String> {
@@ -2345,9 +2348,8 @@ fn direct_expr_type_name<'i>(scope_state: &ScopeState<'i>, expr: &Expr<'i>) -> O
     }
 }
 
-fn is_structured_type_ref(type_ref: &silverscript_lang::ast::TypeRef) -> bool {
-    matches!(&type_ref.base, TypeBase::Custom(_))
-        || type_ref.array_element_type().is_some_and(|element| is_structured_type_ref(&element))
+fn is_structured_type(type_ref: &silverscript_lang::ast::TypeRef) -> bool {
+    type_ref.is_custom() || type_ref.array_element_type().is_some_and(|element| is_structured_type(&element))
 }
 
 fn record_debug_named_values<'i>(bindings: &mut ScopeState<'i>, values: &[DebugNamedValue<'i>], origin: VariableOrigin) {

--- a/extensions/silverscript.nvim/queries/silverscript/highlights.scm
+++ b/extensions/silverscript.nvim/queries/silverscript/highlights.scm
@@ -15,7 +15,7 @@
 (instantiation
   (identifier) @type.builtin
   (#match? @type.builtin
-    "^(LockingBytecodeNullData|ScriptPubKeyP2PK|ScriptPubKeyP2SH|ScriptPubKeyP2SHFromRedeemScript)$"))
+    "^(ScriptPubKeyP2PK|ScriptPubKeyP2SH|ScriptPubKeyP2SHFromRedeemScript)$"))
 
 (instantiation
   (identifier) @type)

--- a/extensions/vscode/queries/highlights.scm
+++ b/extensions/vscode/queries/highlights.scm
@@ -15,7 +15,7 @@
 (instantiation
   (identifier) @type.builtin
   (#match? @type.builtin
-    "^(LockingBytecodeNullData|ScriptPubKeyP2PK|ScriptPubKeyP2SH|ScriptPubKeyP2SHFromRedeemScript)$"))
+    "^(ScriptPubKeyP2PK|ScriptPubKeyP2SH|ScriptPubKeyP2SHFromRedeemScript)$"))
 
 (instantiation
   (identifier) @type)

--- a/extensions/zed/languages/silverscript/highlights.scm
+++ b/extensions/zed/languages/silverscript/highlights.scm
@@ -15,7 +15,7 @@
 (instantiation
   (identifier) @type.builtin
   (#match? @type.builtin
-    "^(LockingBytecodeNullData|ScriptPubKeyP2PK|ScriptPubKeyP2SH|ScriptPubKeyP2SHFromRedeemScript)$"))
+    "^(ScriptPubKeyP2PK|ScriptPubKeyP2SH|ScriptPubKeyP2SHFromRedeemScript)$"))
 
 (instantiation
   (identifier) @type)

--- a/silverscript-lang/src/ast/mod.rs
+++ b/silverscript-lang/src/ast/mod.rs
@@ -118,6 +118,16 @@ pub struct FunctionAst<'i> {
     pub body_span: Span<'i>,
 }
 
+impl FunctionAst<'_> {
+    pub fn return_type_ref(&self) -> Option<TypeRef> {
+        match self.return_types.as_slice() {
+            [] => None,
+            [single] if !self.returns_tuple => Some(single.clone()),
+            elements => Some(TypeRef::tuple(elements.to_vec())),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FunctionAttributeAst<'i> {
     pub path: Vec<String>,
@@ -182,20 +192,24 @@ pub enum TypeBase {
     Sig,
     Datasig,
     Byte,
+    Tuple(Vec<TypeRef>),
     Custom(String),
 }
 
 impl TypeBase {
-    pub fn as_str(&self) -> &str {
+    pub fn type_name(&self) -> String {
         match self {
-            TypeBase::Int => "int",
-            TypeBase::Bool => "bool",
-            TypeBase::String => "string",
-            TypeBase::Pubkey => "pubkey",
-            TypeBase::Sig => "sig",
-            TypeBase::Datasig => "datasig",
-            TypeBase::Byte => "byte",
-            TypeBase::Custom(name) => name,
+            TypeBase::Int => "int".to_string(),
+            TypeBase::Bool => "bool".to_string(),
+            TypeBase::String => "string".to_string(),
+            TypeBase::Pubkey => "pubkey".to_string(),
+            TypeBase::Sig => "sig".to_string(),
+            TypeBase::Datasig => "datasig".to_string(),
+            TypeBase::Byte => "byte".to_string(),
+            TypeBase::Tuple(elements) => {
+                format!("({})", elements.iter().map(TypeRef::type_name).collect::<Vec<_>>().join(", "))
+            }
+            TypeBase::Custom(name) => name.clone(),
         }
     }
 }
@@ -205,7 +219,7 @@ impl Serialize for TypeBase {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.as_str())
+        serializer.serialize_str(&self.type_name())
     }
 }
 
@@ -223,6 +237,7 @@ impl<'de> Deserialize<'de> for TypeBase {
             "sig" => TypeBase::Sig,
             "datasig" => TypeBase::Datasig,
             "byte" => TypeBase::Byte,
+            value if value.starts_with('(') && value.ends_with(')') => parse_type_ref(value).map_err(serde::de::Error::custom)?.base,
             other => TypeBase::Custom(other.to_string()),
         })
     }
@@ -239,7 +254,7 @@ pub enum ArrayDim {
 
 impl TypeRef {
     pub fn type_name(&self) -> String {
-        let mut out = self.base.as_str().to_string();
+        let mut out = self.base.type_name();
         for dim in &self.array_dims {
             match dim {
                 ArrayDim::Dynamic => out.push_str("[]"),
@@ -272,6 +287,20 @@ impl TypeRef {
 
     pub fn array_size(&self) -> Option<&ArrayDim> {
         self.array_dims.last()
+    }
+
+    pub fn tuple(elements: Vec<TypeRef>) -> Self {
+        Self { base: TypeBase::Tuple(elements), array_dims: Vec::new() }
+    }
+
+    pub fn tuple_elements(&self) -> Option<&[TypeRef]> {
+        if self.is_array() {
+            return None;
+        }
+        match &self.base {
+            TypeBase::Tuple(elements) => Some(elements),
+            _ => None,
+        }
     }
 }
 
@@ -1178,9 +1207,40 @@ fn unary_suffix_str(kind: UnarySuffixKind) -> &'static str {
 }
 
 pub fn parse_type_ref(type_name: &str) -> Result<TypeRef, CompilerError> {
+    let type_name = type_name.trim();
+    if type_name.starts_with('(') && type_name.ends_with(')') {
+        let inner = &type_name[1..type_name.len() - 1];
+        let elements = split_tuple_type_names(inner).into_iter().map(parse_type_ref).collect::<Result<Vec<_>, _>>()?;
+        if elements.is_empty() {
+            return Err(CompilerError::Unsupported("tuple type must contain at least one element".to_string()));
+        }
+        return Ok(TypeRef::tuple(elements));
+    }
     let mut pairs = parse_type_name_rule(type_name)?;
     let pair = pairs.next().ok_or_else(|| CompilerError::Unsupported("missing type name".to_string()))?;
     parse_type_name_pair(pair)
+}
+
+fn split_tuple_type_names(value: &str) -> Vec<&str> {
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    let mut parts = Vec::new();
+    for (index, ch) in value.char_indices() {
+        match ch {
+            '(' | '[' => depth += 1,
+            ')' | ']' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                parts.push(value[start..index].trim());
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    let tail = value[start..].trim();
+    if !tail.is_empty() {
+        parts.push(tail);
+    }
+    parts
 }
 
 fn parse_type_name_pair(pair: Pair<'_, Rule>) -> Result<TypeRef, CompilerError> {

--- a/silverscript-lang/src/ast/mod.rs
+++ b/silverscript-lang/src/ast/mod.rs
@@ -119,7 +119,7 @@ pub struct FunctionAst<'i> {
 }
 
 impl FunctionAst<'_> {
-    pub fn return_type_ref(&self) -> Option<TypeRef> {
+    pub fn return_type(&self) -> Option<TypeRef> {
         match self.return_types.as_slice() {
             [] => None,
             [single] if !self.returns_tuple => Some(single.clone()),
@@ -196,7 +196,20 @@ pub enum TypeBase {
     Custom(String),
 }
 
+pub const PUBKEY_BYTE_LEN: usize = 32;
+pub const SIG_BYTE_LEN: usize = 65;
+pub const DATASIG_BYTE_LEN: usize = 64;
+
 impl TypeBase {
+    pub fn fixed_byte_sequence_len(&self) -> Option<usize> {
+        match self {
+            TypeBase::Pubkey => Some(PUBKEY_BYTE_LEN),
+            TypeBase::Sig => Some(SIG_BYTE_LEN),
+            TypeBase::Datasig => Some(DATASIG_BYTE_LEN),
+            _ => None,
+        }
+    }
+
     pub fn type_name(&self) -> String {
         match self {
             TypeBase::Int => "int".to_string(),
@@ -253,6 +266,42 @@ pub enum ArrayDim {
 }
 
 impl TypeRef {
+    pub fn is_int(&self) -> bool {
+        self.array_dims.is_empty() && matches!(self.base, TypeBase::Int)
+    }
+
+    pub fn is_bool(&self) -> bool {
+        self.array_dims.is_empty() && matches!(self.base, TypeBase::Bool)
+    }
+
+    pub fn is_string(&self) -> bool {
+        self.array_dims.is_empty() && matches!(self.base, TypeBase::String)
+    }
+
+    pub fn is_pubkey(&self) -> bool {
+        self.array_dims.is_empty() && matches!(self.base, TypeBase::Pubkey)
+    }
+
+    pub fn is_sig(&self) -> bool {
+        self.array_dims.is_empty() && matches!(self.base, TypeBase::Sig)
+    }
+
+    pub fn is_datasig(&self) -> bool {
+        self.array_dims.is_empty() && matches!(self.base, TypeBase::Datasig)
+    }
+
+    pub fn is_byte(&self) -> bool {
+        self.array_dims.is_empty() && matches!(self.base, TypeBase::Byte)
+    }
+
+    pub fn is_tuple(&self) -> bool {
+        self.array_dims.is_empty() && matches!(self.base, TypeBase::Tuple(_))
+    }
+
+    pub fn is_custom(&self) -> bool {
+        self.array_dims.is_empty() && matches!(self.base, TypeBase::Custom(_))
+    }
+
     pub fn type_name(&self) -> String {
         let mut out = self.base.type_name();
         for dim in &self.array_dims {

--- a/silverscript-lang/src/compiler/builtin_types.rs
+++ b/silverscript-lang/src/compiler/builtin_types.rs
@@ -1,0 +1,84 @@
+use crate::ast::{IntrospectionKind, NullaryOp, TypeRef, parse_type_ref};
+
+pub(super) fn nullary_type(op: NullaryOp) -> TypeRef {
+    parse_type_ref(match op {
+        NullaryOp::ActiveScriptPubKey | NullaryOp::ThisScriptSizeDataPrefix => "byte[]",
+        NullaryOp::ActiveInputIndex
+        | NullaryOp::ThisScriptSize
+        | NullaryOp::TxInputsLength
+        | NullaryOp::TxOutputsLength
+        | NullaryOp::TxVersion
+        | NullaryOp::TxLockTime => "int",
+    })
+    .expect("builtin type is valid")
+}
+
+pub(super) fn introspection_type(kind: IntrospectionKind) -> TypeRef {
+    parse_type_ref(match kind {
+        IntrospectionKind::InputScriptPubKey
+        | IntrospectionKind::InputSigScript
+        | IntrospectionKind::InputOutpointTransactionHash
+        | IntrospectionKind::OutputScriptPubKey => "byte[]",
+        IntrospectionKind::InputValue
+        | IntrospectionKind::InputOutpointIndex
+        | IntrospectionKind::InputSequenceNumber
+        | IntrospectionKind::OutputValue => "int",
+    })
+    .expect("builtin type is valid")
+}
+
+pub(super) fn builtin_return_type(name: &str) -> Option<TypeRef> {
+    let name = match name {
+        "int" | "bool" | "byte" | "string" | "pubkey" | "sig" | "datasig" => name,
+        "OpBin2Num"
+        | "OpTxInputDaaScore"
+        | "OpTxGas"
+        | "OpTxPayloadLen"
+        | "OpTxInputIndex"
+        | "OpTxInputScriptSigLen"
+        | "OpTxInputSpkLen"
+        | "OpOutpointIndex"
+        | "OpTxOutputSpkLen"
+        | "OpAuthOutputCount"
+        | "OpAuthOutputIdx"
+        | "OpCovInputCount"
+        | "OpCovInputIdx"
+        | "OpCovOutputCount"
+        | "OpCovOutputIdx" => "int",
+        "OpTxInputIsCoinbase" | "checkSig" | "checkSigFromStack" | "checkSigFromStackECDSA" => "bool",
+        "blake2b" | "blake2bWithKey" | "blake3" | "blake3WithKey" | "templateHash" | "sha256" | "OpSha256" => "byte[32]",
+        "OpInputCovenantId" | "OpOutputCovenantId" => "byte[32]",
+        "bytes"
+        | "OpTxSubnetId"
+        | "OpTxPayloadSubstr"
+        | "OpOutpointTxId"
+        | "OpTxInputScriptSigSubstr"
+        | "OpTxInputSeq"
+        | "OpTxInputSpkSubstr"
+        | "OpTxOutputSpkSubstr"
+        | "OpNum2Bin"
+        | "OpChainblockSeqCommit"
+        | "LockingBytecodeNullData" => "byte[]",
+        _ => return None,
+    };
+    parse_type_ref(name).ok()
+}
+
+pub(super) fn constructor_return_type(name: &str) -> Option<TypeRef> {
+    parse_type_ref(match name {
+        "LockingBytecodeNullData" => "byte[]",
+        "ScriptPubKeyP2PK" => "byte[34]",
+        "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript" => "byte[35]",
+        _ => return None,
+    })
+    .ok()
+}
+
+pub(super) fn builtin_parameters(name: &str) -> Option<&'static [(&'static str, &'static str)]> {
+    match name {
+        "checkSigFromStack" => Some(&[("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "pubkey")]),
+        "checkSigFromStackECDSA" => Some(&[("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "byte[33]")]),
+        "blake3WithKey" => Some(&[("data", "byte[]"), ("key", "byte[32]")]),
+        _ => None,
+    }
+}

--- a/silverscript-lang/src/compiler/builtin_types.rs
+++ b/silverscript-lang/src/compiler/builtin_types.rs
@@ -1,35 +1,47 @@
-use crate::ast::{IntrospectionKind, NullaryOp, TypeRef, parse_type_ref};
+use crate::ast::{ArrayDim, IntrospectionKind, NullaryOp, TypeBase, TypeRef};
+
+fn scalar(base: TypeBase) -> TypeRef {
+    TypeRef { base, array_dims: Vec::new() }
+}
+
+fn byte_array(dimension: ArrayDim) -> TypeRef {
+    TypeRef { base: TypeBase::Byte, array_dims: vec![dimension] }
+}
 
 pub(super) fn nullary_type(op: NullaryOp) -> TypeRef {
-    parse_type_ref(match op {
-        NullaryOp::ActiveScriptPubKey | NullaryOp::ThisScriptSizeDataPrefix => "byte[]",
+    match op {
+        NullaryOp::ActiveScriptPubKey | NullaryOp::ThisScriptSizeDataPrefix => byte_array(ArrayDim::Dynamic),
         NullaryOp::ActiveInputIndex
         | NullaryOp::ThisScriptSize
         | NullaryOp::TxInputsLength
         | NullaryOp::TxOutputsLength
         | NullaryOp::TxVersion
-        | NullaryOp::TxLockTime => "int",
-    })
-    .expect("builtin type is valid")
+        | NullaryOp::TxLockTime => scalar(TypeBase::Int),
+    }
 }
 
 pub(super) fn introspection_type(kind: IntrospectionKind) -> TypeRef {
-    parse_type_ref(match kind {
+    match kind {
         IntrospectionKind::InputScriptPubKey
         | IntrospectionKind::InputSigScript
         | IntrospectionKind::InputOutpointTransactionHash
-        | IntrospectionKind::OutputScriptPubKey => "byte[]",
+        | IntrospectionKind::OutputScriptPubKey => byte_array(ArrayDim::Dynamic),
         IntrospectionKind::InputValue
         | IntrospectionKind::InputOutpointIndex
         | IntrospectionKind::InputSequenceNumber
-        | IntrospectionKind::OutputValue => "int",
-    })
-    .expect("builtin type is valid")
+        | IntrospectionKind::OutputValue => scalar(TypeBase::Int),
+    }
 }
 
 pub(super) fn builtin_return_type(name: &str) -> Option<TypeRef> {
-    let name = match name {
-        "int" | "bool" | "byte" | "string" | "pubkey" | "sig" | "datasig" => name,
+    Some(match name {
+        "int" => scalar(TypeBase::Int),
+        "bool" => scalar(TypeBase::Bool),
+        "byte" => scalar(TypeBase::Byte),
+        "string" => scalar(TypeBase::String),
+        "pubkey" => scalar(TypeBase::Pubkey),
+        "sig" => scalar(TypeBase::Sig),
+        "datasig" => scalar(TypeBase::Datasig),
         "OpBin2Num"
         | "OpTxInputDaaScore"
         | "OpTxGas"
@@ -44,10 +56,12 @@ pub(super) fn builtin_return_type(name: &str) -> Option<TypeRef> {
         | "OpCovInputCount"
         | "OpCovInputIdx"
         | "OpCovOutputCount"
-        | "OpCovOutputIdx" => "int",
-        "OpTxInputIsCoinbase" | "checkSig" | "checkSigFromStack" | "checkSigFromStackECDSA" => "bool",
-        "blake2b" | "blake2bWithKey" | "blake3" | "blake3WithKey" | "templateHash" | "sha256" | "OpSha256" => "byte[32]",
-        "OpInputCovenantId" | "OpOutputCovenantId" => "byte[32]",
+        | "OpCovOutputIdx" => scalar(TypeBase::Int),
+        "OpTxInputIsCoinbase" | "checkSig" | "checkSigFromStack" | "checkSigFromStackECDSA" => scalar(TypeBase::Bool),
+        "blake2b" | "blake2bWithKey" | "blake3" | "blake3WithKey" | "templateHash" | "sha256" | "OpSha256" => {
+            byte_array(ArrayDim::Fixed(32))
+        }
+        "OpInputCovenantId" | "OpOutputCovenantId" => byte_array(ArrayDim::Fixed(32)),
         "bytes"
         | "OpTxSubnetId"
         | "OpTxPayloadSubstr"
@@ -57,28 +71,41 @@ pub(super) fn builtin_return_type(name: &str) -> Option<TypeRef> {
         | "OpTxInputSpkSubstr"
         | "OpTxOutputSpkSubstr"
         | "OpNum2Bin"
-        | "OpChainblockSeqCommit"
-        | "LockingBytecodeNullData" => "byte[]",
+        | "OpChainblockSeqCommit" => byte_array(ArrayDim::Dynamic),
         _ => return None,
-    };
-    parse_type_ref(name).ok()
+    })
 }
 
 pub(super) fn constructor_return_type(name: &str) -> Option<TypeRef> {
-    parse_type_ref(match name {
-        "LockingBytecodeNullData" => "byte[]",
-        "ScriptPubKeyP2PK" => "byte[34]",
-        "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript" => "byte[35]",
+    Some(match name {
+        "ScriptPubKeyP2PK" => byte_array(ArrayDim::Fixed(34)),
+        "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript" => byte_array(ArrayDim::Fixed(35)),
         _ => return None,
     })
-    .ok()
 }
 
-pub(super) fn builtin_parameters(name: &str) -> Option<&'static [(&'static str, &'static str)]> {
+pub(super) fn constructor_parameters(name: &str) -> Option<Vec<(&'static str, TypeRef)>> {
+    Some(match name {
+        "ScriptPubKeyP2PK" => vec![("publicKey", scalar(TypeBase::Pubkey))],
+        "ScriptPubKeyP2SH" => vec![("scriptHash", byte_array(ArrayDim::Fixed(32)))],
+        "ScriptPubKeyP2SHFromRedeemScript" => vec![("redeemScript", byte_array(ArrayDim::Dynamic))],
+        _ => return None,
+    })
+}
+
+pub(super) fn builtin_parameters(name: &str) -> Option<Vec<(&'static str, TypeRef)>> {
     match name {
-        "checkSigFromStack" => Some(&[("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "pubkey")]),
-        "checkSigFromStackECDSA" => Some(&[("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "byte[33]")]),
-        "blake3WithKey" => Some(&[("data", "byte[]"), ("key", "byte[32]")]),
+        "checkSigFromStack" => Some(vec![
+            ("signature", scalar(TypeBase::Datasig)),
+            ("digest", byte_array(ArrayDim::Fixed(32))),
+            ("publicKey", scalar(TypeBase::Pubkey)),
+        ]),
+        "checkSigFromStackECDSA" => Some(vec![
+            ("signature", scalar(TypeBase::Datasig)),
+            ("digest", byte_array(ArrayDim::Fixed(32))),
+            ("publicKey", byte_array(ArrayDim::Fixed(33))),
+        ]),
+        "blake3WithKey" => Some(vec![("data", byte_array(ArrayDim::Dynamic)), ("key", byte_array(ArrayDim::Fixed(32)))]),
         _ => None,
     }
 }

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -1,7 +1,7 @@
 use super::array_append::lower_array_appends;
 use super::covenant_declarations::lower_covenant_declarations;
 use super::debug_value_types::infer_debug_expr_value_type;
-use super::infer_array::lower_inferred_array_sizes;
+use super::infer_array::{infer_expr_type_ref, lower_inferred_array_sizes};
 use super::inline_functions::lower_inline_functions;
 use super::locals::lower_local_aliases;
 use super::stack_bindings::StackBindings;
@@ -3598,7 +3598,11 @@ fn compile_call_expr<'i>(
         "bytes" => compile_bytes_call(&mut ctx, args),
         "length" => compile_length_call(&mut ctx, args),
         "int" | "byte" | "bool" | "string" | "sig" | "pubkey" | "datasig" => compile_passthrough_cast_call(&mut ctx, name, args),
-        name if name.starts_with("byte[") && name.ends_with(']') => compile_byte_sequence_cast_call(&mut ctx, name, args),
+        name if parse_type_ref(name)
+            .is_ok_and(|type_ref| matches!(type_ref.base, TypeBase::Byte) && type_ref.array_dims.len() == 1) =>
+        {
+            compile_byte_sequence_cast_call(&mut ctx, name, args)
+        }
         name if parse_type_ref(name).is_ok_and(|type_ref| is_array_type_ref(&type_ref)) => {
             compile_array_cast_call(&mut ctx, name, args)
         }
@@ -3774,7 +3778,10 @@ fn compile_byte_sequence_cast_call<'i>(
     if args.len() != 1 {
         return Err(CompilerError::Unsupported(format!("{name}() expects a single argument")));
     }
-    let source_type = infer_debug_expr_value_type(&args[0], ctx.scope.constants, ctx.scope.types, &mut HashSet::new()).ok();
+    let source_type = infer_expr_type_ref(&args[0], ctx.scope.types, ctx.scope.constants, &HashMap::new())
+        .map(|type_ref| type_name_from_ref(&type_ref))
+        .filter(|type_name| byte_sequence_cast_size(type_name).is_some())
+        .or_else(|| infer_debug_expr_value_type(&args[0], ctx.scope.constants, ctx.scope.types, &mut HashSet::new()).ok());
     if let Some(source_type) = source_type.as_deref() {
         if let Some(source_size) = byte_sequence_cast_size(source_type) {
             if let Some(source_size) = source_size {
@@ -3960,7 +3967,8 @@ pub(crate) fn is_bytes_type(type_name: &str) -> bool {
     is_array_type(type_name)
 }
 
-pub(super) fn byte_sequence_cast_size(type_name: &str) -> Option<Option<i64>> {
+// TODO: Make it depend on the actual type instead of the name.
+fn byte_sequence_cast_size(type_name: &str) -> Option<Option<i64>> {
     match type_name {
         "bytes" | "byte[]" | "string" => Some(None),
         "byte" => Some(Some(1)),

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -444,59 +444,8 @@ fn infer_expr_type_ref_for_comparison<'i>(
         }
     }
     if let ExprKind::Call { name, .. } = &expr.kind {
-        let is_builtin_cast = matches!(name.as_str(), "int" | "bool" | "byte" | "string" | "pubkey" | "sig" | "datasig")
-            || (name.contains('[') && parse_type_ref(name).ok().is_some_and(|type_ref| !matches!(type_ref.base, TypeBase::Custom(_))));
-        let is_known_builtin = matches!(
-            name.as_str(),
-            "int"
-                | "bool"
-                | "byte"
-                | "string"
-                | "pubkey"
-                | "sig"
-                | "datasig"
-                | "bytes"
-                | "blake2b"
-                | "blake2bWithKey"
-                | "blake3"
-                | "blake3WithKey"
-                | "templateHash"
-                | "sha256"
-                | "OpSha256"
-                | "OpTxSubnetId"
-                | "OpTxPayloadSubstr"
-                | "OpOutpointTxId"
-                | "OpTxInputScriptSigSubstr"
-                | "OpTxInputSeq"
-                | "OpTxInputSpkSubstr"
-                | "OpTxOutputSpkSubstr"
-                | "OpNum2Bin"
-                | "OpBin2Num"
-                | "OpChainblockSeqCommit"
-                | "LockingBytecodeNullData"
-                | "ScriptPubKeyP2PK"
-                | "ScriptPubKeyP2SH"
-                | "ScriptPubKeyP2SHFromRedeemScript"
-                | "OpInputCovenantId"
-                | "OpOutputCovenantId"
-                | "checkSigFromStack"
-                | "checkSigFromStackECDSA"
-                | "OpTxGas"
-                | "OpTxPayloadLen"
-                | "OpTxInputIndex"
-                | "OpTxInputIsCoinbase"
-                | "OpTxInputScriptSigLen"
-                | "OpTxInputSpkLen"
-                | "OpOutpointIndex"
-                | "OpTxOutputSpkLen"
-                | "OpAuthOutputCount"
-                | "OpAuthOutputIdx"
-                | "OpCovInputCount"
-                | "OpCovInputIdx"
-                | "OpCovOutputCount"
-                | "OpCovOutputIdx"
-        );
-        if !is_builtin_cast && !is_known_builtin {
+        let known_cast = parse_type_ref(name).is_ok_and(|type_ref| !matches!(type_ref.base, TypeBase::Custom(_)));
+        if !known_cast && builtin_types::builtin_return_type(name).is_none() {
             return None;
         }
     }
@@ -520,13 +469,11 @@ pub(super) fn array_literal_matches_type_with_env_ref<'i>(
         }
     }
 
-    values.iter().all(|value| match &value.kind {
-        ExprKind::Identifier(name) => types
-            .get(name)
-            .and_then(|value_type| parse_type_ref(value_type).ok())
-            .is_some_and(|value_type| is_type_assignable_ref(&value_type, &element_type, constants)),
-        _ => super::static_check::value_matches_type_ref(value, &element_type),
-    })
+    let structs = StructRegistry::new();
+    let functions = HashMap::new();
+    let type_context =
+        super::type_check::TypeCheckContext { types, structs: &structs, constants, functions: &functions, contract_fields: &[] };
+    values.iter().all(|value| super::type_check::check_expr(value, Some(&element_type), &type_context).is_ok())
 }
 
 fn build_function_abi_entries<'i>(contract: &ContractAst<'i>) -> Vec<FunctionAbiEntry> {
@@ -600,7 +547,7 @@ fn fixed_type_size_ref(type_ref: &TypeRef) -> Option<i64> {
         TypeBase::Sig => Some(65),
         TypeBase::Datasig => Some(64),
         TypeBase::String => None,
-        TypeBase::Custom(_) => None,
+        TypeBase::Tuple(_) | TypeBase::Custom(_) => None,
     }
 }
 
@@ -800,39 +747,8 @@ fn collect_assigned_names_into<'i>(statements: &[Statement<'i>], assigned: &mut 
     }
 }
 
-fn has_explicit_array_size_ref(type_ref: &TypeRef) -> bool {
-    !matches!(type_ref.array_size(), Some(ArrayDim::Dynamic | ArrayDim::Inferred) | None)
-}
-
 fn has_inferred_array_size_ref(type_ref: &TypeRef) -> bool {
     matches!(type_ref.array_size(), Some(ArrayDim::Inferred))
-}
-
-fn is_array_type_assignable_ref<'i>(actual: &TypeRef, expected: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> bool {
-    if actual == expected {
-        return true;
-    }
-
-    if !is_array_type_ref(actual) || !is_array_type_ref(expected) {
-        return false;
-    }
-
-    if array_element_type_ref(actual) != array_element_type_ref(expected) {
-        return false;
-    }
-
-    if !has_explicit_array_size_ref(expected) {
-        return true;
-    }
-
-    match (array_size_with_constants_ref(actual, constants), array_size_with_constants_ref(expected, constants)) {
-        (Some(actual_size), Some(expected_size)) => actual_size == expected_size,
-        _ => actual == expected,
-    }
-}
-
-pub(super) fn is_type_assignable_ref<'i>(actual: &TypeRef, expected: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> bool {
-    actual == expected || is_array_type_assignable_ref(actual, expected, constants)
 }
 
 fn coerce_expr_for_declared_scalar_type<'i>(expr: Expr<'i>, type_name: &str) -> Expr<'i> {
@@ -876,7 +792,7 @@ fn infer_fixed_array_type_from_initializer_ref<'i>(
         }
         ExprKind::Identifier(name) => {
             let other_type = parse_type_ref(types.get(name)?).ok()?;
-            if !is_array_type_ref(&other_type) || array_element_type_ref(&other_type) != Some(element_type.clone()) {
+            if !is_array_type_ref(&other_type) || !type_refs_equal(&array_element_type_ref(&other_type)?, &element_type, constants) {
                 return None;
             }
             let size = array_size_with_constants_ref(&other_type, constants)?;
@@ -918,14 +834,14 @@ fn array_element_size(type_name: &str) -> Option<i64> {
     array_element_size_ref(&type_ref)
 }
 
-fn is_type_assignable<'i>(actual: &str, expected: &str, constants: &HashMap<String, Expr<'i>>) -> bool {
+fn type_names_equal<'i>(actual: &str, expected: &str, constants: &HashMap<String, Expr<'i>>) -> bool {
     let Ok(actual_type) = parse_type_ref(actual) else {
         return false;
     };
     let Ok(expected_type) = parse_type_ref(expected) else {
         return false;
     };
-    is_type_assignable_ref(&actual_type, &expected_type, constants)
+    type_refs_equal(&actual_type, &expected_type, constants)
 }
 
 fn infer_fixed_array_type_from_initializer<'i>(
@@ -1329,10 +1245,10 @@ fn array_initializer_expr<'i>(
 ) -> Result<Expr<'i>, CompilerError> {
     match expr {
         Some(Expr { kind: ExprKind::Identifier(other), .. }) => match types.get(other) {
-            Some(other_type) if is_type_assignable(other_type, type_name, contract_constants) => {
+            Some(other_type) if type_names_equal(other_type, type_name, contract_constants) => {
                 Ok(Expr::new(ExprKind::Identifier(other.clone()), span::Span::default()))
             }
-            Some(_) => Err(CompilerError::Unsupported("array assignment requires compatible array types".to_string())),
+            Some(_) => Err(CompilerError::Unsupported("array assignment requires identical array types".to_string())),
             None => Err(CompilerError::UndefinedIdentifier(other.clone())),
         },
         Some(expr) => Ok(expr.clone()),
@@ -3780,7 +3696,6 @@ fn compile_byte_sequence_cast_call<'i>(
     }
     let source_type = infer_expr_type_ref(&args[0], ctx.scope.types, ctx.scope.constants, &HashMap::new())
         .map(|type_ref| type_name_from_ref(&type_ref))
-        .filter(|type_name| byte_sequence_cast_size(type_name).is_some())
         .or_else(|| infer_debug_expr_value_type(&args[0], ctx.scope.constants, ctx.scope.types, &mut HashSet::new()).ok());
     if let Some(source_type) = source_type.as_deref() {
         if let Some(source_size) = byte_sequence_cast_size(source_type) {

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -1,7 +1,7 @@
 use super::array_append::lower_array_appends;
 use super::covenant_declarations::lower_covenant_declarations;
 use super::debug_value_types::infer_debug_expr_value_type;
-use super::infer_array::{infer_expr_type_ref, lower_inferred_array_sizes};
+use super::infer_array::{infer_expr_type, lower_inferred_array_sizes};
 use super::inline_functions::lower_inline_functions;
 use super::locals::lower_local_aliases;
 use super::stack_bindings::StackBindings;
@@ -86,7 +86,7 @@ pub(super) fn read_input_state_with_template_values<'i>(
             contract_constants,
             "readInputStateWithTemplate",
         )?);
-        field_chunk_offset += encoded_field_chunk_size_for_type_ref(type_ref, contract_constants)?;
+        field_chunk_offset += encoded_type_chunk_size(type_ref, contract_constants)?;
     }
     Ok(lowered)
 }
@@ -323,15 +323,13 @@ fn compile_contract_fields<'i>(
     let stack_bindings = StackBindings::default();
 
     for field in fields {
-        let type_name = type_name_from_ref(&field.type_ref);
-
         let mut resolve_visiting = HashSet::new();
         let resolved = resolve_expr(field.expr.clone(), base_constants, &mut resolve_visiting)?;
 
         let mut compile_visiting = HashSet::new();
         let mut stack_depth = 0i64;
-        if fixed_type_size_with_constants_ref(&field.type_ref, base_constants).is_some() {
-            let encoded = encode_fixed_size_value(&resolved, &type_name)?;
+        if fixed_type_size_with_constants(&field.type_ref, base_constants).is_some() {
+            let encoded = encode_fixed_size_value(&resolved, &field.type_ref)?;
             builder.add_data_with_push_opcode(&encoded)?;
         } else {
             compile_expr(
@@ -349,7 +347,7 @@ fn compile_contract_fields<'i>(
         }
 
         field_values.insert(field.name.clone(), resolved);
-        field_types.insert(field.name.clone(), type_name);
+        field_types.insert(field.name.clone(), field.type_ref.clone());
     }
 
     Ok((field_values, builder.drain()))
@@ -433,14 +431,10 @@ fn byte_array_len<'i>(expr: &Expr<'i>) -> Option<usize> {
     }
 }
 
-fn infer_expr_type_ref_for_comparison<'i>(
-    expr: &Expr<'i>,
-    constants: &HashMap<String, Expr<'i>>,
-    types: &HashMap<String, String>,
-) -> Option<TypeRef> {
+fn infer_expr_type_for_comparison<'i>(expr: &Expr<'i>, constants: &HashMap<String, Expr<'i>>, types: &TypeMap) -> Option<TypeRef> {
     if let ExprKind::Identifier(name) = &expr.kind {
-        if let Some(type_ref) = types.get(name).and_then(|type_name| parse_type_ref(type_name).ok()) {
-            return Some(type_ref);
+        if let Some(type_ref) = types.get(name) {
+            return Some(type_ref.clone());
         }
     }
     if let ExprKind::Call { name, .. } = &expr.kind {
@@ -449,21 +443,20 @@ fn infer_expr_type_ref_for_comparison<'i>(
             return None;
         }
     }
-    let type_name = infer_debug_expr_value_type(expr, constants, types, &mut HashSet::new()).ok()?;
-    parse_type_ref(&type_name).ok()
+    infer_debug_expr_value_type(expr, constants, types, &mut HashSet::new()).ok()
 }
 
-pub(super) fn array_literal_matches_type_with_env_ref<'i>(
+pub(super) fn array_literal_matches_type_with_env<'i>(
     values: &[Expr<'i>],
     type_ref: &TypeRef,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,
 ) -> bool {
-    let Some(element_type) = array_element_type_ref(type_ref) else {
+    let Some(element_type) = type_ref.array_element_type() else {
         return false;
     };
 
-    if let Some(expected_size) = array_size_with_constants_ref(type_ref, constants) {
+    if let Some(expected_size) = array_size_with_constants(type_ref, constants) {
         if values.len() != expected_size {
             return false;
         }
@@ -486,32 +479,20 @@ fn build_function_abi_entries<'i>(contract: &ContractAst<'i>) -> Vec<FunctionAbi
             inputs: func
                 .params
                 .iter()
-                .map(|param| FunctionInputAbi { name: param.name.clone(), type_name: type_name_from_ref(&param.type_ref) })
+                .map(|param| FunctionInputAbi { name: param.name.clone(), type_name: param.type_ref.type_name() })
                 .collect(),
         })
         .collect()
 }
 
-pub(crate) fn type_name_from_ref(type_ref: &TypeRef) -> String {
-    type_ref.type_name()
-}
-
-fn is_array_type_ref(type_ref: &TypeRef) -> bool {
-    type_ref.is_array()
-}
-
-fn array_element_type_ref(type_ref: &TypeRef) -> Option<TypeRef> {
-    type_ref.array_element_type()
-}
-
-fn array_size_ref(type_ref: &TypeRef) -> Option<usize> {
+fn array_size(type_ref: &TypeRef) -> Option<usize> {
     match type_ref.array_size()? {
         ArrayDim::Fixed(size) => Some(*size),
         _ => None,
     }
 }
 
-fn array_size_with_constants_ref<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
+fn array_size_with_constants<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
     match type_ref.array_size()? {
         ArrayDim::Fixed(size) => Some(*size),
         ArrayDim::Constant(name) => {
@@ -526,13 +507,13 @@ fn array_size_with_constants_ref<'i>(type_ref: &TypeRef, constants: &HashMap<Str
     }
 }
 
-fn fixed_type_size_ref(type_ref: &TypeRef) -> Option<i64> {
+fn fixed_type_size(type_ref: &TypeRef) -> Option<i64> {
     if type_ref.is_array() {
-        if let (Some(elem_type), Some(size)) = (array_element_type_ref(type_ref), array_size_ref(type_ref)) {
-            if elem_type.base == TypeBase::Byte && !elem_type.is_array() {
+        if let (Some(elem_type), Some(size)) = (type_ref.array_element_type(), array_size(type_ref)) {
+            if elem_type.is_byte() {
                 return Some(size as i64);
             }
-            if elem_type.base == TypeBase::Int && !elem_type.is_array() {
+            if elem_type.is_int() {
                 return Some((size * 8) as i64);
             }
         }
@@ -543,43 +524,37 @@ fn fixed_type_size_ref(type_ref: &TypeRef) -> Option<i64> {
         TypeBase::Int => Some(8),
         TypeBase::Bool => Some(1),
         TypeBase::Byte => Some(1),
-        TypeBase::Pubkey => Some(32),
-        TypeBase::Sig => Some(65),
-        TypeBase::Datasig => Some(64),
+        TypeBase::Pubkey | TypeBase::Sig | TypeBase::Datasig => type_ref.base.fixed_byte_sequence_len().map(|size| size as i64),
         TypeBase::String => None,
         TypeBase::Tuple(_) | TypeBase::Custom(_) => None,
     }
 }
 
-fn fixed_type_size_with_constants_ref<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
+fn fixed_type_size_with_constants<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
     if !type_ref.is_array() {
-        return fixed_type_size_ref(type_ref).map(|size| size as usize);
+        return fixed_type_size(type_ref).map(|size| size as usize);
     }
 
-    let element_type = array_element_type_ref(type_ref)?;
-    let array_len = array_size_with_constants_ref(type_ref, constants)?;
-    let element_size = fixed_type_size_with_constants_ref(&element_type, constants)?;
+    let element_type = type_ref.array_element_type()?;
+    let array_len = array_size_with_constants(type_ref, constants)?;
+    let element_size = fixed_type_size_with_constants(&element_type, constants)?;
     Some(array_len * element_size)
 }
 
-fn fixed_state_field_payload_len_for_type_ref<'i>(
-    type_ref: &TypeRef,
-    contract_constants: &HashMap<String, Expr<'i>>,
-) -> Result<usize, CompilerError> {
-    fixed_type_size_with_constants_ref(type_ref, contract_constants).ok_or_else(|| {
-        CompilerError::Unsupported(format!("readInputState does not support field type {}", type_name_from_ref(type_ref)))
-    })
+fn fixed_state_payload_len<'i>(type_ref: &TypeRef, contract_constants: &HashMap<String, Expr<'i>>) -> Result<usize, CompilerError> {
+    fixed_type_size_with_constants(type_ref, contract_constants)
+        .ok_or_else(|| CompilerError::Unsupported(format!("readInputState does not support field type {}", type_ref.type_name())))
 }
 
 fn fixed_state_field_payload_len<'i>(
     field: &ContractFieldAst<'i>,
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<usize, CompilerError> {
-    fixed_state_field_payload_len_for_type_ref(&field.type_ref, contract_constants)
+    fixed_state_payload_len(&field.type_ref, contract_constants)
 }
 
-fn array_element_size_ref(type_ref: &TypeRef) -> Option<i64> {
-    array_element_type_ref(type_ref).and_then(|element| fixed_type_size_ref(&element))
+fn array_element_size(type_ref: &TypeRef) -> Option<i64> {
+    type_ref.array_element_type().and_then(|element| fixed_type_size(&element))
 }
 
 fn contains_return(stmt: &Statement<'_>) -> bool {
@@ -747,12 +722,12 @@ fn collect_assigned_names_into<'i>(statements: &[Statement<'i>], assigned: &mut 
     }
 }
 
-fn has_inferred_array_size_ref(type_ref: &TypeRef) -> bool {
+fn has_inferred_array_size(type_ref: &TypeRef) -> bool {
     matches!(type_ref.array_size(), Some(ArrayDim::Inferred))
 }
 
-fn coerce_expr_for_declared_scalar_type<'i>(expr: Expr<'i>, type_name: &str) -> Expr<'i> {
-    if type_name == "byte"
+fn coerce_expr_for_declared_scalar_type<'i>(expr: Expr<'i>, type_ref: &TypeRef) -> Expr<'i> {
+    if type_ref.is_byte()
         && let ExprKind::Int(value) = expr.kind
         && (0..=255).contains(&value)
     {
@@ -762,7 +737,7 @@ fn coerce_expr_for_declared_scalar_type<'i>(expr: Expr<'i>, type_name: &str) -> 
 }
 
 fn coerce_rhs_byte_literal_for_comparison<'i>(left_type: Option<&TypeRef>, right: &Expr<'i>) -> Expr<'i> {
-    if left_type.is_some_and(|type_ref| matches!(type_ref.base, TypeBase::Byte) && !type_ref.is_array())
+    if left_type.is_some_and(TypeRef::is_byte)
         && let ExprKind::Int(value) = right.kind
         && (0..=255).contains(&value)
     {
@@ -771,31 +746,31 @@ fn coerce_rhs_byte_literal_for_comparison<'i>(left_type: Option<&TypeRef>, right
     right.clone()
 }
 
-fn infer_fixed_array_type_from_initializer_ref<'i>(
+fn infer_fixed_array_type_from_initializer<'i>(
     declared_type: &TypeRef,
     initializer: Option<&Expr<'i>>,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,
 ) -> Option<TypeRef> {
-    if !has_inferred_array_size_ref(declared_type) {
+    if !has_inferred_array_size(declared_type) {
         return None;
     }
 
-    let element_type = array_element_type_ref(declared_type)?;
+    let element_type = declared_type.array_element_type()?;
     let init = initializer?;
 
     match &init.kind {
         ExprKind::Array(values) => {
             let mut inferred = element_type.clone();
             inferred.array_dims.push(ArrayDim::Fixed(values.len()));
-            if array_literal_matches_type_with_env_ref(values, &inferred, types, constants) { Some(inferred) } else { None }
+            if array_literal_matches_type_with_env(values, &inferred, types, constants) { Some(inferred) } else { None }
         }
         ExprKind::Identifier(name) => {
-            let other_type = parse_type_ref(types.get(name)?).ok()?;
-            if !is_array_type_ref(&other_type) || !type_refs_equal(&array_element_type_ref(&other_type)?, &element_type, constants) {
+            let other_type = types.get(name)?.clone();
+            if !other_type.is_array() || !type_refs_equal(&other_type.array_element_type()?, &element_type, constants) {
                 return None;
             }
-            let size = array_size_with_constants_ref(&other_type, constants)?;
+            let size = array_size_with_constants(&other_type, constants)?;
             let mut inferred = element_type;
             inferred.array_dims.push(ArrayDim::Fixed(size));
             Some(inferred)
@@ -804,59 +779,9 @@ fn infer_fixed_array_type_from_initializer_ref<'i>(
     }
 }
 
-pub(super) fn is_array_type(type_name: &str) -> bool {
-    parse_type_ref(type_name).is_ok_and(|type_ref| is_array_type_ref(&type_ref))
-}
-
-pub(crate) fn array_element_type(type_name: &str) -> Option<String> {
-    let type_ref = parse_type_ref(type_name).ok()?;
-    let element = array_element_type_ref(&type_ref)?;
-    Some(type_name_from_ref(&element))
-}
-
-fn array_size(type_name: &str) -> Option<usize> {
-    let type_ref = parse_type_ref(type_name).ok()?;
-    array_size_ref(&type_ref)
-}
-
-fn array_size_with_constants<'i>(type_name: &str, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
-    let type_ref = parse_type_ref(type_name).ok()?;
-    array_size_with_constants_ref(&type_ref, constants)
-}
-
-fn fixed_type_size(type_name: &str) -> Option<i64> {
-    let type_ref = parse_type_ref(type_name).ok()?;
-    fixed_type_size_ref(&type_ref)
-}
-
-fn array_element_size(type_name: &str) -> Option<i64> {
-    let type_ref = parse_type_ref(type_name).ok()?;
-    array_element_size_ref(&type_ref)
-}
-
-fn type_names_equal<'i>(actual: &str, expected: &str, constants: &HashMap<String, Expr<'i>>) -> bool {
-    let Ok(actual_type) = parse_type_ref(actual) else {
-        return false;
-    };
-    let Ok(expected_type) = parse_type_ref(expected) else {
-        return false;
-    };
-    type_refs_equal(&actual_type, &expected_type, constants)
-}
-
-fn infer_fixed_array_type_from_initializer<'i>(
-    declared_type: &str,
-    initializer: Option<&Expr<'i>>,
-    types: &HashMap<String, String>,
-    constants: &HashMap<String, Expr<'i>>,
-) -> Option<String> {
-    let declared_type = parse_type_ref(declared_type).ok()?;
-    infer_fixed_array_type_from_initializer_ref(&declared_type, initializer, types, constants).map(|t| type_name_from_ref(&t))
-}
-
-fn encode_fixed_size_value<'i>(value: &Expr<'i>, type_name: &str) -> Result<Vec<u8>, CompilerError> {
-    match type_name {
-        "int" => {
+fn encode_fixed_size_value<'i>(value: &Expr<'i>, type_ref: &TypeRef) -> Result<Vec<u8>, CompilerError> {
+    match (&type_ref.base, type_ref.array_dims.as_slice()) {
+        (TypeBase::Int, []) => {
             let number = match &value.kind {
                 ExprKind::Int(number) | ExprKind::DateLiteral(number) => *number,
                 _ => return Err(CompilerError::Unsupported("array literal element type mismatch".to_string())),
@@ -865,39 +790,23 @@ fn encode_fixed_size_value<'i>(value: &Expr<'i>, type_name: &str) -> Result<Vec<
                 .map(|bytes| bytes.to_vec())
                 .map_err(|err| CompilerError::Unsupported(format!("failed to serialize int literal {}: {err}", number)))
         }
-        "bool" => {
+        (TypeBase::Bool, []) => {
             let ExprKind::Bool(flag) = &value.kind else {
                 return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
             };
             Ok(vec![u8::from(*flag)])
         }
-        "byte" => {
+        (TypeBase::Byte, []) => {
             let ExprKind::Byte(byte) = &value.kind else {
                 return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
             };
             Ok(vec![*byte])
         }
-        "pubkey" => {
+        (base @ (TypeBase::Pubkey | TypeBase::Sig | TypeBase::Datasig), []) => {
             let Some(len) = byte_array_len(value) else {
                 return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
             };
-            if len != 32 {
-                return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
-            }
-            let ExprKind::Array(bytes_exprs) = &value.kind else {
-                return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
-            };
-            Ok(bytes_exprs
-                .iter()
-                .filter_map(|value| if let ExprKind::Byte(byte) = &value.kind { Some(*byte) } else { None })
-                .collect())
-        }
-        "sig" | "datasig" => {
-            let expected_len = if type_name == "sig" { 65 } else { 64 };
-            let Some(len) = byte_array_len(value) else {
-                return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
-            };
-            if len != expected_len {
+            if Some(len) != base.fixed_byte_sequence_len() {
                 return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
             }
             let ExprKind::Array(bytes_exprs) = &value.kind else {
@@ -910,8 +819,8 @@ fn encode_fixed_size_value<'i>(value: &Expr<'i>, type_name: &str) -> Result<Vec<
         }
         _ => {
             // Handle fixed-size byte arrays like byte[N]
-            if let (Some(inner_type), Some(size)) = (array_element_type(type_name), array_size(type_name)) {
-                if inner_type == "byte" {
+            if let (Some(inner_type), Some(size)) = (type_ref.array_element_type(), array_size(type_ref)) {
+                if inner_type.is_byte() {
                     let Some(len) = byte_array_len(value) else {
                         return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
                     };
@@ -930,9 +839,10 @@ fn encode_fixed_size_value<'i>(value: &Expr<'i>, type_name: &str) -> Result<Vec<
 
             // Handle nested fixed-size arrays with known element sizes.
             if let ExprKind::Array(values) = &value.kind {
-                let element_type = array_element_type(type_name)
+                let element_type = type_ref
+                    .array_element_type()
                     .ok_or_else(|| CompilerError::Unsupported("array element type must have known size".to_string()))?;
-                let expected_len = array_size(type_name)
+                let expected_len = array_size(type_ref)
                     .ok_or_else(|| CompilerError::Unsupported("array literal element type mismatch".to_string()))?;
                 if values.len() != expected_len {
                     return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
@@ -950,8 +860,9 @@ fn encode_fixed_size_value<'i>(value: &Expr<'i>, type_name: &str) -> Result<Vec<
     }
 }
 
-pub(super) fn encode_array_literal<'i>(values: &[Expr<'i>], type_name: &str) -> Result<Vec<u8>, CompilerError> {
-    let element_type = array_element_type(type_name)
+pub(super) fn encode_array_literal<'i>(values: &[Expr<'i>], type_ref: &TypeRef) -> Result<Vec<u8>, CompilerError> {
+    let element_type = type_ref
+        .array_element_type()
         .ok_or_else(|| CompilerError::Unsupported("array element type must have known size".to_string()))?;
     let mut out = Vec::new();
     debug_assert!(fixed_type_size(&element_type).is_some(), "type_check must validate array element type has known size");
@@ -961,28 +872,29 @@ pub(super) fn encode_array_literal<'i>(values: &[Expr<'i>], type_name: &str) -> 
     Ok(out)
 }
 
-fn infer_fixed_type_from_literal_expr<'i>(expr: &Expr<'i>) -> Option<String> {
+fn infer_fixed_type_from_literal_expr<'i>(expr: &Expr<'i>) -> Option<TypeRef> {
     match &expr.kind {
-        ExprKind::Int(_) | ExprKind::DateLiteral(_) => Some("int".to_string()),
-        ExprKind::Bool(_) => Some("bool".to_string()),
-        ExprKind::Byte(_) => Some("byte".to_string()),
-        ExprKind::Array(values) if is_byte_array(expr) => Some(format!("byte[{}]", values.len())),
-        ExprKind::Array(values) => {
-            let nested_type = infer_fixed_array_literal_type(values)?;
-            Some(nested_type.trim_end_matches("[]").to_string())
+        ExprKind::Int(_) | ExprKind::DateLiteral(_) => Some(TypeRef { base: TypeBase::Int, array_dims: Vec::new() }),
+        ExprKind::Bool(_) => Some(TypeRef { base: TypeBase::Bool, array_dims: Vec::new() }),
+        ExprKind::Byte(_) => Some(TypeRef { base: TypeBase::Byte, array_dims: Vec::new() }),
+        ExprKind::Array(values) if is_byte_array(expr) => {
+            Some(TypeRef { base: TypeBase::Byte, array_dims: vec![ArrayDim::Fixed(values.len())] })
         }
+        ExprKind::Array(values) => infer_fixed_array_literal_type(values)?.array_element_type(),
         _ => None,
     }
 }
 
-fn infer_fixed_array_literal_type<'i>(values: &[Expr<'i>]) -> Option<String> {
+fn infer_fixed_array_literal_type<'i>(values: &[Expr<'i>]) -> Option<TypeRef> {
     if values.is_empty() {
         return None;
     }
     let first_type = infer_fixed_type_from_literal_expr(values.first()?)?;
     fixed_type_size(&first_type)?;
-    if values.iter().skip(1).all(|value| infer_fixed_type_from_literal_expr(value).as_deref() == Some(first_type.as_str())) {
-        Some(format!("{}[]", first_type))
+    if values.iter().skip(1).all(|value| infer_fixed_type_from_literal_expr(value).as_ref() == Some(&first_type)) {
+        let mut array_type = first_type;
+        array_type.array_dims.push(ArrayDim::Dynamic);
+        Some(array_type)
     } else {
         None
     }
@@ -1016,13 +928,13 @@ fn compile_entrypoint_function<'i>(
     let mut flattened_param_names = Vec::new();
     let mut types = HashMap::new();
     for param in contract_params {
-        types.insert(param.name.clone(), type_name_from_ref(&param.type_ref));
+        types.insert(param.name.clone(), param.type_ref.clone());
     }
     for constant in contract_constants {
-        types.insert(constant.name.clone(), type_name_from_ref(&constant.type_ref));
+        types.insert(constant.name.clone(), constant.type_ref.clone());
     }
     for param in &function.params {
-        types.insert(param.name.clone(), type_name_from_ref(&param.type_ref));
+        types.insert(param.name.clone(), param.type_ref.clone());
         flattened_param_names.push(param.name.clone());
     }
 
@@ -1041,7 +953,7 @@ fn compile_entrypoint_function<'i>(
     }
 
     for field in contract_fields {
-        types.insert(field.name.clone(), type_name_from_ref(&field.type_ref));
+        types.insert(field.name.clone(), field.type_ref.clone());
     }
     let mut builder = script_builder();
     let mut return_exprs: Vec<Expr> = Vec::new();
@@ -1170,7 +1082,7 @@ fn compile_statement<'i>(ctx: &mut CompileStatementContext<'_, 'i>, stmt: &State
 struct CompileStatementContext<'a, 'i> {
     assigned_names: &'a HashSet<String>,
     identifier_uses: &'a HashMap<String, usize>,
-    types: &'a mut HashMap<String, String>,
+    types: &'a mut TypeMap,
     stack_bindings: &'a mut StackBindings,
     builder: &'a mut ScriptBuilder,
     options: CompileOptions,
@@ -1185,7 +1097,7 @@ struct CompileStatementContext<'a, 'i> {
 impl<'a, 'i> CompileStatementContext<'a, 'i> {
     pub(crate) fn with_types_and_stack_bindings<'b>(
         &'b mut self,
-        types: &'b mut HashMap<String, String>,
+        types: &'b mut TypeMap,
         stack_bindings: &'b mut StackBindings,
     ) -> CompileStatementContext<'b, 'i>
     where
@@ -1214,38 +1126,37 @@ fn compile_variable_definition_statement<'i>(
     name: &str,
     expr: Option<&Expr<'i>>,
 ) -> Result<Vec<String>, CompilerError> {
-    let type_name = type_name_from_ref(type_ref);
-    let effective_type_name = if has_inferred_array_size_ref(type_ref) {
-        infer_fixed_array_type_from_initializer(&type_name, expr, ctx.types, ctx.contract_constants).ok_or_else(|| {
+    let effective_type = if has_inferred_array_size(type_ref) {
+        infer_fixed_array_type_from_initializer(type_ref, expr, ctx.types, ctx.contract_constants).ok_or_else(|| {
             CompilerError::Unsupported(format!(
                 "variable '{}' requires an initializer with inferrable size for type {}",
-                name, type_name
+                name,
+                type_ref.type_name()
             ))
         })?
     } else {
-        type_name.clone()
+        type_ref.clone()
     };
 
-    let is_array = is_array_type(&effective_type_name);
-    if is_array {
-        let initial = array_initializer_expr(expr, &effective_type_name, ctx.types, ctx.contract_constants)?;
-        return compile_runtime_variable_definition(ctx, name, effective_type_name, initial);
+    if effective_type.is_array() {
+        let initial = array_initializer_expr(expr, &effective_type, ctx.types, ctx.contract_constants)?;
+        return compile_runtime_variable_definition(ctx, name, effective_type, initial);
     }
 
     let expr = expr.cloned().ok_or_else(|| CompilerError::Unsupported("variable definition requires initializer".to_string()))?;
-    let expr = coerce_expr_for_declared_scalar_type(expr, &effective_type_name);
-    compile_runtime_variable_definition(ctx, name, effective_type_name, expr)
+    let expr = coerce_expr_for_declared_scalar_type(expr, &effective_type);
+    compile_runtime_variable_definition(ctx, name, effective_type, expr)
 }
 
 fn array_initializer_expr<'i>(
     expr: Option<&Expr<'i>>,
-    type_name: &str,
-    types: &HashMap<String, String>,
+    type_ref: &TypeRef,
+    types: &TypeMap,
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<Expr<'i>, CompilerError> {
     match expr {
         Some(Expr { kind: ExprKind::Identifier(other), .. }) => match types.get(other) {
-            Some(other_type) if type_names_equal(other_type, type_name, contract_constants) => {
+            Some(other_type) if type_refs_equal(other_type, type_ref, contract_constants) => {
                 Ok(Expr::new(ExprKind::Identifier(other.clone()), span::Span::default()))
             }
             Some(_) => Err(CompilerError::Unsupported("array assignment requires identical array types".to_string())),
@@ -1259,10 +1170,10 @@ fn array_initializer_expr<'i>(
 fn compile_runtime_variable_definition<'i>(
     ctx: &mut CompileStatementContext<'_, 'i>,
     name: &str,
-    type_name: String,
+    type_ref: TypeRef,
     expr: Expr<'i>,
 ) -> Result<Vec<String>, CompilerError> {
-    ctx.types.insert(name.to_string(), type_name.clone());
+    ctx.types.insert(name.to_string(), type_ref);
     if ctx.stack_bindings.contains(name) {
         return Err(CompilerError::Unsupported(format!("variable '{}' is already defined", name)));
     }
@@ -1287,14 +1198,14 @@ fn compile_runtime_variable_definition<'i>(
 fn compile_stack_variable_definition<'i>(
     ctx: &mut CompileStatementContext<'_, 'i>,
     name: &str,
-    type_name: String,
+    type_ref: TypeRef,
     expr: Expr<'i>,
 ) -> Result<Vec<String>, CompilerError> {
     if ctx.stack_bindings.contains(name) {
         return Err(CompilerError::Unsupported(format!("variable '{}' is already defined", name)));
     }
 
-    ctx.types.insert(name.to_string(), type_name);
+    ctx.types.insert(name.to_string(), type_ref);
     let mut stack_depth = 0i64;
     compile_expr(
         &expr,
@@ -1370,8 +1281,8 @@ fn compile_tuple_assignment_statement<'i>(
                 ExprKind::Split { source: source.clone(), index: index.clone(), part: SplitPart::Right, span: *split_span },
                 span::Span::default(),
             );
-            let mut added = compile_stack_variable_definition(ctx, left_name, type_name_from_ref(left_type_ref), left_expr)?;
-            added.extend(compile_stack_variable_definition(ctx, right_name, type_name_from_ref(right_type_ref), right_expr)?);
+            let mut added = compile_stack_variable_definition(ctx, left_name, left_type_ref.clone(), left_expr)?;
+            added.extend(compile_stack_variable_definition(ctx, right_name, right_type_ref.clone(), right_expr)?);
             Ok(added)
         }
         _ => Err(CompilerError::Unsupported("tuple assignment only supports split()".to_string())),
@@ -1461,12 +1372,12 @@ fn compile_assign_statement<'i>(
     name: &str,
     expr: &Expr<'i>,
 ) -> Result<Vec<String>, CompilerError> {
-    if let Some(type_name) = ctx.types.get(name) {
+    if let Some(type_ref) = ctx.types.get(name) {
         if !ctx.stack_bindings.contains(name) {
             return Err(CompilerError::Unsupported(format!("assigned variable '{}' must be stack-bound before reassignment", name)));
         }
 
-        let lowered_expr = coerce_expr_for_declared_scalar_type(expr.clone(), type_name);
+        let lowered_expr = coerce_expr_for_declared_scalar_type(expr.clone(), type_ref);
         let mut stack_depth = 0i64;
         compile_expr(
             &lowered_expr,
@@ -1499,11 +1410,8 @@ pub(super) fn encoded_field_chunk_size<'i>(
     Ok(data_prefix(payload_size).len() + payload_size)
 }
 
-fn encoded_field_chunk_size_for_type_ref<'i>(
-    type_ref: &TypeRef,
-    contract_constants: &HashMap<String, Expr<'i>>,
-) -> Result<usize, CompilerError> {
-    let payload_size = fixed_state_field_payload_len_for_type_ref(type_ref, contract_constants)?;
+fn encoded_type_chunk_size<'i>(type_ref: &TypeRef, contract_constants: &HashMap<String, Expr<'i>>) -> Result<usize, CompilerError> {
+    let payload_size = fixed_state_payload_len(type_ref, contract_constants)?;
     Ok(data_prefix(payload_size).len() + payload_size)
 }
 
@@ -1518,9 +1426,7 @@ fn encoded_state_len_for_layout_field_types<'i>(
     layout_field_types: &[TypeRef],
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<usize, CompilerError> {
-    layout_field_types
-        .iter()
-        .try_fold(0usize, |acc, type_ref| Ok(acc + encoded_field_chunk_size_for_type_ref(type_ref, contract_constants)?))
+    layout_field_types.iter().try_fold(0usize, |acc, type_ref| Ok(acc + encoded_type_chunk_size(type_ref, contract_constants)?))
 }
 
 fn state_start_offset<'i>(
@@ -1589,9 +1495,8 @@ fn read_input_state_field_expr_with_type<'i>(
     contract_constants: &HashMap<String, Expr<'i>>,
     builtin_name: &str,
 ) -> Result<Expr<'i>, CompilerError> {
-    let field_payload_len = fixed_state_field_payload_len_for_type_ref(field_type, contract_constants).map_err(|_| {
-        CompilerError::Unsupported(format!("{builtin_name} does not support field type {}", type_name_from_ref(field_type)))
-    })?;
+    let field_payload_len = fixed_state_payload_len(field_type, contract_constants)
+        .map_err(|_| CompilerError::Unsupported(format!("{builtin_name} does not support field type {}", field_type.type_name())))?;
     let field_payload_offset = binary_expr(
         BinaryOp::Add,
         state_start_offset_expr,
@@ -1605,7 +1510,7 @@ fn read_input_state_field_expr_with_type<'i>(
 }
 
 fn cast_read_input_state_expr<'i>(substr: Expr<'i>, type_ref: &TypeRef) -> Result<Expr<'i>, CompilerError> {
-    let type_name = type_name_from_ref(type_ref);
+    let type_name = type_ref.type_name();
     match type_ref.base {
         TypeBase::Custom(_) => Err(CompilerError::Unsupported(format!("readInputState does not support field type {type_name}"))),
         _ => Ok(Expr::call(type_name.as_str(), vec![substr])),
@@ -1657,12 +1562,11 @@ fn compile_read_input_state_statement<'i>(
                     CompilerError::Unsupported("readInputState bindings must include all contract fields exactly once".to_string())
                 })?;
 
-                let binding_type = type_name_from_ref(&binding.type_ref);
-                let field_type = type_name_from_ref(&field.type_ref);
-                if binding_type != field_type {
+                if binding.type_ref != field.type_ref {
                     return Err(CompilerError::Unsupported(format!(
                         "readInputState binding '{}' expects {}",
-                        binding.name, field_type
+                        binding.name,
+                        field.type_ref.type_name()
                     )));
                 }
 
@@ -1674,7 +1578,12 @@ fn compile_read_input_state_statement<'i>(
                     script_size_value,
                     ctx.contract_constants,
                 )?;
-                added_stack_locals.extend(compile_stack_variable_definition(ctx, &binding.name, binding_type, binding_expr)?);
+                added_stack_locals.extend(compile_stack_variable_definition(
+                    ctx,
+                    &binding.name,
+                    binding.type_ref.clone(),
+                    binding_expr,
+                )?);
 
                 field_chunk_offset += encoded_field_chunk_size(field, ctx.contract_constants)?;
             }
@@ -1731,10 +1640,8 @@ fn compile_read_input_state_statement<'i>(
                         "readInputStateWithTemplate bindings must include all target fields exactly once".to_string(),
                     )
                 })?;
-                let binding_type = type_name_from_ref(&binding.type_ref);
-                let field_type = type_name_from_ref(&field.type_ref);
                 debug_assert_eq!(
-                    binding_type, field_type,
+                    binding.type_ref, field.type_ref,
                     "type_check must validate readInputStateWithTemplate destructuring binding types"
                 );
 
@@ -1747,9 +1654,14 @@ fn compile_read_input_state_statement<'i>(
                     ctx.contract_constants,
                     "readInputStateWithTemplate",
                 )?;
-                added_stack_locals.extend(compile_stack_variable_definition(ctx, &binding.name, binding_type, binding_expr)?);
+                added_stack_locals.extend(compile_stack_variable_definition(
+                    ctx,
+                    &binding.name,
+                    binding.type_ref.clone(),
+                    binding_expr,
+                )?);
 
-                field_chunk_offset += encoded_field_chunk_size_for_type_ref(&field.type_ref, ctx.contract_constants)?;
+                field_chunk_offset += encoded_type_chunk_size(&field.type_ref, ctx.contract_constants)?;
             }
 
             Ok(added_stack_locals)
@@ -1822,7 +1734,7 @@ fn struct_name_for_state_bindings<'i>(bindings: &[StructBindingAst<'i>], structs
 fn compile_read_input_state_with_template_validation(
     args: &[Expr<'_>],
     stack_bindings: &StackBindings,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
     layout_field_types: &[TypeRef],
@@ -1938,7 +1850,7 @@ fn compile_validate_output_state_inner_statement(
     args: &[Expr<'_>],
     constants: &HashMap<String, Expr<'_>>,
     stack_bindings: &StackBindings,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
     contract_fields: &[ContractFieldAst<'_>],
@@ -2087,7 +1999,7 @@ fn compile_validate_output_state_with_template_inner_statement(
     args: &[Expr<'_>],
     constants: &HashMap<String, Expr<'_>>,
     stack_bindings: &StackBindings,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
     script_size: Option<i64>,
@@ -2230,7 +2142,7 @@ fn compile_encoded_state_object(
     state_entries: &[StateFieldExpr<'_>],
     constants: &HashMap<String, Expr<'_>>,
     stack_bindings: &StackBindings,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
     script_size: Option<i64>,
@@ -2240,13 +2152,11 @@ fn compile_encoded_state_object(
     let mut stack_depth = 0i64;
     for entry in state_entries {
         let new_value = &entry.expr;
-        let type_name = infer_debug_expr_value_type(new_value, constants, types, &mut HashSet::new())?;
-        let type_ref = parse_type_ref(&type_name)?;
-        let field_size = fixed_state_field_payload_len_for_type_ref(&type_ref, contract_constants).map_err(|_| {
-            CompilerError::Unsupported(format!("{builtin_name} does not support field type {}", type_name_from_ref(&type_ref)))
-        })?;
+        let type_ref = infer_debug_expr_value_type(new_value, constants, types, &mut HashSet::new())?;
+        let field_size = fixed_state_payload_len(&type_ref, contract_constants)
+            .map_err(|_| CompilerError::Unsupported(format!("{builtin_name} does not support field type {}", type_ref.type_name())))?;
 
-        if !type_ref.is_array() && matches!(type_ref.base, TypeBase::Int | TypeBase::Bool) {
+        if type_ref.is_int() || type_ref.is_bool() {
             compile_expr(
                 new_value,
                 constants,
@@ -2297,7 +2207,7 @@ fn compile_encoded_flat_state_fields(
     state_fields: &[Expr<'_>],
     constants: &HashMap<String, Expr<'_>>,
     stack_bindings: &StackBindings,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
     script_size: Option<i64>,
@@ -2306,13 +2216,11 @@ fn compile_encoded_flat_state_fields(
 ) -> Result<i64, CompilerError> {
     let mut stack_depth = 0i64;
     for new_value in state_fields {
-        let type_name = infer_debug_expr_value_type(new_value, constants, types, &mut HashSet::new())?;
-        let type_ref = parse_type_ref(&type_name)?;
-        let field_size = fixed_state_field_payload_len_for_type_ref(&type_ref, contract_constants).map_err(|_| {
-            CompilerError::Unsupported(format!("{builtin_name} does not support field type {}", type_name_from_ref(&type_ref)))
-        })?;
+        let type_ref = infer_debug_expr_value_type(new_value, constants, types, &mut HashSet::new())?;
+        let field_size = fixed_state_payload_len(&type_ref, contract_constants)
+            .map_err(|_| CompilerError::Unsupported(format!("{builtin_name} does not support field type {}", type_ref.type_name())))?;
 
-        if !type_ref.is_array() && matches!(type_ref.base, TypeBase::Int | TypeBase::Bool) {
+        if type_ref.is_int() || type_ref.is_bool() {
             compile_expr(
                 new_value,
                 constants,
@@ -2408,7 +2316,7 @@ fn compile_time_op_statement<'i>(
     tx_var: &TimeVar,
     expr: &Expr<'i>,
     stack_bindings: &StackBindings,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
     script_size: Option<i64>,
@@ -2638,14 +2546,14 @@ pub(crate) fn resolve_expr<'i>(
 struct CompilationScope<'a, 'i> {
     constants: &'a HashMap<String, Expr<'i>>,
     stack_bindings: &'a StackBindings,
-    types: &'a HashMap<String, String>,
+    types: &'a TypeMap,
 }
 
 pub(super) fn compile_expr<'i>(
     expr: &Expr<'i>,
     constants: &HashMap<String, Expr<'i>>,
     stack_bindings: &StackBindings,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
     visiting: &mut HashSet<String>,
@@ -2746,9 +2654,10 @@ fn compile_array_expr<'i>(ctx: &mut CompileExprContext<'_, 'i>, values: &[Expr<'
 fn compile_runtime_array_literal<'i>(
     ctx: &mut CompileExprContext<'_, 'i>,
     values: &[Expr<'i>],
-    array_type: &str,
+    array_type: &TypeRef,
 ) -> Result<(), CompilerError> {
-    let element_type = array_element_type(array_type)
+    let element_type = array_type
+        .array_element_type()
         .ok_or_else(|| CompilerError::Unsupported("array literal type cannot be inferred".to_string()))?;
     for (index, value) in values.iter().enumerate() {
         compile_array_literal_element(ctx, value, &element_type)?;
@@ -2763,10 +2672,10 @@ fn compile_runtime_array_literal<'i>(
 fn compile_array_literal_element<'i>(
     ctx: &mut CompileExprContext<'_, 'i>,
     value: &Expr<'i>,
-    element_type: &str,
+    element_type: &TypeRef,
 ) -> Result<(), CompilerError> {
-    match element_type {
-        "int" => {
+    match (&element_type.base, element_type.array_dims.as_slice()) {
+        (TypeBase::Int, []) => {
             compile_expr_with_context(ctx, value)?;
             ctx.builder.add_i64(8)?;
             *ctx.stack_depth += 1;
@@ -2774,30 +2683,30 @@ fn compile_array_literal_element<'i>(
             *ctx.stack_depth -= 1;
             Ok(())
         }
-        "bool" => {
+        (TypeBase::Bool, []) => {
             let cast_expr = Expr::new(
                 ExprKind::Call { name: "byte[1]".to_string(), args: vec![value.clone()], name_span: span::Span::default() },
                 span::Span::default(),
             );
             compile_expr_with_context(ctx, &cast_expr)
         }
-        "byte" => compile_expr_with_context(ctx, value),
+        (TypeBase::Byte, []) => compile_expr_with_context(ctx, value),
         _ => compile_expr_with_context(ctx, value),
     }
 }
 
-fn infer_fixed_array_runtime_type<'i>(
-    values: &[Expr<'i>],
-    constants: &HashMap<String, Expr<'i>>,
-    types: &HashMap<String, String>,
-) -> Option<String> {
+fn infer_fixed_array_runtime_type<'i>(values: &[Expr<'i>], constants: &HashMap<String, Expr<'i>>, types: &TypeMap) -> Option<TypeRef> {
     infer_fixed_array_literal_type(values).or_else(|| {
         let first_type = infer_debug_expr_value_type(values.first()?, constants, types, &mut HashSet::new()).ok()?;
         fixed_type_size(&first_type)?;
-        if values.iter().skip(1).all(|value| {
-            infer_debug_expr_value_type(value, constants, types, &mut HashSet::new()).ok().as_deref() == Some(first_type.as_str())
-        }) {
-            Some(format!("{first_type}[]"))
+        if values
+            .iter()
+            .skip(1)
+            .all(|value| infer_debug_expr_value_type(value, constants, types, &mut HashSet::new()).ok().as_ref() == Some(&first_type))
+        {
+            let mut array_type = first_type;
+            array_type.array_dims.push(ArrayDim::Dynamic);
+            Some(array_type)
         } else {
             None
         }
@@ -2870,15 +2779,6 @@ fn compile_call_branch_expr<'i>(ctx: &mut CompileExprContext<'_, 'i>, name: &str
 
 fn compile_new_expr<'i>(ctx: &mut CompileExprContext<'_, 'i>, name: &str, args: &[Expr<'i>]) -> Result<(), CompilerError> {
     match name {
-        "LockingBytecodeNullData" => {
-            if args.len() != 1 {
-                return Err(CompilerError::Unsupported("LockingBytecodeNullData expects a single array argument".to_string()));
-            }
-            let script = build_null_data_script(&args[0])?;
-            ctx.builder.add_data_with_push_opcode(&script)?;
-            *ctx.stack_depth += 1;
-            Ok(())
-        }
         "ScriptPubKeyP2PK" => {
             if args.len() != 1 {
                 return Err(CompilerError::Unsupported("ScriptPubKeyP2PK expects a single pubkey argument".to_string()));
@@ -2965,7 +2865,7 @@ fn compile_binary_expr<'i>(
     left: &Expr<'i>,
     right: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    let left_cmp_type = infer_expr_type_ref_for_comparison(left, ctx.scope.constants, ctx.scope.types);
+    let left_cmp_type = infer_expr_type_for_comparison(left, ctx.scope.constants, ctx.scope.types);
     let coerced_right = if matches!(op, BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge) {
         coerce_rhs_byte_literal_for_comparison(left_cmp_type.as_ref(), right)
     } else {
@@ -2974,12 +2874,13 @@ fn compile_binary_expr<'i>(
     let left_value_type = infer_debug_expr_value_type(left, ctx.scope.constants, ctx.scope.types, &mut HashSet::new()).ok();
     let right_value_type = infer_debug_expr_value_type(&coerced_right, ctx.scope.constants, ctx.scope.types, &mut HashSet::new()).ok();
     debug_assert!(
-        !matches!(op, BinaryOp::Add) || (left_value_type.as_deref() != Some("byte") && right_value_type.as_deref() != Some("byte")),
+        !matches!(op, BinaryOp::Add)
+            || (!left_value_type.as_ref().is_some_and(TypeRef::is_byte) && !right_value_type.as_ref().is_some_and(TypeRef::is_byte)),
         "type_check must reject byte addition"
     );
     let bool_eq = matches!(op, BinaryOp::Eq | BinaryOp::Ne)
-        && left_value_type.as_deref() == Some("bool")
-        && right_value_type.as_deref() == Some("bool");
+        && left_value_type.as_ref().is_some_and(TypeRef::is_bool)
+        && right_value_type.as_ref().is_some_and(TypeRef::is_bool);
     let bytes_eq = matches!(op, BinaryOp::Eq | BinaryOp::Ne)
         && (expr_is_bytes(left, ctx.scope.types) || expr_is_bytes(&coerced_right, ctx.scope.types));
     let bytes_add = matches!(op, BinaryOp::Add) && (expr_is_bytes(left, ctx.scope.types) || expr_is_bytes(right, ctx.scope.types));
@@ -3133,8 +3034,9 @@ fn compile_array_index_expr<'i>(
         _ => resolve_expr(source.clone(), ctx.scope.constants, ctx.visiting)?,
     };
     let source_type = infer_debug_expr_value_type(&resolved_source, ctx.scope.constants, ctx.scope.types, &mut HashSet::new())?;
-    let element_type = array_element_type(&source_type)
-        .ok_or_else(|| CompilerError::Unsupported(format!("array index requires array source, got {source_type}")))?;
+    let element_type = source_type
+        .array_element_type()
+        .ok_or_else(|| CompilerError::Unsupported(format!("array index requires array source, got {}", source_type.type_name())))?;
     let element_size = fixed_type_size(&element_type)
         .ok_or_else(|| CompilerError::Unsupported("array element type must have known size".to_string()))?;
     compile_expr_with_context(ctx, &resolved_source)?;
@@ -3265,7 +3167,7 @@ fn compile_split_part<'i>(
     index: &Expr<'i>,
     part: SplitPart,
     stack_bindings: &StackBindings,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
     visiting: &mut HashSet<String>,
@@ -3329,12 +3231,12 @@ fn compile_split_part<'i>(
     }
 }
 
-fn expr_is_bytes<'i>(expr: &Expr<'i>, types: &HashMap<String, String>) -> bool {
+fn expr_is_bytes<'i>(expr: &Expr<'i>, types: &TypeMap) -> bool {
     let mut visiting = HashSet::new();
     expr_is_bytes_inner(expr, types, &mut visiting)
 }
 
-fn expr_is_bytes_inner<'i>(expr: &Expr<'i>, types: &HashMap<String, String>, visiting: &mut HashSet<String>) -> bool {
+fn expr_is_bytes_inner<'i>(expr: &Expr<'i>, types: &TypeMap, visiting: &mut HashSet<String>) -> bool {
     match &expr.kind {
         ExprKind::Byte(_) => true,
         ExprKind::String(_) => true,
@@ -3342,10 +3244,9 @@ fn expr_is_bytes_inner<'i>(expr: &Expr<'i>, types: &HashMap<String, String>, vis
         // regardless of element type, so downstream bytewise ops must treat them as bytes.
         ExprKind::Array(_) => true,
         ExprKind::Slice { .. } => true,
-        ExprKind::New { name, .. } => matches!(
-            name.as_str(),
-            "LockingBytecodeNullData" | "ScriptPubKeyP2PK" | "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript"
-        ),
+        ExprKind::New { name, .. } => {
+            matches!(name.as_str(), "ScriptPubKeyP2PK" | "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript")
+        }
         ExprKind::Call { name, .. } => {
             let name = name.as_str();
             matches!(
@@ -3389,7 +3290,7 @@ fn expr_is_bytes_inner<'i>(expr: &Expr<'i>, types: &HashMap<String, String>, vis
         ExprKind::Nullary(NullaryOp::ThisScriptSizeDataPrefix) => true,
         ExprKind::ArrayIndex { source, .. } => match &source.kind {
             ExprKind::Identifier(name) => {
-                types.get(name).and_then(|type_name| array_element_type(type_name)).map(|element| element != "int").unwrap_or(false)
+                types.get(name).and_then(TypeRef::array_element_type).is_some_and(|element| element.is_array() || !element.is_int())
             }
             _ => false,
         },
@@ -3398,7 +3299,7 @@ fn expr_is_bytes_inner<'i>(expr: &Expr<'i>, types: &HashMap<String, String>, vis
                 return false;
             }
             visiting.remove(name);
-            types.get(name).map(|type_name| is_bytes_type(type_name)).unwrap_or(false)
+            types.get(name).is_some_and(is_bytes_type)
         }
         ExprKind::UnarySuffix { kind, .. } => matches!(kind, UnarySuffixKind::Reverse),
         _ => false,
@@ -3408,7 +3309,7 @@ fn expr_is_bytes_inner<'i>(expr: &Expr<'i>, types: &HashMap<String, String>, vis
 fn compile_length_expr<'i>(
     expr: &Expr<'i>,
     stack_bindings: &StackBindings,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
     visiting: &mut HashSet<String>,
@@ -3417,13 +3318,13 @@ fn compile_length_expr<'i>(
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<(), CompilerError> {
     if let ExprKind::Identifier(name) = &expr.kind {
-        if let Some(type_name) = types.get(name) {
-            if let Some(size) = array_size_with_constants(type_name, contract_constants) {
+        if let Some(type_ref) = types.get(name) {
+            if let Some(size) = array_size_with_constants(type_ref, contract_constants) {
                 builder.add_i64(size as i64)?;
                 *stack_depth += 1;
                 return Ok(());
             }
-            if let Some(element_size) = array_element_size(type_name) {
+            if let Some(element_size) = array_element_size(type_ref) {
                 compile_expr(
                     expr,
                     contract_constants,
@@ -3519,9 +3420,7 @@ fn compile_call_expr<'i>(
         {
             compile_byte_sequence_cast_call(&mut ctx, name, args)
         }
-        name if parse_type_ref(name).is_ok_and(|type_ref| is_array_type_ref(&type_ref)) => {
-            compile_array_cast_call(&mut ctx, name, args)
-        }
+        name if parse_type_ref(name).is_ok_and(|type_ref| type_ref.is_array()) => compile_array_cast_call(&mut ctx, name, args),
         "blake2b" => compile_blake2b_call(&mut ctx, args),
         "blake2bWithKey" => compile_blake2b_with_key_call(&mut ctx, args),
         "blake3" => compile_blake3_call(&mut ctx, args),
@@ -3694,14 +3593,13 @@ fn compile_byte_sequence_cast_call<'i>(
     if args.len() != 1 {
         return Err(CompilerError::Unsupported(format!("{name}() expects a single argument")));
     }
-    let source_type = infer_expr_type_ref(&args[0], ctx.scope.types, ctx.scope.constants, &HashMap::new())
-        .map(|type_ref| type_name_from_ref(&type_ref))
+    let source_type = infer_expr_type(&args[0], ctx.scope.types, ctx.scope.constants, &HashMap::new())
         .or_else(|| infer_debug_expr_value_type(&args[0], ctx.scope.constants, ctx.scope.types, &mut HashSet::new()).ok());
-    if let Some(source_type) = source_type.as_deref() {
+    if let Some(source_type) = source_type.as_ref() {
         if let Some(source_size) = byte_sequence_cast_size(source_type) {
             if let Some(source_size) = source_size {
                 if source_size != size {
-                    return Err(CompilerError::Unsupported(format!("cannot cast {source_type} to {name}")));
+                    return Err(CompilerError::Unsupported(format!("cannot cast {} to {name}", source_type.type_name())));
                 }
             }
             return compile_call_arg_with_context(ctx, &args[0]);
@@ -3851,7 +3749,7 @@ fn compile_concat_operand<'i>(
     expr: &Expr<'i>,
     constants: &HashMap<String, Expr<'i>>,
     stack_bindings: &StackBindings,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     builder: &mut ScriptBuilder,
     options: CompileOptions,
     visiting: &mut HashSet<String>,
@@ -3869,88 +3767,31 @@ fn compile_concat_operand<'i>(
     Ok(())
 }
 
-pub(crate) fn is_bytes_type(type_name: &str) -> bool {
-    if type_name == "bytes" || type_name == "byte" || matches!(type_name, "pubkey" | "sig" | "datasig" | "string") {
-        return true;
-    }
-    // Check for byte[N] arrays
-    if let Some(elem_type) = array_element_type(type_name) {
-        if elem_type == "byte" || elem_type == "bytes" {
-            return true;
-        }
-    }
-    is_array_type(type_name)
+fn is_bytes_type(type_ref: &TypeRef) -> bool {
+    type_ref.is_array()
+        || type_ref.is_byte()
+        || type_ref.is_string()
+        || type_ref.is_pubkey()
+        || type_ref.is_sig()
+        || type_ref.is_datasig()
 }
 
-// TODO: Make it depend on the actual type instead of the name.
-fn byte_sequence_cast_size(type_name: &str) -> Option<Option<i64>> {
-    match type_name {
-        "bytes" | "byte[]" | "string" => Some(None),
-        "byte" => Some(Some(1)),
-        "pubkey" => Some(Some(32)),
-        "sig" => Some(Some(65)),
-        "datasig" => Some(Some(64)),
-        _ => match array_element_type(type_name).as_deref() {
-            Some("byte") => Some(array_size(type_name).map(|size| size as i64)),
-            _ => None,
-        },
+fn byte_sequence_cast_size(type_ref: &TypeRef) -> Option<Option<i64>> {
+    if type_ref.is_string() {
+        return Some(None);
     }
-}
-
-fn build_null_data_script<'i>(arg: &Expr<'i>) -> Result<Vec<u8>, CompilerError> {
-    let elements = match &arg.kind {
-        ExprKind::Array(items) => items,
-        _ => return Err(CompilerError::Unsupported("LockingBytecodeNullData expects an array literal".to_string())),
-    };
-
-    let mut builder = script_builder();
-    builder.add_op(OpReturn)?;
-    for item in elements {
-        match &item.kind {
-            ExprKind::Int(value) => {
-                builder.add_i64(*value)?;
-            }
-            ExprKind::DateLiteral(value) => {
-                builder.add_i64(*value)?;
-            }
-            ExprKind::Array(values) if values.iter().all(|value| matches!(&value.kind, ExprKind::Byte(_))) => {
-                let bytes: Vec<u8> = values
-                    .iter()
-                    .filter_map(|value| if let ExprKind::Byte(byte) = &value.kind { Some(*byte) } else { None })
-                    .collect();
-                builder.add_data_with_push_opcode(&bytes)?;
-            }
-            ExprKind::String(value) => {
-                builder.add_data_with_push_opcode(value.as_bytes())?;
-            }
-            ExprKind::Call { name, args, .. } if name == "bytes" || name == "byte[]" => {
-                if args.len() != 1 {
-                    return Err(CompilerError::Unsupported(
-                        "byte[]() in LockingBytecodeNullData expects a single argument".to_string(),
-                    ));
-                }
-                match &args[0].kind {
-                    ExprKind::String(value) => {
-                        builder.add_data_with_push_opcode(value.as_bytes())?;
-                    }
-                    _ => {
-                        return Err(CompilerError::Unsupported(
-                            "byte[]() in LockingBytecodeNullData only supports string literals".to_string(),
-                        ));
-                    }
-                }
-            }
-            _ => {
-                return Err(CompilerError::Unsupported("LockingBytecodeNullData only supports int or bytes literals".to_string()));
-            }
-        }
+    if type_ref.is_byte() {
+        return Some(Some(1));
     }
-
-    let script = builder.drain();
-    let mut spk_bytes = Vec::with_capacity(2 + script.len());
-    spk_bytes.extend_from_slice(&0u16.to_be_bytes());
-    spk_bytes.extend_from_slice(&script);
-    Ok(spk_bytes)
+    if !type_ref.is_array()
+        && let Some(size) = type_ref.base.fixed_byte_sequence_len()
+    {
+        return i64::try_from(size).ok().map(Some);
+    }
+    match type_ref.array_element_type() {
+        Some(element) if element.is_byte() => Some(array_size(type_ref).and_then(|size| i64::try_from(size).ok())),
+        _ => None,
+    }
 }
 
 fn data_prefix(data_len: usize) -> Vec<u8> {
@@ -3966,12 +3807,12 @@ pub fn compile_debug_expr<'i>(
     expr: &Expr<'i>,
     constants: &HashMap<String, Expr<'i>>,
     stack_bindings: &HashMap<String, i64>,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
 ) -> Result<(Vec<u8>, String), CompilerError> {
     let empty_constants = HashMap::new();
     let mut builder = script_builder();
     let mut stack_depth = 0i64;
-    let type_name = infer_debug_expr_value_type(expr, constants, types, &mut HashSet::new())?;
+    let type_ref = infer_debug_expr_value_type(expr, constants, types, &mut HashSet::new())?;
     let stack_bindings = StackBindings::from_depths(stack_bindings.clone());
     compile_expr(
         expr,
@@ -3985,7 +3826,7 @@ pub fn compile_debug_expr<'i>(
         None,
         &empty_constants,
     )?;
-    Ok((builder.drain(), type_name))
+    Ok((builder.drain(), type_ref.type_name()))
 }
 
 #[cfg(test)]

--- a/silverscript-lang/src/compiler/covenant_declarations.rs
+++ b/silverscript-lang/src/compiler/covenant_declarations.rs
@@ -263,7 +263,7 @@ fn parse_covenant_declaration<'i>(
     }
 
     let infers_single_state_transition_to_one =
-        mode == CovenantMode::Transition && function.return_types.len() == 1 && is_state_type_ref(&function.return_types[0]);
+        mode == CovenantMode::Transition && function.return_types.len() == 1 && is_state_type(&function.return_types[0]);
     let to_expr = match to_expr {
         Some(to_expr) => to_expr,
         None if infers_single_state_transition_to_one => Expr::int(1),
@@ -310,9 +310,7 @@ fn validate_covenant_policy_state_shape<'i>(
     match (declaration.binding, declaration.mode) {
         (CovenantBinding::Auth, CovenantMode::Verification) => {
             if declaration.singleton && declaration.termination != CovenantTermination::Allowed {
-                if policy.params.len() < 2
-                    || !is_state_type_ref(&policy.params[0].type_ref)
-                    || !is_state_type_ref(&policy.params[1].type_ref)
+                if policy.params.len() < 2 || !is_state_type(&policy.params[0].type_ref) || !is_state_type(&policy.params[1].type_ref)
                 {
                     return Err(CompilerError::Unsupported(format!(
                         "mode=verification with binding=auth on singleton function '{}' expects parameters '(State prev_state, State new_state, ...)'",
@@ -320,8 +318,8 @@ fn validate_covenant_policy_state_shape<'i>(
                     )));
                 }
             } else if policy.params.len() < 2
-                || !is_state_type_ref(&policy.params[0].type_ref)
-                || !is_state_array_type_ref(&policy.params[1].type_ref)
+                || !is_state_type(&policy.params[0].type_ref)
+                || !is_state_array_type(&policy.params[1].type_ref)
             {
                 return Err(CompilerError::Unsupported(format!(
                     "mode=verification with binding=auth on function '{}' expects parameters '(State prev_state, State[] new_states, ...)'",
@@ -331,8 +329,8 @@ fn validate_covenant_policy_state_shape<'i>(
         }
         (CovenantBinding::Cov, CovenantMode::Verification) => {
             if policy.params.len() < 2
-                || !is_state_array_type_ref(&policy.params[0].type_ref)
-                || !is_state_array_type_ref(&policy.params[1].type_ref)
+                || !is_state_array_type(&policy.params[0].type_ref)
+                || !is_state_array_type(&policy.params[1].type_ref)
             {
                 return Err(CompilerError::Unsupported(format!(
                     "mode=verification with binding=cov on function '{}' expects parameters '(State[] prev_states, State[] new_states, ...)'",
@@ -341,7 +339,7 @@ fn validate_covenant_policy_state_shape<'i>(
             }
         }
         (CovenantBinding::Auth, CovenantMode::Transition) => {
-            if policy.params.is_empty() || !is_state_type_ref(&policy.params[0].type_ref) {
+            if policy.params.is_empty() || !is_state_type(&policy.params[0].type_ref) {
                 return Err(CompilerError::Unsupported(format!(
                     "mode=transition with binding=auth on function '{}' expects parameters '(State prev_state, ...)'",
                     policy.name
@@ -349,7 +347,7 @@ fn validate_covenant_policy_state_shape<'i>(
             }
         }
         (CovenantBinding::Cov, CovenantMode::Transition) => {
-            if policy.params.is_empty() || !is_state_array_type_ref(&policy.params[0].type_ref) {
+            if policy.params.is_empty() || !is_state_array_type(&policy.params[0].type_ref) {
                 return Err(CompilerError::Unsupported(format!(
                     "mode=transition with binding=cov on function '{}' expects parameters '(State[] prev_states, ...)'",
                     policy.name
@@ -367,21 +365,21 @@ fn validate_covenant_policy_state_shape<'i>(
         }
 
         let return_type = &policy.return_types[0];
-        if !is_state_type_ref(return_type) && !is_state_array_type_ref(return_type) {
+        if !is_state_type(return_type) && !is_state_array_type(return_type) {
             return Err(CompilerError::Unsupported(format!(
                 "mode=transition on function '{}' with contract state expects return type 'State' or 'State[]'",
                 policy.name
             )));
         }
 
-        if declaration.singleton && is_state_array_type_ref(return_type) && declaration.termination != CovenantTermination::Allowed {
+        if declaration.singleton && is_state_array_type(return_type) && declaration.termination != CovenantTermination::Allowed {
             return Err(CompilerError::Unsupported(format!(
                 "transition mode singleton policy function '{}' must return a single State (arrays are not allowed unless termination=allowed)",
                 policy.name
             )));
         }
 
-        if is_state_type_ref(return_type) && !is_literal_int(&declaration.to_expr, 1) {
+        if is_state_type(return_type) && !is_literal_int(&declaration.to_expr, 1) {
             return Err(CompilerError::Unsupported(format!(
                 "mode=transition on function '{}' may return a single State only when 'to' is the literal 1 or omitted",
                 policy.name
@@ -425,14 +423,14 @@ fn build_auth_wrapper<'i>(
 
     let active_input = active_input_index_expr();
     let auth_out_count_name = "__auth_out_count";
-    body.push(var_def_statement(int_type_ref(), auth_out_count_name, Expr::call("OpAuthOutputCount", vec![active_input.clone()])));
+    body.push(var_def_statement(int_type(), auth_out_count_name, Expr::call("OpAuthOutputCount", vec![active_input.clone()])));
 
     if declaration.groups == CovenantGroups::Single {
         let cov_id_name = "__cov_id";
-        body.push(var_def_statement(bytes32_type_ref(), cov_id_name, Expr::call("OpInputCovenantId", vec![active_input.clone()])));
+        body.push(var_def_statement(bytes32_type(), cov_id_name, Expr::call("OpInputCovenantId", vec![active_input.clone()])));
         let cov_shared_out_count_name = "__cov_shared_out_count";
         body.push(var_def_statement(
-            int_type_ref(),
+            int_type(),
             cov_shared_out_count_name,
             Expr::call("OpCovOutputCount", vec![identifier_expr(cov_id_name)]),
         ));
@@ -448,18 +446,14 @@ fn build_auth_wrapper<'i>(
             CovenantMode::Verification => {
                 entrypoint_params = policy.params.iter().skip(1).cloned().collect();
                 let prev_state_name = &policy.params[0].name;
-                body.push(var_def_statement(
-                    state_type_ref(),
-                    prev_state_name,
-                    state_object_expr_from_contract_fields(contract_fields),
-                ));
+                body.push(var_def_statement(state_type(), prev_state_name, state_object_expr_from_contract_fields(contract_fields)));
                 body.push(call_statement(policy_name, policy.params.iter().map(|param| identifier_expr(&param.name)).collect()));
                 if declaration.singleton && declaration.termination != CovenantTermination::Allowed {
                     let new_state_name = &policy.params[1].name;
                     body.push(require_statement(binary_expr(BinaryOp::Eq, identifier_expr(auth_out_count_name), Expr::int(1))));
                     let out_idx_name = "__cov_out_idx";
                     body.push(var_def_statement(
-                        int_type_ref(),
+                        int_type(),
                         out_idx_name,
                         Expr::call("OpAuthOutputIdx", vec![active_input.clone(), Expr::int(0)]),
                     ));
@@ -491,23 +485,19 @@ fn build_auth_wrapper<'i>(
             CovenantMode::Transition => {
                 entrypoint_params = policy.params.iter().skip(1).cloned().collect();
                 let prev_state_name = &policy.params[0].name;
-                body.push(var_def_statement(
-                    state_type_ref(),
-                    prev_state_name,
-                    state_object_expr_from_contract_fields(contract_fields),
-                ));
+                body.push(var_def_statement(state_type(), prev_state_name, state_object_expr_from_contract_fields(contract_fields)));
                 let call_args = policy.params.iter().map(|param| identifier_expr(&param.name)).collect();
-                if is_state_type_ref(&policy.return_types[0]) {
+                if is_state_type(&policy.return_types[0]) {
                     let next_state_name = "__cov_new_state";
                     body.push(function_call_assign_statement(
-                        vec![typed_binding(state_type_ref(), next_state_name)],
+                        vec![typed_binding(state_type(), next_state_name)],
                         policy_name,
                         call_args,
                     ));
                     body.push(require_statement(binary_expr(BinaryOp::Eq, identifier_expr(auth_out_count_name), Expr::int(1))));
                     let out_idx_name = "__cov_out_idx";
                     body.push(var_def_statement(
-                        int_type_ref(),
+                        int_type(),
                         out_idx_name,
                         Expr::call("OpAuthOutputIdx", vec![active_input.clone(), Expr::int(0)]),
                     ));
@@ -518,7 +508,7 @@ fn build_auth_wrapper<'i>(
                 } else {
                     let next_states_name = "__cov_new_states";
                     body.push(function_call_assign_statement(
-                        vec![typed_binding(state_array_type_ref(), next_states_name)],
+                        vec![typed_binding(state_array_type(), next_states_name)],
                         policy_name,
                         call_args,
                     ));
@@ -573,22 +563,18 @@ fn build_cov_wrapper<'i>(
 
     let active_input = active_input_index_expr();
     let cov_id_name = "__cov_id";
-    body.push(var_def_statement(bytes32_type_ref(), cov_id_name, Expr::call("OpInputCovenantId", vec![active_input.clone()])));
+    body.push(var_def_statement(bytes32_type(), cov_id_name, Expr::call("OpInputCovenantId", vec![active_input.clone()])));
 
     let leader_idx_expr = Expr::call("OpCovInputIdx", vec![identifier_expr(cov_id_name), Expr::int(0)]);
     body.push(require_statement(binary_expr(if leader { BinaryOp::Eq } else { BinaryOp::Ne }, leader_idx_expr, active_input)));
 
     if leader {
         let in_count_name = "__cov_in_count";
-        body.push(var_def_statement(int_type_ref(), in_count_name, Expr::call("OpCovInputCount", vec![identifier_expr(cov_id_name)])));
+        body.push(var_def_statement(int_type(), in_count_name, Expr::call("OpCovInputCount", vec![identifier_expr(cov_id_name)])));
         body.push(require_statement(binary_expr(BinaryOp::Le, identifier_expr(in_count_name), declaration.from_expr.clone())));
 
         let out_count_name = "__cov_out_count";
-        body.push(var_def_statement(
-            int_type_ref(),
-            out_count_name,
-            Expr::call("OpCovOutputCount", vec![identifier_expr(cov_id_name)]),
-        ));
+        body.push(var_def_statement(int_type(), out_count_name, Expr::call("OpCovOutputCount", vec![identifier_expr(cov_id_name)])));
 
         if !contract_fields.is_empty() {
             match declaration.mode {
@@ -633,17 +619,17 @@ fn build_cov_wrapper<'i>(
                         prev_states_name,
                     );
                     let call_args = policy.params.iter().map(|param| identifier_expr(&param.name)).collect();
-                    if is_state_type_ref(&policy.return_types[0]) {
+                    if is_state_type(&policy.return_types[0]) {
                         let next_state_name = "__cov_new_state";
                         body.push(function_call_assign_statement(
-                            vec![typed_binding(state_type_ref(), next_state_name)],
+                            vec![typed_binding(state_type(), next_state_name)],
                             policy_name,
                             call_args,
                         ));
                         body.push(require_statement(binary_expr(BinaryOp::Eq, identifier_expr(out_count_name), Expr::int(1))));
                         let out_idx_name = "__cov_out_idx";
                         body.push(var_def_statement(
-                            int_type_ref(),
+                            int_type(),
                             out_idx_name,
                             Expr::call("OpCovOutputIdx", vec![identifier_expr(cov_id_name), Expr::int(0)]),
                         ));
@@ -654,7 +640,7 @@ fn build_cov_wrapper<'i>(
                     } else {
                         let next_states_name = "__cov_new_states";
                         body.push(function_call_assign_statement(
-                            vec![typed_binding(state_array_type_ref(), next_states_name)],
+                            vec![typed_binding(state_array_type(), next_states_name)],
                             policy_name,
                             call_args,
                         ));
@@ -721,19 +707,20 @@ fn generated_entrypoint<'i>(
     }
 }
 
-fn int_type_ref() -> TypeRef {
+// TODO: Define these constructor functions in a more central location.
+fn int_type() -> TypeRef {
     TypeRef { base: TypeBase::Int, array_dims: Vec::new() }
 }
 
-fn state_type_ref() -> TypeRef {
+fn state_type() -> TypeRef {
     TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: Vec::new() }
 }
 
-fn state_array_type_ref() -> TypeRef {
+fn state_array_type() -> TypeRef {
     TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: vec![ArrayDim::Dynamic] }
 }
 
-fn bytes32_type_ref() -> TypeRef {
+fn bytes32_type() -> TypeRef {
     TypeRef { base: TypeBase::Byte, array_dims: vec![ArrayDim::Fixed(32)] }
 }
 
@@ -858,12 +845,33 @@ fn length_expr<'i>(expr: Expr<'i>) -> Expr<'i> {
     )
 }
 
-fn is_state_type_ref(type_ref: &TypeRef) -> bool {
-    !type_ref.is_array() && matches!(&type_ref.base, TypeBase::Custom(name) if name == STATE_TYPE_NAME)
+// TODO: Define `is_state_type` and `is_state_array_type` in one central place.
+fn is_state_type(type_ref: &TypeRef) -> bool {
+    type_ref.is_custom() && matches!(&type_ref.base, TypeBase::Custom(name) if name == STATE_TYPE_NAME)
 }
 
-fn is_state_array_type_ref(type_ref: &TypeRef) -> bool {
-    type_ref.is_array() && matches!(&type_ref.base, TypeBase::Custom(name) if name == STATE_TYPE_NAME)
+fn is_state_array_type(type_ref: &TypeRef) -> bool {
+    matches!(&type_ref.base, TypeBase::Custom(name) if name == STATE_TYPE_NAME)
+        && matches!(type_ref.array_dims.as_slice(), [ArrayDim::Dynamic])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_array_type_requires_one_dynamic_dimension() {
+        assert!(is_state_array_type(&state_array_type()));
+        assert!(!is_state_array_type(&state_type()));
+        assert!(!is_state_array_type(&TypeRef {
+            base: TypeBase::Custom(STATE_TYPE_NAME.to_string()),
+            array_dims: vec![ArrayDim::Fixed(2)],
+        }));
+        assert!(!is_state_array_type(&TypeRef {
+            base: TypeBase::Custom(STATE_TYPE_NAME.to_string()),
+            array_dims: vec![ArrayDim::Dynamic, ArrayDim::Dynamic],
+        }));
+    }
 }
 
 fn is_literal_int(expr: &Expr<'_>, expected: i64) -> bool {
@@ -878,7 +886,7 @@ fn append_cov_input_state_reads_into_state_array<'i>(
     prev_states_name: &str,
 ) {
     let loop_var = "__cov_in_k";
-    body.push(var_decl_statement(state_array_type_ref(), prev_states_name));
+    body.push(var_decl_statement(state_array_type(), prev_states_name));
     let for_body = vec![array_append_statement(
         prev_states_name,
         Expr::call("readInputState", vec![Expr::call("OpCovInputIdx", vec![identifier_expr(cov_id_name), identifier_expr(loop_var)])]),
@@ -897,7 +905,7 @@ fn append_auth_output_state_array_checks_from_state_array<'i>(
     let out_idx_name = "__cov_out_idx";
     let for_body = vec![
         var_def_statement(
-            int_type_ref(),
+            int_type(),
             out_idx_name,
             Expr::call("OpAuthOutputIdx", vec![active_input.clone(), identifier_expr(loop_var)]),
         ),
@@ -920,7 +928,7 @@ fn append_cov_output_state_array_checks_from_state_array<'i>(
     let out_idx_name = "__cov_out_idx";
     let for_body = vec![
         var_def_statement(
-            int_type_ref(),
+            int_type(),
             out_idx_name,
             Expr::call("OpCovOutputIdx", vec![identifier_expr(cov_id_name), identifier_expr(loop_var)]),
         ),

--- a/silverscript-lang/src/compiler/covenant_declarations.rs
+++ b/silverscript-lang/src/compiler/covenant_declarations.rs
@@ -855,25 +855,6 @@ fn is_state_array_type(type_ref: &TypeRef) -> bool {
         && matches!(type_ref.array_dims.as_slice(), [ArrayDim::Dynamic])
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn state_array_type_requires_one_dynamic_dimension() {
-        assert!(is_state_array_type(&state_array_type()));
-        assert!(!is_state_array_type(&state_type()));
-        assert!(!is_state_array_type(&TypeRef {
-            base: TypeBase::Custom(STATE_TYPE_NAME.to_string()),
-            array_dims: vec![ArrayDim::Fixed(2)],
-        }));
-        assert!(!is_state_array_type(&TypeRef {
-            base: TypeBase::Custom(STATE_TYPE_NAME.to_string()),
-            array_dims: vec![ArrayDim::Dynamic, ArrayDim::Dynamic],
-        }));
-    }
-}
-
 fn is_literal_int(expr: &Expr<'_>, expected: i64) -> bool {
     matches!(expr.kind, ExprKind::Int(value) if value == expected)
 }
@@ -938,4 +919,23 @@ fn append_cov_output_state_array_checks_from_state_array<'i>(
         ),
     ];
     body.push(for_statement(loop_var, Expr::int(0), identifier_expr(out_count_name), to_expr, for_body));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_array_type_requires_one_dynamic_dimension() {
+        assert!(is_state_array_type(&state_array_type()));
+        assert!(!is_state_array_type(&state_type()));
+        assert!(!is_state_array_type(&TypeRef {
+            base: TypeBase::Custom(STATE_TYPE_NAME.to_string()),
+            array_dims: vec![ArrayDim::Fixed(2)],
+        }));
+        assert!(!is_state_array_type(&TypeRef {
+            base: TypeBase::Custom(STATE_TYPE_NAME.to_string()),
+            array_dims: vec![ArrayDim::Dynamic, ArrayDim::Dynamic],
+        }));
+    }
 }

--- a/silverscript-lang/src/compiler/debug_recording.rs
+++ b/silverscript-lang/src/compiler/debug_recording.rs
@@ -10,8 +10,7 @@ use crate::debug_info::{
 
 use super::stack_bindings::StackBindings;
 use super::{
-    CompileOptions, CompilerError, StructRegistry, build_struct_registry, flatten_type_ref_leaves, is_struct, is_struct_array,
-    type_name_from_ref,
+    CompileOptions, CompilerError, StructRegistry, TypeMap, build_struct_registry, flatten_type_leaves, is_struct, is_struct_array,
 };
 
 /// High-level compiler/debug bridge.
@@ -324,7 +323,7 @@ impl<'i> DebugRecorder<'i> {
         &mut self,
         stmt: &Statement<'i>,
         bytecode_start: usize,
-        _before_types: &HashMap<String, String>,
+        _before_types: &TypeMap,
         _before_stack_bindings: &StackBindings,
     ) {
         let Some(active) = self.active.as_mut() else {
@@ -360,7 +359,7 @@ impl<'i> DebugRecorder<'i> {
         &mut self,
         stmt: &Statement<'i>,
         bytecode_end: usize,
-        after_types: &HashMap<String, String>,
+        after_types: &TypeMap,
         after_stack_bindings: &StackBindings,
     ) {
         if !should_record_source_step(stmt) {
@@ -420,7 +419,7 @@ impl<'i> DebugRecorder<'i> {
         &mut self,
         stmt: &Statement<'i>,
         bytecode_end: usize,
-        after_types: &HashMap<String, String>,
+        after_types: &TypeMap,
         after_stack_bindings: &StackBindings,
     ) {
         let current_updates =
@@ -620,9 +619,9 @@ fn collect_console_args<'i>(recorder: &DebugRecorder<'i>, stmt: &Statement<'i>) 
 fn collect_variable_updates<'i>(
     recorder: &DebugRecorder<'i>,
     stmt: &Statement<'i>,
-    _before_types: &HashMap<String, String>,
+    _before_types: &TypeMap,
     _before_stack_bindings: &StackBindings,
-    after_types: &HashMap<String, String>,
+    after_types: &TypeMap,
     after_stack_bindings: &StackBindings,
 ) -> Vec<DebugVariableUpdate<'i>> {
     match stmt {
@@ -715,13 +714,13 @@ fn build_runtime_debug_update<'i>(
     recorder: &DebugRecorder<'i>,
     lowered_name: &str,
     expr: Expr<'i>,
-    after_types: &HashMap<String, String>,
+    after_types: &TypeMap,
     after_stack_bindings: &StackBindings,
 ) -> Option<DebugVariableUpdate<'i>> {
     if let Some(update) = build_structured_root_debug_update(recorder, lowered_name, expr.clone(), after_stack_bindings) {
         return Some(update);
     }
-    let type_name = after_types.get(lowered_name)?.clone();
+    let type_name = after_types.get(lowered_name)?.type_name();
     let stack_binding = after_stack_bindings
         .depth(lowered_name)
         .map(|from_top| crate::debug_info::DebugStackBinding { from_top, stack_height: Some(after_stack_bindings.len()) });
@@ -1127,10 +1126,10 @@ fn inline_param_leaf_bindings(type_ref: &TypeRef, structs: &StructRegistry) -> O
         return None;
     }
 
-    let leaf_bindings = flatten_type_ref_leaves(type_ref, structs)
+    let leaf_bindings = flatten_type_leaves(type_ref, structs)
         .ok()?
         .into_iter()
-        .map(|(field_path, leaf_type)| DebugLeafBinding { field_path, type_name: type_name_from_ref(&leaf_type), stack_binding: None })
+        .map(|(field_path, leaf_type)| DebugLeafBinding { field_path, type_name: leaf_type.type_name(), stack_binding: None })
         .collect::<Vec<_>>();
     Some(leaf_bindings)
 }
@@ -1207,7 +1206,7 @@ fn record_structured_binding_spec(
         visible_names.and_then(|names| names.get(lowered_base_name)).cloned().unwrap_or_else(|| lowered_base_name.to_string());
     let base_type_name = type_ref.type_name();
 
-    for (field_path, leaf_type) in flatten_type_ref_leaves(type_ref, structs)? {
+    for (field_path, leaf_type) in flatten_type_leaves(type_ref, structs)? {
         let lowered_leaf_name = flattened_struct_field_name(lowered_base_name, &field_path);
         specs.insert(
             lowered_leaf_name,
@@ -1215,7 +1214,7 @@ fn record_structured_binding_spec(
                 visible_base_name: visible_base_name.clone(),
                 base_type_name: base_type_name.clone(),
                 field_path,
-                leaf_type_name: type_name_from_ref(&leaf_type),
+                leaf_type_name: leaf_type.type_name(),
             },
         );
     }
@@ -1236,9 +1235,9 @@ fn build_param_mappings<'i>(
 
     for param in params_source {
         if is_struct(&param.type_ref, structs) || is_struct_array(&param.type_ref, structs) {
-            let leaf_specs = flatten_type_ref_leaves(&param.type_ref, structs)?
+            let leaf_specs = flatten_type_leaves(&param.type_ref, structs)?
                 .into_iter()
-                .map(|(field_path, leaf_type)| (field_path, type_name_from_ref(&leaf_type)))
+                .map(|(field_path, leaf_type)| (field_path, leaf_type.type_name()))
                 .collect::<Vec<_>>();
             for (field_path, _) in &leaf_specs {
                 flattened_param_names.push(flattened_struct_field_name(&param.name, field_path));

--- a/silverscript-lang/src/compiler/debug_value_types.rs
+++ b/silverscript-lang/src/compiler/debug_value_types.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::ast::{BinaryOp, Expr, ExprKind, IntrospectionKind, NullaryOp, TypeBase, UnaryOp, UnarySuffixKind};
+use crate::ast::{ArrayDim, BinaryOp, Expr, ExprKind, IntrospectionKind, NullaryOp, TypeBase, UnaryOp, UnarySuffixKind};
 use crate::errors::CompilerError;
 
 use super::{array_element_type, is_bytes_type, parse_type_ref};
@@ -89,6 +89,24 @@ fn is_builtin_cast_type_name(name: &str) -> bool {
     !matches!(type_ref.base, TypeBase::Custom(_))
 }
 
+fn concatenated_array_type(left: &str, right: &str) -> Option<String> {
+    let left = parse_type_ref(left).ok()?;
+    let right = parse_type_ref(right).ok()?;
+    let left_element = left.array_element_type()?;
+    if right.array_element_type()? != left_element {
+        return None;
+    }
+
+    let dimension = match (left.array_size()?, right.array_size()?) {
+        (ArrayDim::Dynamic, _) | (_, ArrayDim::Dynamic) => ArrayDim::Dynamic,
+        (ArrayDim::Fixed(left), ArrayDim::Fixed(right)) => ArrayDim::Fixed(left.checked_add(*right)?),
+        _ => return None,
+    };
+    let mut result = left_element;
+    result.array_dims.push(dimension);
+    Some(result.type_name())
+}
+
 pub(super) fn infer_debug_expr_value_type<'i>(
     expr: &Expr<'i>,
     env: &HashMap<String, Expr<'i>>,
@@ -127,6 +145,8 @@ pub(super) fn infer_debug_expr_value_type<'i>(
                     Ok("string".to_string())
                 } else if left_type == "byte" || right_type == "byte" {
                     Ok("int".to_string())
+                } else if let Some(concatenated) = concatenated_array_type(&left_type, &right_type) {
+                    Ok(concatenated)
                 } else if is_bytes_type(&left_type) {
                     Ok(left_type)
                 } else if is_bytes_type(&right_type) {
@@ -162,7 +182,12 @@ pub(super) fn infer_debug_expr_value_type<'i>(
                 Ok("byte[]".to_string())
             }
         }
-        ExprKind::Split { .. } | ExprKind::Slice { .. } | ExprKind::New { .. } => Ok("byte[]".to_string()),
+        ExprKind::Split { .. } | ExprKind::Slice { .. } => Ok("byte[]".to_string()),
+        ExprKind::New { name, .. } => match name.as_str() {
+            "ScriptPubKeyP2PK" => Ok("byte[34]".to_string()),
+            "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript" => Ok("byte[35]".to_string()),
+            _ => Ok("byte[]".to_string()),
+        },
         ExprKind::Append { source, .. } => infer_debug_expr_value_type(source, env, types, visiting),
         ExprKind::ArrayIndex { source, .. } => {
             let source_type = infer_debug_expr_value_type(source, env, types, visiting)?;
@@ -225,6 +250,24 @@ mod tests {
         types.insert("a".to_string(), "int".to_string());
         types.insert("b".to_string(), "int".to_string());
         assert_eq!(infer(add, HashMap::new(), types), "int");
+
+        let concat = Expr::new(
+            ExprKind::Binary { op: BinaryOp::Add, left: Box::new(Expr::identifier("a")), right: Box::new(Expr::identifier("b")) },
+            span::Span::default(),
+        );
+        let mut types = HashMap::new();
+        types.insert("a".to_string(), "int[2]".to_string());
+        types.insert("b".to_string(), "int[3]".to_string());
+        assert_eq!(infer(concat, HashMap::new(), types), "int[5]");
+
+        let dynamic_concat = Expr::new(
+            ExprKind::Binary { op: BinaryOp::Add, left: Box::new(Expr::identifier("a")), right: Box::new(Expr::identifier("b")) },
+            span::Span::default(),
+        );
+        let mut types = HashMap::new();
+        types.insert("a".to_string(), "int[]".to_string());
+        types.insert("b".to_string(), "int[3]".to_string());
+        assert_eq!(infer(dynamic_concat, HashMap::new(), types), "int[]");
 
         let index = Expr::new(
             ExprKind::ArrayIndex { source: Box::new(Expr::identifier("items")), index: Box::new(Expr::int(0)) },

--- a/silverscript-lang/src/compiler/debug_value_types.rs
+++ b/silverscript-lang/src/compiler/debug_value_types.rs
@@ -1,42 +1,45 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::ast::{BinaryOp, Expr, ExprKind, TypeBase, UnaryOp, UnarySuffixKind};
+use crate::ast::{ArrayDim, BinaryOp, Expr, ExprKind, TypeBase, TypeRef, UnaryOp, UnarySuffixKind};
 use crate::errors::CompilerError;
 
 use super::builtin_types::{builtin_return_type, constructor_return_type, introspection_type, nullary_type};
-use super::{array_element_type, concat_types, is_bytes_type, parse_type_ref};
+use super::{TypeMap, concat_types, parse_type_ref};
 
-fn is_builtin_cast_type_name(name: &str) -> bool {
-    if matches!(name, "int" | "bool" | "byte" | "string" | "pubkey" | "sig" | "datasig") {
-        return true;
-    }
-    if !name.contains('[') {
-        return false;
-    }
-    let Ok(type_ref) = parse_type_ref(name) else {
-        return false;
-    };
-
-    !matches!(type_ref.base, TypeBase::Custom(_))
+// TODO: Define these constructor functions in a more central location.
+fn scalar(base: TypeBase) -> TypeRef {
+    TypeRef { base, array_dims: Vec::new() }
 }
 
-fn concatenated_array_type<'i>(left: &str, right: &str, constants: &HashMap<String, Expr<'i>>) -> Option<String> {
-    let left = parse_type_ref(left).ok()?;
-    let right = parse_type_ref(right).ok()?;
-    concat_types(&left, &right, constants).map(|type_ref| type_ref.type_name())
+fn dynamic_bytes() -> TypeRef {
+    TypeRef { base: TypeBase::Byte, array_dims: vec![ArrayDim::Dynamic] }
+}
+
+fn builtin_cast_type(name: &str) -> Option<TypeRef> {
+    let type_ref = parse_type_ref(name).ok()?;
+    (!matches!(type_ref.base, TypeBase::Custom(_))).then_some(type_ref)
+}
+
+fn is_bytes_type(type_ref: &TypeRef) -> bool {
+    type_ref.is_array()
+        || type_ref.is_byte()
+        || type_ref.is_string()
+        || type_ref.is_pubkey()
+        || type_ref.is_sig()
+        || type_ref.is_datasig()
 }
 
 pub(super) fn infer_debug_expr_value_type<'i>(
     expr: &Expr<'i>,
     env: &HashMap<String, Expr<'i>>,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     visiting: &mut HashSet<String>,
-) -> Result<String, CompilerError> {
+) -> Result<TypeRef, CompilerError> {
     match &expr.kind {
-        ExprKind::Int(_) | ExprKind::DateLiteral(_) | ExprKind::NumberWithUnit { .. } => Ok("int".to_string()),
-        ExprKind::Bool(_) => Ok("bool".to_string()),
-        ExprKind::Byte(_) => Ok("byte".to_string()),
-        ExprKind::String(_) => Ok("string".to_string()),
+        ExprKind::Int(_) | ExprKind::DateLiteral(_) | ExprKind::NumberWithUnit { .. } => Ok(scalar(TypeBase::Int)),
+        ExprKind::Bool(_) => Ok(scalar(TypeBase::Bool)),
+        ExprKind::Byte(_) => Ok(scalar(TypeBase::Byte)),
+        ExprKind::String(_) => Ok(scalar(TypeBase::String)),
         ExprKind::Identifier(name) => {
             if !visiting.insert(name.clone()) {
                 return Err(CompilerError::CyclicIdentifier(name.clone()));
@@ -51,39 +54,39 @@ pub(super) fn infer_debug_expr_value_type<'i>(
             visiting.remove(name);
             result
         }
-        ExprKind::Unary { op: UnaryOp::Not, .. } => Ok("bool".to_string()),
-        ExprKind::Unary { op: UnaryOp::Neg, .. } => Ok("int".to_string()),
+        ExprKind::Unary { op: UnaryOp::Not, .. } => Ok(scalar(TypeBase::Bool)),
+        ExprKind::Unary { op: UnaryOp::Neg, .. } => Ok(scalar(TypeBase::Int)),
         ExprKind::Binary { op, left, right } => match op {
             BinaryOp::Or | BinaryOp::And | BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => {
-                Ok("bool".to_string())
+                Ok(scalar(TypeBase::Bool))
             }
             BinaryOp::Add => {
                 let left_type = infer_debug_expr_value_type(left, env, types, visiting)?;
                 let right_type = infer_debug_expr_value_type(right, env, types, visiting)?;
-                if left_type == "string" || right_type == "string" {
-                    Ok("string".to_string())
-                } else if left_type == "byte" || right_type == "byte" {
-                    Ok("int".to_string())
-                } else if let Some(concatenated) = concatenated_array_type(&left_type, &right_type, env) {
+                if left_type.is_string() || right_type.is_string() {
+                    Ok(scalar(TypeBase::String))
+                } else if left_type.is_byte() || right_type.is_byte() {
+                    Ok(scalar(TypeBase::Int))
+                } else if let Some(concatenated) = concat_types(&left_type, &right_type, env) {
                     Ok(concatenated)
                 } else if is_bytes_type(&left_type) {
                     Ok(left_type)
                 } else if is_bytes_type(&right_type) {
                     Ok(right_type)
-                } else if array_element_type(&left_type).is_some() {
+                } else if left_type.is_array() {
                     Ok(left_type)
-                } else if array_element_type(&right_type).is_some() {
+                } else if right_type.is_array() {
                     Ok(right_type)
                 } else {
-                    Ok("int".to_string())
+                    Ok(scalar(TypeBase::Int))
                 }
             }
             BinaryOp::BitOr | BinaryOp::BitXor | BinaryOp::BitAnd => {
                 let left_type = infer_debug_expr_value_type(left, env, types, visiting)?;
                 let right_type = infer_debug_expr_value_type(right, env, types, visiting)?;
-                if left_type == right_type && is_bytes_type(&left_type) { Ok(left_type) } else { Ok("int".to_string()) }
+                if left_type == right_type && is_bytes_type(&left_type) { Ok(left_type) } else { Ok(scalar(TypeBase::Int)) }
             }
-            BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod => Ok("int".to_string()),
+            BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod => Ok(scalar(TypeBase::Int)),
         },
         ExprKind::IfElse { then_expr, else_expr, .. } => {
             let then_type = infer_debug_expr_value_type(then_expr, env, types, visiting)?;
@@ -91,34 +94,34 @@ pub(super) fn infer_debug_expr_value_type<'i>(
             if then_type == else_type || (is_bytes_type(&then_type) && is_bytes_type(&else_type)) {
                 Ok(then_type)
             } else {
-                Ok("byte[]".to_string())
+                Ok(dynamic_bytes())
             }
         }
         ExprKind::Array(values) => {
             if values.iter().all(|value| matches!(value.kind, ExprKind::Byte(_))) {
-                Ok(format!("byte[{}]", values.len()))
+                Ok(TypeRef { base: TypeBase::Byte, array_dims: vec![ArrayDim::Fixed(values.len())] })
             } else {
-                Ok("byte[]".to_string())
+                Ok(dynamic_bytes())
             }
         }
-        ExprKind::Split { .. } | ExprKind::Slice { .. } => Ok("byte[]".to_string()),
-        ExprKind::New { name, .. } => Ok(constructor_return_type(name).map_or_else(|| "byte[]".to_string(), |ty| ty.type_name())),
+        ExprKind::Split { .. } | ExprKind::Slice { .. } => Ok(dynamic_bytes()),
+        ExprKind::New { name, .. } => Ok(constructor_return_type(name).unwrap_or_else(dynamic_bytes)),
         ExprKind::Append { source, .. } => infer_debug_expr_value_type(source, env, types, visiting),
         ExprKind::ArrayIndex { source, .. } => {
             let source_type = infer_debug_expr_value_type(source, env, types, visiting)?;
-            Ok(array_element_type(&source_type).unwrap_or_else(|| "byte[]".to_string()))
+            Ok(source_type.array_element_type().unwrap_or_else(dynamic_bytes))
         }
-        ExprKind::Nullary(kind) => Ok(nullary_type(*kind).type_name()),
-        ExprKind::Introspection { kind, .. } => Ok(introspection_type(*kind).type_name()),
+        ExprKind::Nullary(kind) => Ok(nullary_type(*kind)),
+        ExprKind::Introspection { kind, .. } => Ok(introspection_type(*kind)),
         ExprKind::Call { name, .. } => {
-            if is_builtin_cast_type_name(name) {
-                Ok(name.clone())
+            if let Some(type_ref) = builtin_cast_type(name) {
+                Ok(type_ref)
             } else {
-                Ok(builtin_return_type(name).map_or_else(|| "byte[]".to_string(), |ty| ty.type_name()))
+                Ok(builtin_return_type(name).unwrap_or_else(dynamic_bytes))
             }
         }
         ExprKind::UnarySuffix { source, kind, .. } => match kind {
-            UnarySuffixKind::Length => Ok("int".to_string()),
+            UnarySuffixKind::Length => Ok(scalar(TypeBase::Int)),
             UnarySuffixKind::Reverse => infer_debug_expr_value_type(source, env, types, visiting),
         },
         ExprKind::FieldAccess { .. } => {
@@ -134,13 +137,14 @@ pub(super) fn infer_debug_expr_value_type<'i>(
 mod tests {
     use std::collections::{HashMap, HashSet};
 
-    use crate::ast::{BinaryOp, Expr, ExprKind, IntrospectionKind, NullaryOp, UnarySuffixKind};
+    use crate::ast::{BinaryOp, Expr, ExprKind, IntrospectionKind, NullaryOp, UnarySuffixKind, parse_type_ref};
     use crate::span;
 
     use super::infer_debug_expr_value_type;
 
     fn infer(expr: Expr<'static>, env: HashMap<String, Expr<'static>>, types: HashMap<String, String>) -> String {
-        infer_debug_expr_value_type(&expr, &env, &types, &mut HashSet::new()).expect("infer type")
+        let types = types.into_iter().map(|(name, type_name)| (name, parse_type_ref(&type_name).expect("valid test type"))).collect();
+        infer_debug_expr_value_type(&expr, &env, &types, &mut HashSet::new()).expect("infer type").type_name()
     }
 
     #[test]

--- a/silverscript-lang/src/compiler/debug_value_types.rs
+++ b/silverscript-lang/src/compiler/debug_value_types.rs
@@ -1,79 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::ast::{ArrayDim, BinaryOp, Expr, ExprKind, IntrospectionKind, NullaryOp, TypeBase, UnaryOp, UnarySuffixKind};
+use crate::ast::{BinaryOp, Expr, ExprKind, TypeBase, UnaryOp, UnarySuffixKind};
 use crate::errors::CompilerError;
 
-use super::{array_element_type, is_bytes_type, parse_type_ref};
-
-fn nullary_value_type(op: NullaryOp) -> &'static str {
-    match op {
-        NullaryOp::ActiveScriptPubKey | NullaryOp::ThisScriptSizeDataPrefix => "byte[]",
-        NullaryOp::ActiveInputIndex
-        | NullaryOp::ThisScriptSize
-        | NullaryOp::TxInputsLength
-        | NullaryOp::TxOutputsLength
-        | NullaryOp::TxVersion
-        | NullaryOp::TxLockTime => "int",
-    }
-}
-
-fn introspection_value_type(kind: IntrospectionKind) -> &'static str {
-    match kind {
-        IntrospectionKind::InputScriptPubKey
-        | IntrospectionKind::InputSigScript
-        | IntrospectionKind::InputOutpointTransactionHash
-        | IntrospectionKind::OutputScriptPubKey => "byte[]",
-        IntrospectionKind::InputValue
-        | IntrospectionKind::InputOutpointIndex
-        | IntrospectionKind::InputSequenceNumber
-        | IntrospectionKind::OutputValue => "int",
-    }
-}
-
-fn builtin_call_value_type(name: &str) -> &'static str {
-    match name {
-        "int" => "int",
-        "bool" => "bool",
-        "byte" => "byte",
-        "string" => "string",
-        "pubkey" => "pubkey",
-        "sig" => "sig",
-        "datasig" => "datasig",
-        "OpBin2Num"
-        | "OpTxInputDaaScore"
-        | "OpTxGas"
-        | "OpTxPayloadLen"
-        | "OpTxInputIndex"
-        | "OpTxInputScriptSigLen"
-        | "OpTxInputSpkLen"
-        | "OpOutpointIndex"
-        | "OpTxOutputSpkLen"
-        | "OpAuthOutputCount"
-        | "OpAuthOutputIdx"
-        | "OpCovInputCount"
-        | "OpCovInputIdx"
-        | "OpCovOutputCount"
-        | "OpCovOutputIdx" => "int",
-        "OpTxInputIsCoinbase" | "checkSig" | "checkSigFromStack" | "checkSigFromStackECDSA" => "bool",
-        "blake2b" | "blake2bWithKey" | "blake3" | "blake3WithKey" | "templateHash" | "sha256" | "OpSha256" => "byte[32]",
-        "bytes"
-        | "OpTxSubnetId"
-        | "OpTxPayloadSubstr"
-        | "OpOutpointTxId"
-        | "OpTxInputScriptSigSubstr"
-        | "OpTxInputSeq"
-        | "OpTxInputSpkSubstr"
-        | "OpTxOutputSpkSubstr"
-        | "OpNum2Bin"
-        | "OpChainblockSeqCommit"
-        | "LockingBytecodeNullData"
-        | "ScriptPubKeyP2PK"
-        | "ScriptPubKeyP2SH"
-        | "ScriptPubKeyP2SHFromRedeemScript" => "byte[]",
-        "OpInputCovenantId" | "OpOutputCovenantId" => "byte[32]",
-        _ => "byte[]",
-    }
-}
+use super::builtin_types::{builtin_return_type, constructor_return_type, introspection_type, nullary_type};
+use super::{array_element_type, concat_types, is_bytes_type, parse_type_ref};
 
 fn is_builtin_cast_type_name(name: &str) -> bool {
     if matches!(name, "int" | "bool" | "byte" | "string" | "pubkey" | "sig" | "datasig") {
@@ -89,22 +20,10 @@ fn is_builtin_cast_type_name(name: &str) -> bool {
     !matches!(type_ref.base, TypeBase::Custom(_))
 }
 
-fn concatenated_array_type(left: &str, right: &str) -> Option<String> {
+fn concatenated_array_type<'i>(left: &str, right: &str, constants: &HashMap<String, Expr<'i>>) -> Option<String> {
     let left = parse_type_ref(left).ok()?;
     let right = parse_type_ref(right).ok()?;
-    let left_element = left.array_element_type()?;
-    if right.array_element_type()? != left_element {
-        return None;
-    }
-
-    let dimension = match (left.array_size()?, right.array_size()?) {
-        (ArrayDim::Dynamic, _) | (_, ArrayDim::Dynamic) => ArrayDim::Dynamic,
-        (ArrayDim::Fixed(left), ArrayDim::Fixed(right)) => ArrayDim::Fixed(left.checked_add(*right)?),
-        _ => return None,
-    };
-    let mut result = left_element;
-    result.array_dims.push(dimension);
-    Some(result.type_name())
+    concat_types(&left, &right, constants).map(|type_ref| type_ref.type_name())
 }
 
 pub(super) fn infer_debug_expr_value_type<'i>(
@@ -145,7 +64,7 @@ pub(super) fn infer_debug_expr_value_type<'i>(
                     Ok("string".to_string())
                 } else if left_type == "byte" || right_type == "byte" {
                     Ok("int".to_string())
-                } else if let Some(concatenated) = concatenated_array_type(&left_type, &right_type) {
+                } else if let Some(concatenated) = concatenated_array_type(&left_type, &right_type, env) {
                     Ok(concatenated)
                 } else if is_bytes_type(&left_type) {
                     Ok(left_type)
@@ -183,23 +102,19 @@ pub(super) fn infer_debug_expr_value_type<'i>(
             }
         }
         ExprKind::Split { .. } | ExprKind::Slice { .. } => Ok("byte[]".to_string()),
-        ExprKind::New { name, .. } => match name.as_str() {
-            "ScriptPubKeyP2PK" => Ok("byte[34]".to_string()),
-            "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript" => Ok("byte[35]".to_string()),
-            _ => Ok("byte[]".to_string()),
-        },
+        ExprKind::New { name, .. } => Ok(constructor_return_type(name).map_or_else(|| "byte[]".to_string(), |ty| ty.type_name())),
         ExprKind::Append { source, .. } => infer_debug_expr_value_type(source, env, types, visiting),
         ExprKind::ArrayIndex { source, .. } => {
             let source_type = infer_debug_expr_value_type(source, env, types, visiting)?;
             Ok(array_element_type(&source_type).unwrap_or_else(|| "byte[]".to_string()))
         }
-        ExprKind::Nullary(kind) => Ok(nullary_value_type(*kind).to_string()),
-        ExprKind::Introspection { kind, .. } => Ok(introspection_value_type(*kind).to_string()),
+        ExprKind::Nullary(kind) => Ok(nullary_type(*kind).type_name()),
+        ExprKind::Introspection { kind, .. } => Ok(introspection_type(*kind).type_name()),
         ExprKind::Call { name, .. } => {
             if is_builtin_cast_type_name(name) {
                 Ok(name.clone())
             } else {
-                Ok(builtin_call_value_type(name).to_string())
+                Ok(builtin_return_type(name).map_or_else(|| "byte[]".to_string(), |ty| ty.type_name()))
             }
         }
         ExprKind::UnarySuffix { source, kind, .. } => match kind {

--- a/silverscript-lang/src/compiler/infer_array.rs
+++ b/silverscript-lang/src/compiler/infer_array.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
 
 use super::builtin_types::{builtin_return_type, constructor_return_type, introspection_type, nullary_type};
-use super::compile::type_name_from_ref;
 use super::*;
-use crate::ast::{ArrayDim, ConstantAst, ContractAst, ContractFieldAst, FunctionAst, ParamAst, Statement, TypeRef};
+use crate::ast::{ArrayDim, ConstantAst, ContractAst, ContractFieldAst, FunctionAst, ParamAst, Statement, TypeBase, TypeRef};
 
 pub(super) fn lower_inferred_array_sizes<'i>(
     contract: &ContractAst<'i>,
@@ -13,7 +12,7 @@ pub(super) fn lower_inferred_array_sizes<'i>(
         contract.functions.iter().map(|function| (function.name.clone(), function)).collect();
     let mut top_level_types = HashMap::new();
     for param in &contract.params {
-        top_level_types.insert(param.name.clone(), type_name_from_ref(&param.type_ref));
+        top_level_types.insert(param.name.clone(), param.type_ref.clone());
     }
 
     let constants = contract
@@ -45,10 +44,10 @@ pub(super) fn lower_inferred_array_sizes<'i>(
     })
 }
 
-fn infer_fixed_array_type_from_initializer_ref<'i>(
+fn infer_fixed_array_type_from_initializer<'i>(
     declared_type: &TypeRef,
     initializer: Option<&Expr<'i>>,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Option<TypeRef> {
@@ -58,7 +57,7 @@ fn infer_fixed_array_type_from_initializer_ref<'i>(
 
     let element_type = declared_type.array_element_type()?;
     let init = initializer?;
-    let init_type = infer_expr_type_ref_with_hint(init, types, constants, functions, Some(&element_type))?;
+    let init_type = infer_expr_type_with_hint(init, types, constants, functions, Some(&element_type))?;
 
     if !init_type.is_array() || !type_refs_equal(&init_type.array_element_type()?, &element_type, constants) {
         return None;
@@ -72,37 +71,37 @@ fn infer_fixed_array_type_from_initializer_ref<'i>(
 
 fn lower_constant<'i>(
     constant: &ConstantAst<'i>,
-    types: &mut HashMap<String, String>,
+    types: &mut TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Result<ConstantAst<'i>, CompilerError> {
-    let type_ref = infer_type_ref(&constant.type_ref, Some(&constant.expr), types, constants, functions)
+    let type_ref = infer_type(&constant.type_ref, Some(&constant.expr), types, constants, functions)
         .ok_or_else(|| CompilerError::Unsupported(format!("cannot infer fixed array size from constant '{}'", constant.name)))?;
-    types.insert(constant.name.clone(), type_name_from_ref(&type_ref));
+    types.insert(constant.name.clone(), type_ref.clone());
     Ok(ConstantAst { type_ref, ..constant.clone() })
 }
 
 fn lower_field<'i>(
     field: &ContractFieldAst<'i>,
-    types: &mut HashMap<String, String>,
+    types: &mut TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Result<ContractFieldAst<'i>, CompilerError> {
-    let type_ref = infer_type_ref(&field.type_ref, Some(&field.expr), types, constants, functions)
+    let type_ref = infer_type(&field.type_ref, Some(&field.expr), types, constants, functions)
         .ok_or_else(|| CompilerError::Unsupported(format!("cannot infer fixed array size from contract field '{}'", field.name)))?;
-    types.insert(field.name.clone(), type_name_from_ref(&type_ref));
+    types.insert(field.name.clone(), type_ref.clone());
     Ok(ContractFieldAst { type_ref, ..field.clone() })
 }
 
 fn lower_function<'i>(
     function: &FunctionAst<'i>,
-    top_level_types: &HashMap<String, String>,
+    top_level_types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Result<FunctionAst<'i>, CompilerError> {
     let mut types = top_level_types.clone();
     for param in &function.params {
-        types.insert(param.name.clone(), type_name_from_ref(&param.type_ref));
+        types.insert(param.name.clone(), param.type_ref.clone());
     }
     let body = lower_block(&function.body, &mut types, constants, functions)?;
     Ok(FunctionAst { body, ..function.clone() })
@@ -110,7 +109,7 @@ fn lower_function<'i>(
 
 fn lower_block<'i>(
     statements: &[Statement<'i>],
-    types: &mut HashMap<String, String>,
+    types: &mut TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Result<Vec<Statement<'i>>, CompilerError> {
@@ -123,15 +122,15 @@ fn lower_block<'i>(
 
 fn lower_statement<'i>(
     statement: &Statement<'i>,
-    types: &mut HashMap<String, String>,
+    types: &mut TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Result<Statement<'i>, CompilerError> {
     match statement {
         Statement::VariableDefinition { type_ref, name, expr, .. } => {
-            let lowered_type = infer_type_ref(type_ref, expr.as_ref(), types, constants, functions)
+            let lowered_type = infer_type(type_ref, expr.as_ref(), types, constants, functions)
                 .ok_or_else(|| CompilerError::Unsupported(format!("cannot infer fixed array size from variable '{}'", name)))?;
-            types.insert(name.clone(), type_name_from_ref(&lowered_type));
+            types.insert(name.clone(), lowered_type.clone());
             Ok(match statement {
                 Statement::VariableDefinition { modifiers, span, type_span, modifier_spans, name_span, .. } => {
                     Statement::VariableDefinition {
@@ -152,10 +151,10 @@ fn lower_statement<'i>(
             let lowered_bindings = bindings
                 .iter()
                 .map(|binding| {
-                    let lowered_type = infer_type_ref(&binding.type_ref, None, types, constants, functions).ok_or_else(|| {
+                    let lowered_type = infer_type(&binding.type_ref, None, types, constants, functions).ok_or_else(|| {
                         CompilerError::Unsupported(format!("cannot infer fixed array size from binding '{}'", binding.name))
                     })?;
-                    types.insert(binding.name.clone(), type_name_from_ref(&lowered_type));
+                    types.insert(binding.name.clone(), lowered_type.clone());
                     Ok(ParamAst { type_ref: lowered_type, ..binding.clone() })
                 })
                 .collect::<Result<Vec<_>, CompilerError>>()?;
@@ -193,7 +192,7 @@ fn lower_statement<'i>(
         }
         Statement::For { ident, start, end, max_iterations, body, span, ident_span, body_span } => {
             let mut body_types = types.clone();
-            body_types.insert(ident.clone(), "int".to_string());
+            body_types.insert(ident.clone(), TypeRef { base: TypeBase::Int, array_dims: Vec::new() });
             let lowered_body = lower_block(body, &mut body_types, constants, functions)?;
             Ok(Statement::For {
                 ident: ident.clone(),
@@ -210,42 +209,44 @@ fn lower_statement<'i>(
     }
 }
 
-fn infer_type_ref<'i>(
+fn infer_type<'i>(
     declared_type: &TypeRef,
     initializer: Option<&Expr<'i>>,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Option<TypeRef> {
     if matches!(declared_type.array_size(), Some(ArrayDim::Inferred)) {
-        infer_fixed_array_type_from_initializer_ref(declared_type, initializer, types, constants, functions)
+        infer_fixed_array_type_from_initializer(declared_type, initializer, types, constants, functions)
     } else {
         Some(declared_type.clone())
     }
 }
 
-pub(super) fn infer_expr_type_ref<'i>(
+pub(super) fn infer_expr_type<'i>(
     expr: &Expr<'i>,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Option<TypeRef> {
-    infer_expr_type_ref_with_hint(expr, types, constants, functions, None)
+    infer_expr_type_with_hint(expr, types, constants, functions, None)
 }
 
-fn infer_expr_type_ref_with_hint<'i>(
+fn infer_expr_type_with_hint<'i>(
     expr: &Expr<'i>,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
     array_literal_element_type: Option<&TypeRef>,
 ) -> Option<TypeRef> {
     match &expr.kind {
-        ExprKind::Int(_) | ExprKind::DateLiteral(_) | ExprKind::NumberWithUnit { .. } => parse_type_ref("int").ok(),
-        ExprKind::Bool(_) => parse_type_ref("bool").ok(),
-        ExprKind::String(_) => parse_type_ref("string").ok(),
-        ExprKind::Byte(_) => parse_type_ref("byte").ok(),
-        ExprKind::Identifier(name) => parse_type_ref(types.get(name)?).ok(),
+        ExprKind::Int(_) | ExprKind::DateLiteral(_) | ExprKind::NumberWithUnit { .. } => {
+            Some(TypeRef { base: TypeBase::Int, array_dims: Vec::new() })
+        }
+        ExprKind::Bool(_) => Some(TypeRef { base: TypeBase::Bool, array_dims: Vec::new() }),
+        ExprKind::String(_) => Some(TypeRef { base: TypeBase::String, array_dims: Vec::new() }),
+        ExprKind::Byte(_) => Some(TypeRef { base: TypeBase::Byte, array_dims: Vec::new() }),
+        ExprKind::Identifier(name) => types.get(name).cloned(),
         ExprKind::Array(values) => {
             let mut inferred = array_literal_element_type
                 .cloned()
@@ -255,7 +256,7 @@ fn infer_expr_type_ref_with_hint<'i>(
         }
         ExprKind::Call { name, .. } => {
             if let Some(function) = functions.get(name) {
-                return (!function.entrypoint).then(|| function.return_type_ref()).flatten();
+                return (!function.entrypoint).then(|| function.return_type()).flatten();
             }
             parse_type_ref(name)
                 .ok()
@@ -264,21 +265,21 @@ fn infer_expr_type_ref_with_hint<'i>(
         }
         ExprKind::New { name, .. } => constructor_return_type(name),
         ExprKind::Binary { op: BinaryOp::Add, left, right } => {
-            let left_type = infer_expr_type_ref_with_hint(left, types, constants, functions, None)?;
-            let right_type = infer_expr_type_ref_with_hint(right, types, constants, functions, None)?;
+            let left_type = infer_expr_type_with_hint(left, types, constants, functions, None)?;
+            let right_type = infer_expr_type_with_hint(right, types, constants, functions, None)?;
             concat_types(&left_type, &right_type, constants)
         }
         ExprKind::IfElse { then_expr, else_expr, .. } => {
-            let then_type = infer_expr_type_ref_with_hint(then_expr, types, constants, functions, None)?;
-            let else_type = infer_expr_type_ref_with_hint(else_expr, types, constants, functions, None)?;
+            let then_type = infer_expr_type_with_hint(then_expr, types, constants, functions, None)?;
+            let else_type = infer_expr_type_with_hint(else_expr, types, constants, functions, None)?;
             type_refs_equal(&then_type, &else_type, constants).then_some(then_type)
         }
         ExprKind::Append { source, args, .. } => {
-            let source_type = infer_expr_type_ref_with_hint(source, types, constants, functions, None)?;
+            let source_type = infer_expr_type_with_hint(source, types, constants, functions, None)?;
             append_type(&source_type, args.len(), constants)
         }
         ExprKind::UnarySuffix { source, kind: UnarySuffixKind::Reverse, .. } => {
-            infer_expr_type_ref_with_hint(source, types, constants, functions, None)
+            infer_expr_type_with_hint(source, types, constants, functions, None)
         }
         ExprKind::Nullary(kind) => Some(nullary_type(*kind)),
         ExprKind::Introspection { kind, .. } => Some(introspection_type(*kind)),
@@ -288,13 +289,13 @@ fn infer_expr_type_ref_with_hint<'i>(
 
 fn infer_array_literal_element_type<'i>(
     values: &[Expr<'i>],
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Option<TypeRef> {
-    let first_type = infer_expr_type_ref_with_hint(values.first()?, types, constants, functions, None)?;
+    let first_type = infer_expr_type_with_hint(values.first()?, types, constants, functions, None)?;
     if values.iter().skip(1).all(|value| {
-        infer_expr_type_ref_with_hint(value, types, constants, functions, None)
+        infer_expr_type_with_hint(value, types, constants, functions, None)
             .is_some_and(|type_ref| type_refs_equal(&type_ref, &first_type, constants))
     }) {
         Some(first_type)

--- a/silverscript-lang/src/compiler/infer_array.rs
+++ b/silverscript-lang/src/compiler/infer_array.rs
@@ -57,7 +57,7 @@ fn infer_fixed_array_type_from_initializer_ref<'i>(
 
     let element_type = declared_type.array_element_type()?;
     let init = initializer?;
-    let init_type = infer_expr_type_ref(init, types, constants, functions, Some(&element_type))?;
+    let init_type = infer_expr_type_ref_with_hint(init, types, constants, functions, Some(&element_type))?;
 
     if !init_type.is_array() || init_type.array_element_type() != Some(element_type.clone()) {
         return None;
@@ -223,7 +223,16 @@ fn infer_type_ref<'i>(
     }
 }
 
-fn infer_expr_type_ref<'i>(
+pub(super) fn infer_expr_type_ref<'i>(
+    expr: &Expr<'i>,
+    types: &HashMap<String, String>,
+    constants: &HashMap<String, Expr<'i>>,
+    functions: &HashMap<String, &FunctionAst<'i>>,
+) -> Option<TypeRef> {
+    infer_expr_type_ref_with_hint(expr, types, constants, functions, None)
+}
+
+fn infer_expr_type_ref_with_hint<'i>(
     expr: &Expr<'i>,
     types: &HashMap<String, String>,
     constants: &HashMap<String, Expr<'i>>,
@@ -231,6 +240,10 @@ fn infer_expr_type_ref<'i>(
     array_literal_element_type: Option<&TypeRef>,
 ) -> Option<TypeRef> {
     match &expr.kind {
+        ExprKind::Int(_) | ExprKind::DateLiteral(_) => parse_type_ref("int").ok(),
+        ExprKind::Bool(_) => parse_type_ref("bool").ok(),
+        ExprKind::String(_) => parse_type_ref("string").ok(),
+        ExprKind::Byte(_) => parse_type_ref("byte").ok(),
         ExprKind::Identifier(name) => parse_type_ref(types.get(name)?).ok(),
         ExprKind::Array(values) => {
             let mut inferred = array_literal_element_type
@@ -248,26 +261,39 @@ fn infer_expr_type_ref<'i>(
             }
             parse_type_ref(name).ok()
         }
+        ExprKind::New { name, .. } => match name.as_str() {
+            "ScriptPubKeyP2PK" => parse_type_ref("byte[34]").ok(),
+            "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript" => parse_type_ref("byte[35]").ok(),
+            _ => None,
+        },
         ExprKind::Binary { op: BinaryOp::Add, left, right } => {
-            let left_type = infer_expr_type_ref(left, types, constants, functions, None)?;
-            let right_type = infer_expr_type_ref(right, types, constants, functions, None)?;
+            let left_type = infer_expr_type_ref_with_hint(left, types, constants, functions, None)?;
+            let right_type = infer_expr_type_ref_with_hint(right, types, constants, functions, None)?;
             let left_element = left_type.array_element_type()?;
             if right_type.array_element_type() != Some(left_element.clone()) {
                 return None;
             }
-            let left_size = array_size_with_constants_ref(&left_type, constants)?;
-            let right_size = array_size_with_constants_ref(&right_type, constants)?;
             let mut inferred = left_element;
-            inferred.array_dims.push(ArrayDim::Fixed(left_size.checked_add(right_size)?));
+            match (array_size_with_constants_ref(&left_type, constants), array_size_with_constants_ref(&right_type, constants)) {
+                (Some(left_size), Some(right_size)) => {
+                    inferred.array_dims.push(ArrayDim::Fixed(left_size.checked_add(right_size)?));
+                }
+                _ if matches!(left_type.array_size(), Some(ArrayDim::Dynamic))
+                    || matches!(right_type.array_size(), Some(ArrayDim::Dynamic)) =>
+                {
+                    inferred.array_dims.push(ArrayDim::Dynamic);
+                }
+                _ => return None,
+            }
             Some(inferred)
         }
         ExprKind::IfElse { then_expr, else_expr, .. } => {
-            let then_type = infer_expr_type_ref(then_expr, types, constants, functions, None)?;
-            let else_type = infer_expr_type_ref(else_expr, types, constants, functions, None)?;
+            let then_type = infer_expr_type_ref_with_hint(then_expr, types, constants, functions, None)?;
+            let else_type = infer_expr_type_ref_with_hint(else_expr, types, constants, functions, None)?;
             (then_type == else_type).then_some(then_type)
         }
         ExprKind::Append { source, args, .. } => {
-            let source_type = infer_expr_type_ref(source, types, constants, functions, None)?;
+            let source_type = infer_expr_type_ref_with_hint(source, types, constants, functions, None)?;
             let element_type = source_type.array_element_type()?;
             let source_size = array_size_with_constants_ref(&source_type, constants)?;
             let mut inferred = element_type;
@@ -275,7 +301,7 @@ fn infer_expr_type_ref<'i>(
             Some(inferred)
         }
         ExprKind::UnarySuffix { source, kind: UnarySuffixKind::Reverse, .. } => {
-            infer_expr_type_ref(source, types, constants, functions, None)
+            infer_expr_type_ref_with_hint(source, types, constants, functions, None)
         }
         _ => None,
     }
@@ -287,8 +313,12 @@ fn infer_array_literal_element_type<'i>(
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Option<TypeRef> {
-    let first_type = infer_expr_type_ref(values.first()?, types, constants, functions, None)?;
-    if values.iter().skip(1).all(|value| infer_expr_type_ref(value, types, constants, functions, None).as_ref() == Some(&first_type)) {
+    let first_type = infer_expr_type_ref_with_hint(values.first()?, types, constants, functions, None)?;
+    if values
+        .iter()
+        .skip(1)
+        .all(|value| infer_expr_type_ref_with_hint(value, types, constants, functions, None).as_ref() == Some(&first_type))
+    {
         Some(first_type)
     } else {
         None

--- a/silverscript-lang/src/compiler/infer_array.rs
+++ b/silverscript-lang/src/compiler/infer_array.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use super::builtin_types::{builtin_return_type, constructor_return_type, introspection_type, nullary_type};
 use super::compile::type_name_from_ref;
 use super::*;
 use crate::ast::{ArrayDim, ConstantAst, ContractAst, ContractFieldAst, FunctionAst, ParamAst, Statement, TypeRef};
@@ -59,11 +60,11 @@ fn infer_fixed_array_type_from_initializer_ref<'i>(
     let init = initializer?;
     let init_type = infer_expr_type_ref_with_hint(init, types, constants, functions, Some(&element_type))?;
 
-    if !init_type.is_array() || init_type.array_element_type() != Some(element_type.clone()) {
+    if !init_type.is_array() || !type_refs_equal(&init_type.array_element_type()?, &element_type, constants) {
         return None;
     }
 
-    let size = array_size_with_constants_ref(&init_type, constants)?;
+    let size = array_type_size(&init_type, constants)?;
     let mut inferred = element_type;
     inferred.array_dims.push(ArrayDim::Fixed(size));
     Some(inferred)
@@ -240,7 +241,7 @@ fn infer_expr_type_ref_with_hint<'i>(
     array_literal_element_type: Option<&TypeRef>,
 ) -> Option<TypeRef> {
     match &expr.kind {
-        ExprKind::Int(_) | ExprKind::DateLiteral(_) => parse_type_ref("int").ok(),
+        ExprKind::Int(_) | ExprKind::DateLiteral(_) | ExprKind::NumberWithUnit { .. } => parse_type_ref("int").ok(),
         ExprKind::Bool(_) => parse_type_ref("bool").ok(),
         ExprKind::String(_) => parse_type_ref("string").ok(),
         ExprKind::Byte(_) => parse_type_ref("byte").ok(),
@@ -254,55 +255,33 @@ fn infer_expr_type_ref_with_hint<'i>(
         }
         ExprKind::Call { name, .. } => {
             if let Some(function) = functions.get(name) {
-                if function.entrypoint || function.return_types.len() != 1 {
-                    return None;
-                }
-                return Some(function.return_types[0].clone());
+                return (!function.entrypoint).then(|| function.return_type_ref()).flatten();
             }
-            parse_type_ref(name).ok()
+            parse_type_ref(name)
+                .ok()
+                .filter(|type_ref| !matches!(type_ref.base, TypeBase::Custom(_)))
+                .or_else(|| builtin_return_type(name))
         }
-        ExprKind::New { name, .. } => match name.as_str() {
-            "ScriptPubKeyP2PK" => parse_type_ref("byte[34]").ok(),
-            "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript" => parse_type_ref("byte[35]").ok(),
-            _ => None,
-        },
+        ExprKind::New { name, .. } => constructor_return_type(name),
         ExprKind::Binary { op: BinaryOp::Add, left, right } => {
             let left_type = infer_expr_type_ref_with_hint(left, types, constants, functions, None)?;
             let right_type = infer_expr_type_ref_with_hint(right, types, constants, functions, None)?;
-            let left_element = left_type.array_element_type()?;
-            if right_type.array_element_type() != Some(left_element.clone()) {
-                return None;
-            }
-            let mut inferred = left_element;
-            match (array_size_with_constants_ref(&left_type, constants), array_size_with_constants_ref(&right_type, constants)) {
-                (Some(left_size), Some(right_size)) => {
-                    inferred.array_dims.push(ArrayDim::Fixed(left_size.checked_add(right_size)?));
-                }
-                _ if matches!(left_type.array_size(), Some(ArrayDim::Dynamic))
-                    || matches!(right_type.array_size(), Some(ArrayDim::Dynamic)) =>
-                {
-                    inferred.array_dims.push(ArrayDim::Dynamic);
-                }
-                _ => return None,
-            }
-            Some(inferred)
+            concat_types(&left_type, &right_type, constants)
         }
         ExprKind::IfElse { then_expr, else_expr, .. } => {
             let then_type = infer_expr_type_ref_with_hint(then_expr, types, constants, functions, None)?;
             let else_type = infer_expr_type_ref_with_hint(else_expr, types, constants, functions, None)?;
-            (then_type == else_type).then_some(then_type)
+            type_refs_equal(&then_type, &else_type, constants).then_some(then_type)
         }
         ExprKind::Append { source, args, .. } => {
             let source_type = infer_expr_type_ref_with_hint(source, types, constants, functions, None)?;
-            let element_type = source_type.array_element_type()?;
-            let source_size = array_size_with_constants_ref(&source_type, constants)?;
-            let mut inferred = element_type;
-            inferred.array_dims.push(ArrayDim::Fixed(source_size.checked_add(args.len())?));
-            Some(inferred)
+            append_type(&source_type, args.len(), constants)
         }
         ExprKind::UnarySuffix { source, kind: UnarySuffixKind::Reverse, .. } => {
             infer_expr_type_ref_with_hint(source, types, constants, functions, None)
         }
+        ExprKind::Nullary(kind) => Some(nullary_type(*kind)),
+        ExprKind::Introspection { kind, .. } => Some(introspection_type(*kind)),
         _ => None,
     }
 }
@@ -314,24 +293,12 @@ fn infer_array_literal_element_type<'i>(
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Option<TypeRef> {
     let first_type = infer_expr_type_ref_with_hint(values.first()?, types, constants, functions, None)?;
-    if values
-        .iter()
-        .skip(1)
-        .all(|value| infer_expr_type_ref_with_hint(value, types, constants, functions, None).as_ref() == Some(&first_type))
-    {
+    if values.iter().skip(1).all(|value| {
+        infer_expr_type_ref_with_hint(value, types, constants, functions, None)
+            .is_some_and(|type_ref| type_refs_equal(&type_ref, &first_type, constants))
+    }) {
         Some(first_type)
     } else {
         None
-    }
-}
-
-fn array_size_with_constants_ref<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
-    match type_ref.array_size()? {
-        ArrayDim::Fixed(size) => Some(*size),
-        ArrayDim::Constant(name) => match constants.get(name)?.kind {
-            ExprKind::Int(value) if value >= 0 => Some(value as usize),
-            _ => None,
-        },
-        ArrayDim::Dynamic | ArrayDim::Inferred => None,
     }
 }

--- a/silverscript-lang/src/compiler/locals.rs
+++ b/silverscript-lang/src/compiler/locals.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crate::ast::{ContractAst, Expr, ExprKind, FunctionAst, StateFieldExpr, Statement, TypeBase, TypeRef};
+use crate::ast::{ContractAst, Expr, ExprKind, FunctionAst, StateFieldExpr, Statement, TypeRef};
 
 use super::CompilerError;
 
@@ -190,8 +190,7 @@ fn lower_statements<'i>(
 }
 
 fn coerce_expr_for_declared_scalar_type<'i>(expr: Expr<'i>, type_ref: &TypeRef) -> Result<Expr<'i>, CompilerError> {
-    if matches!(type_ref.base, TypeBase::Byte)
-        && !type_ref.is_array()
+    if type_ref.is_byte()
         && let ExprKind::Int(value) = expr.kind
     {
         let byte_value =

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -31,8 +31,8 @@ mod type_system;
 mod validate_output_state;
 
 use compile::compile_contract_impl;
+pub(super) use compile::eval_const_int;
 pub(crate) use compile::resolve_expr;
-pub(super) use compile::{array_element_type, eval_const_int, is_bytes_type, type_name_from_ref};
 pub use compile::{compile_debug_expr, function_branch_index};
 pub(crate) use debug_recording::DebugRecorder;
 use r#for::lower_for_loops;
@@ -40,9 +40,8 @@ use read_input_state::lower_read_input_state_calls;
 use static_check::validate_expr_matches_type;
 pub use structs::flattened_struct_name;
 pub(super) use structs::{
-    StructRegistry, build_struct_registry, ensure_known_or_builtin_type, flatten_constructor_args_env, flatten_type_ref_leaves,
-    flattened_struct_field_specs_for_type, is_struct, is_struct_array, lower_structs_contract, struct_name_from_type_ref,
-    validate_struct_graph,
+    StructRegistry, build_struct_registry, ensure_known_or_builtin_type, flatten_constructor_args_env, flatten_type_leaves,
+    flattened_struct_field_specs_for_type, is_struct, is_struct_array, lower_structs_contract, struct_name, validate_struct_graph,
 };
 pub(super) use type_system::{append_type, array_size as array_type_size, concat_types, type_refs_equal};
 use validate_output_state::lower_validate_output_state;
@@ -52,6 +51,7 @@ pub const SYNTHETIC_ARG_PREFIX: &str = "__arg";
 pub const COMPILER_VERSION: &str = "0.1.0";
 const COVENANT_POLICY_PREFIX: &str = "__covenant_policy";
 pub const COVENANT_ENTRYPOINT_AUTH_PREFIX: &str = "__covenant_entrypoint_auth";
+pub(super) type TypeMap = HashMap<String, TypeRef>;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct CovenantDeclCallOptions {
@@ -140,7 +140,7 @@ impl<'i> ContractAst<'i> {
         let mut env = constants.clone();
 
         for (param, value) in self.params.iter().zip(constructor_args.iter()) {
-            let type_name = type_name_from_ref(&param.type_ref);
+            let type_name = param.type_ref.type_name();
             if validate_expr_matches_type(value, &param.type_ref, &HashMap::new(), &structs, &constants, &HashMap::new(), &self.fields)
                 .is_err()
             {
@@ -265,7 +265,7 @@ fn push_typed_sigscript_arg<'i>(
     structs: &StructRegistry,
 ) -> Result<(), CompilerError> {
     if let Some(element_type) = type_ref.array_element_type() {
-        if let Some(struct_name) = struct_name_from_type_ref(&element_type, structs) {
+        if let Some(struct_name) = struct_name(&element_type, structs) {
             let item =
                 structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
             let ExprKind::Array(values) = arg.kind else {
@@ -314,7 +314,7 @@ fn push_typed_sigscript_arg<'i>(
         }
     }
 
-    if let Some(struct_name) = struct_name_from_type_ref(type_ref, structs) {
+    if let Some(struct_name) = struct_name(type_ref, structs) {
         let item = structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
         let ExprKind::StructLiteral(fields) = arg.kind else {
             return Err(CompilerError::Unsupported("signature script struct arguments must be object literals".to_string()));
@@ -346,8 +346,7 @@ fn push_typed_sigscript_arg<'i>(
         return Err(CompilerError::Unsupported("signature script arguments must match the declared type".to_string()));
     }
 
-    let type_name = type_name_from_ref(type_ref);
-    if compile::is_array_type(&type_name) {
+    if type_ref.is_array() {
         match &arg.kind {
             ExprKind::Array(values) => {
                 if compile::is_byte_array(&arg) {
@@ -357,7 +356,7 @@ fn push_typed_sigscript_arg<'i>(
                         .collect();
                     builder.add_data(&bytes)?;
                 } else {
-                    let bytes = compile::encode_array_literal(values, &type_name)?;
+                    let bytes = compile::encode_array_literal(values, type_ref)?;
                     builder.add_data(&bytes)?;
                 }
                 Ok(())

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -34,8 +34,7 @@ pub use compile::{compile_debug_expr, function_branch_index};
 pub(crate) use debug_recording::DebugRecorder;
 use r#for::lower_for_loops;
 use read_input_state::lower_read_input_state_calls;
-pub(crate) use static_check::expr_matches_declared_type_ref;
-use static_check::value_matches_type_ref;
+use static_check::{validate_expr_matches_type, value_matches_type_ref};
 pub use structs::flattened_struct_name;
 pub(super) use structs::{
     StructRegistry, build_struct_registry, ensure_known_or_builtin_type, flatten_constructor_args_env, flatten_type_ref_leaves,
@@ -132,12 +131,15 @@ impl<'i> ContractAst<'i> {
         }
 
         let structs = build_struct_registry(self)?;
-        let mut env: HashMap<String, Expr<'i>> =
+        let constants: HashMap<String, Expr<'i>> =
             self.constants.iter().map(|constant| (constant.name.clone(), constant.expr.clone())).collect();
+        let mut env = constants.clone();
 
         for (param, value) in self.params.iter().zip(constructor_args.iter()) {
             let type_name = type_name_from_ref(&param.type_ref);
-            if !expr_matches_declared_type_ref(value, &param.type_ref, &structs) {
+            if validate_expr_matches_type(value, &param.type_ref, &HashMap::new(), &structs, &constants, &HashMap::new(), &self.fields)
+                .is_err()
+            {
                 return Err(CompilerError::Unsupported(format!("constructor argument '{}' expects {}", param.name, type_name)));
             }
             env.insert(param.name.clone(), value.clone());
@@ -151,7 +153,17 @@ impl<'i> ContractAst<'i> {
 
             let type_name = field.type_ref.type_name();
             let resolved = resolve_expr(field.expr.clone(), &env, &mut std::collections::HashSet::new())?;
-            if !expr_matches_declared_type_ref(&resolved, &field.type_ref, &structs) {
+            if validate_expr_matches_type(
+                &resolved,
+                &field.type_ref,
+                &HashMap::new(),
+                &structs,
+                &constants,
+                &HashMap::new(),
+                &self.fields,
+            )
+            .is_err()
+            {
                 return Err(CompilerError::Unsupported(format!("contract field '{}' expects {}", field.name, type_name)));
             }
 

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -13,6 +13,7 @@ use crate::debug_info::{DebugInfo, DebugNamedValue};
 pub use crate::errors::{CompilerError, ErrorSpan};
 use crate::span;
 mod array_append;
+mod builtin_types;
 mod compile;
 mod covenant_declarations;
 mod debug_recording;
@@ -25,6 +26,8 @@ mod read_input_state;
 mod stack_bindings;
 mod static_check;
 mod structs;
+mod type_check;
+mod type_system;
 mod validate_output_state;
 
 use compile::compile_contract_impl;
@@ -34,13 +37,14 @@ pub use compile::{compile_debug_expr, function_branch_index};
 pub(crate) use debug_recording::DebugRecorder;
 use r#for::lower_for_loops;
 use read_input_state::lower_read_input_state_calls;
-use static_check::{validate_expr_matches_type, value_matches_type_ref};
+use static_check::validate_expr_matches_type;
 pub use structs::flattened_struct_name;
 pub(super) use structs::{
     StructRegistry, build_struct_registry, ensure_known_or_builtin_type, flatten_constructor_args_env, flatten_type_ref_leaves,
-    flattened_struct_field_specs_for_type, is_struct, is_struct_array, lower_runtime_expr, lower_runtime_struct_expr,
-    lower_structs_contract, struct_name_from_type_ref, validate_struct_graph,
+    flattened_struct_field_specs_for_type, is_struct, is_struct_array, lower_structs_contract, struct_name_from_type_ref,
+    validate_struct_graph,
 };
+pub(super) use type_system::{append_type, array_size as array_type_size, concat_types, type_refs_equal};
 use validate_output_state::lower_validate_output_state;
 
 /// Prefix used for synthetic argument bindings during inline function expansion.
@@ -333,7 +337,12 @@ fn push_typed_sigscript_arg<'i>(
         return Ok(());
     }
 
-    if !value_matches_type_ref(&arg, type_ref) {
+    let types = HashMap::new();
+    let constants = HashMap::new();
+    let functions = HashMap::new();
+    let type_context =
+        type_check::TypeCheckContext { types: &types, structs, constants: &constants, functions: &functions, contract_fields: &[] };
+    if type_check::check_expr(&arg, Some(type_ref), &type_context).is_err() {
         return Err(CompilerError::Unsupported("signature script arguments must match the declared type".to_string()));
     }
 

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -25,7 +25,7 @@ pub(super) fn static_check_contract<'i>(
     validate_function_signatures(contract, &structs, &constants, options)?;
 
     for (param, value) in contract.params.iter().zip(constructor_args.iter()) {
-        let param_type_name = type_name_from_ref(&param.type_ref);
+        let param_type_name = param.type_ref.type_name();
         if validate_expr_matches_type(value, &param.type_ref, &HashMap::new(), &structs, &constants, &HashMap::new(), &contract.fields)
             .is_err()
         {
@@ -64,7 +64,7 @@ fn validate_pragma_versions<'i>(contract: &ContractAst<'i>) -> Result<(), Compil
 pub(crate) fn validate_return_types<'i>(
     exprs: &[Expr<'i>],
     return_types: &[TypeRef],
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
@@ -78,7 +78,7 @@ pub(crate) fn validate_return_types<'i>(
     }
     for (expr, return_type) in exprs.iter().zip(return_types.iter()) {
         if validate_expr_matches_type(expr, return_type, types, structs, constants, functions, contract_fields).is_err() {
-            let type_name = type_name_from_ref(return_type);
+            let type_name = return_type.type_name();
             return Err(CompilerError::Unsupported(format!("return value expects {type_name}")));
         }
     }
@@ -109,10 +109,10 @@ fn validate_function_signatures<'i>(
 
     for function in &contract.functions {
         for param in &function.params {
-            ensure_array_elements_have_known_size(&param.type_ref, structs, &type_name_from_ref(&param.type_ref))?;
+            ensure_array_elements_have_known_size(&param.type_ref, structs, &param.type_ref.type_name())?;
         }
         for return_type in &function.return_types {
-            ensure_array_elements_have_known_size(return_type, structs, &type_name_from_ref(return_type))?;
+            ensure_array_elements_have_known_size(return_type, structs, &return_type.type_name())?;
         }
 
         if function.entrypoint && !options.allow_entrypoint_return && !function.return_types.is_empty() {
@@ -154,18 +154,18 @@ fn validate_contract_field_initializers<'i>(
 ) -> Result<(), CompilerError> {
     let mut types = HashMap::new();
     for param in &contract.params {
-        types.insert(param.name.clone(), type_name_from_ref(&param.type_ref));
+        types.insert(param.name.clone(), param.type_ref.clone());
     }
     for constant in &contract.constants {
-        types.insert(constant.name.clone(), type_name_from_ref(&constant.type_ref));
+        types.insert(constant.name.clone(), constant.type_ref.clone());
     }
 
     for field in &contract.fields {
-        let type_name = type_name_from_ref(&field.type_ref);
+        let type_name = field.type_ref.type_name();
         ensure_array_elements_have_known_size(&field.type_ref, structs, &type_name)?;
         validate_expr_matches_type(&field.expr, &field.type_ref, &types, structs, constants, &HashMap::new(), &contract.fields)
             .map_err(|_| CompilerError::Unsupported(format!("contract field '{}' expects {}", field.name, type_name)))?;
-        types.insert(field.name.clone(), type_name);
+        types.insert(field.name.clone(), field.type_ref.clone());
     }
 
     Ok(())
@@ -174,7 +174,7 @@ fn validate_contract_field_initializers<'i>(
 #[allow(clippy::too_many_arguments)]
 fn validate_statement_shapes<'i>(
     statements: &[Statement<'i>],
-    types: &mut HashMap<String, String>,
+    types: &mut TypeMap,
     return_types: &[TypeRef],
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
@@ -220,7 +220,7 @@ fn validate_statement_shapes<'i>(
 }
 
 struct ValidateStatementShapesContext<'a, 'i> {
-    types: &'a mut HashMap<String, String>,
+    types: &'a mut TypeMap,
     return_types: &'a [TypeRef],
     structs: &'a StructRegistry,
     constants: &'a HashMap<String, Expr<'i>>,
@@ -254,7 +254,7 @@ fn validate_variable_definition_statement_shape<'i>(
     name: &str,
     expr: Option<&Expr<'i>>,
 ) -> Result<(), CompilerError> {
-    let type_name = type_name_from_ref(type_ref);
+    let type_name = type_ref.type_name();
     ensure_array_elements_have_known_size(type_ref, ctx.structs, &type_name)?;
     if expr.is_none() && type_ref.is_array() && array_type_size(type_ref, ctx.constants).is_some() {
         return Err(CompilerError::Unsupported("variable definition requires initializer".to_string()));
@@ -271,7 +271,7 @@ fn validate_variable_definition_statement_shape<'i>(
                 err,
                 "variable",
                 name,
-                &type_name_from_ref(type_ref),
+                &type_ref.type_name(),
                 expr,
                 type_ref,
                 ctx.types,
@@ -293,8 +293,8 @@ fn validate_tuple_assignment_statement_shape<'i>(
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
     ctx.check_expr(expr, None)?;
-    ensure_array_elements_have_known_size(left_type_ref, ctx.structs, &type_name_from_ref(left_type_ref))?;
-    ensure_array_elements_have_known_size(right_type_ref, ctx.structs, &type_name_from_ref(right_type_ref))?;
+    ensure_array_elements_have_known_size(left_type_ref, ctx.structs, &left_type_ref.type_name())?;
+    ensure_array_elements_have_known_size(right_type_ref, ctx.structs, &right_type_ref.type_name())?;
     insert_type_binding(ctx.types, left_name, left_type_ref);
     insert_type_binding(ctx.types, right_name, right_type_ref);
     Ok(())
@@ -311,7 +311,7 @@ fn validate_state_function_call_assign_statement_shape<'i>(
             ctx.check_call(name, args, None)?;
         }
         "readInputStateWithTemplate" => {
-            let struct_name = struct_name_for_state_bindings_ref(bindings, ctx.structs, ctx.constants)?;
+            let struct_name = struct_name_for_state_bindings(bindings, ctx.structs, ctx.constants)?;
             let expected = TypeRef { base: TypeBase::Custom(struct_name), array_dims: Vec::new() };
             ctx.check_call(name, args, Some(&expected))?;
         }
@@ -323,7 +323,7 @@ fn validate_state_function_call_assign_statement_shape<'i>(
     }
     validate_state_function_call_assign(bindings, name, args, ctx.structs, ctx.constants, ctx.contract_fields)?;
     for binding in bindings {
-        ensure_array_elements_have_known_size(&binding.type_ref, ctx.structs, &type_name_from_ref(&binding.type_ref))?;
+        ensure_array_elements_have_known_size(&binding.type_ref, ctx.structs, &binding.type_ref.type_name())?;
         insert_type_binding(ctx.types, &binding.name, &binding.type_ref);
     }
     Ok(())
@@ -338,7 +338,7 @@ fn validate_struct_destructure_statement_shape<'i>(
     let direct_read_input_state = matches!(&expr.kind, ExprKind::Call { name, .. } if name == "readInputState");
     validate_struct_destructure_bindings(bindings, &expr_type, direct_read_input_state, ctx.structs, ctx.constants)?;
     for binding in bindings {
-        ensure_array_elements_have_known_size(&binding.type_ref, ctx.structs, &type_name_from_ref(&binding.type_ref))?;
+        ensure_array_elements_have_known_size(&binding.type_ref, ctx.structs, &binding.type_ref.type_name())?;
         insert_type_binding(ctx.types, &binding.name, &binding.type_ref);
     }
     Ok(())
@@ -360,7 +360,7 @@ fn validate_output_state_call<'i>(
     name: &str,
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
-    let int_type = parse_type_ref("int")?;
+    let int_type = TypeRef { base: TypeBase::Int, array_dims: Vec::new() };
     match (name, args) {
         ("validateOutputState", [output_index, state]) => {
             let state_type = TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: Vec::new() };
@@ -419,7 +419,7 @@ fn validate_function_call_assign_statement_shape<'i>(
             return Err(CompilerError::Unsupported(format!(
                 "function return binding '{}' expects {}",
                 binding.name,
-                type_name_from_ref(return_type)
+                return_type.type_name()
             )));
         }
         insert_type_binding(ctx.types, &binding.name, &binding.type_ref);
@@ -438,14 +438,14 @@ fn validate_require_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    ctx.check_expr(expr, Some(&parse_type_ref("bool")?)).map(|_| ())
+    ctx.check_expr(expr, Some(&TypeRef { base: TypeBase::Bool, array_dims: Vec::new() })).map(|_| ())
 }
 
 fn validate_time_op_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    ctx.check_expr(expr, Some(&parse_type_ref("int")?)).map(|_| ())
+    ctx.check_expr(expr, Some(&TypeRef { base: TypeBase::Int, array_dims: Vec::new() })).map(|_| ())
 }
 
 fn validate_console_statement_shape<'i>(
@@ -463,8 +463,8 @@ fn validate_assign_statement_shape<'i>(
     name: &str,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    if let Some(type_name) = ctx.types.get(name).cloned() {
-        let type_ref = parse_type_ref(&type_name)?;
+    if let Some(type_ref) = ctx.types.get(name).cloned() {
+        let type_name = type_ref.type_name();
         ctx.check_expr(expr, Some(&type_ref)).map_err(|err| {
             map_declared_type_error(err, "variable", name, &type_name, expr, &type_ref, ctx.types, ctx.structs, ctx.constants)
         })?;
@@ -478,7 +478,7 @@ fn validate_if_statement_shape<'i>(
     then_branch: &[Statement<'i>],
     else_branch: Option<&[Statement<'i>]>,
 ) -> Result<(), CompilerError> {
-    ctx.check_expr(condition, Some(&parse_type_ref("bool")?))?;
+    ctx.check_expr(condition, Some(&TypeRef { base: TypeBase::Bool, array_dims: Vec::new() }))?;
     let mut then_types = ctx.types.clone();
     validate_statement_shapes(
         then_branch,
@@ -520,12 +520,12 @@ fn validate_for_statement_shape<'i>(
     max_iterations: &Expr<'i>,
     body: &[Statement<'i>],
 ) -> Result<(), CompilerError> {
-    let int_type = parse_type_ref("int")?;
+    let int_type = TypeRef { base: TypeBase::Int, array_dims: Vec::new() };
     ctx.check_expr(start, Some(&int_type))?;
     ctx.check_expr(end, Some(&int_type))?;
     ctx.check_expr(max_iterations, Some(&int_type))?;
     let mut body_types = ctx.types.clone();
-    body_types.insert(ident.to_string(), "int".to_string());
+    body_types.insert(ident.to_string(), int_type);
     validate_statement_shapes(body, &mut body_types, ctx.return_types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
 }
 
@@ -536,7 +536,7 @@ fn validate_struct_destructure_bindings<'i>(
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
 ) -> Result<(), CompilerError> {
-    let struct_name = struct_name_from_type_ref(expr_type, structs)
+    let struct_name = struct_name(expr_type, structs)
         .ok_or_else(|| CompilerError::Unsupported("struct destructuring requires a struct value".to_string()))?;
     let struct_ast = structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
     let mut seen_fields = HashSet::new();
@@ -561,11 +561,7 @@ fn validate_struct_destructure_bindings<'i>(
             return Err(CompilerError::Unsupported("struct destructuring must bind all fields exactly once".to_string()));
         };
         if !type_refs_equal(&binding.type_ref, &field.type_ref, constants) {
-            return Err(CompilerError::Unsupported(format!(
-                "struct field '{}' expects {}",
-                field.name,
-                type_name_from_ref(&field.type_ref)
-            )));
+            return Err(CompilerError::Unsupported(format!("struct field '{}' expects {}", field.name, field.type_ref.type_name())));
         }
         if direct_read_input_state && is_struct(&binding.type_ref, structs) {
             return Err(CompilerError::Unsupported("readInputState does not support nested struct fields".to_string()));
@@ -607,7 +603,7 @@ fn validate_state_function_call_assign<'i>(
                     return Err(CompilerError::Unsupported(format!(
                         "readInputState binding '{}' expects {}",
                         binding.name,
-                        type_name_from_ref(&field.type_ref)
+                        field.type_ref.type_name()
                     )));
                 }
             }
@@ -620,7 +616,7 @@ fn validate_state_function_call_assign<'i>(
                         .to_string(),
                 ));
             };
-            let struct_name = struct_name_for_state_bindings_ref(bindings, structs, constants)?;
+            let struct_name = struct_name_for_state_bindings(bindings, structs, constants)?;
             let struct_spec =
                 structs.get(&struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
             if bindings.len() != struct_spec.fields.len() {
@@ -643,7 +639,7 @@ fn validate_state_function_call_assign<'i>(
                     return Err(CompilerError::Unsupported(format!(
                         "readInputStateWithTemplate binding '{}' expects {}",
                         binding.name,
-                        type_name_from_ref(&field.type_ref)
+                        field.type_ref.type_name()
                     )));
                 }
             }
@@ -653,7 +649,7 @@ fn validate_state_function_call_assign<'i>(
     }
 }
 
-fn struct_name_for_state_bindings_ref<'i>(
+fn struct_name_for_state_bindings<'i>(
     bindings: &[StructBindingAst<'i>],
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
@@ -684,10 +680,7 @@ fn struct_name_for_state_bindings_ref<'i>(
     }
 }
 
-fn initial_function_types<'i>(
-    contract: &ContractAst<'i>,
-    function: &FunctionAst<'i>,
-) -> Result<HashMap<String, String>, CompilerError> {
+fn initial_function_types<'i>(contract: &ContractAst<'i>, function: &FunctionAst<'i>) -> Result<TypeMap, CompilerError> {
     let mut types = HashMap::new();
 
     for param in &contract.params {
@@ -706,14 +699,14 @@ fn initial_function_types<'i>(
     Ok(types)
 }
 
-fn insert_type_binding(types: &mut HashMap<String, String>, name: &str, type_ref: &TypeRef) {
-    types.insert(name.to_string(), type_name_from_ref(type_ref));
+fn insert_type_binding(types: &mut TypeMap, name: &str, type_ref: &TypeRef) {
+    types.insert(name.to_string(), type_ref.clone());
 }
 
 pub(crate) fn validate_expr_matches_type<'i>(
     expr: &Expr<'i>,
     type_ref: &TypeRef,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
@@ -730,13 +723,13 @@ fn map_declared_type_error<'i>(
     type_name: &str,
     expr: &Expr<'i>,
     type_ref: &TypeRef,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
 ) -> CompilerError {
     match err {
         CompilerError::Unsupported(message) if message == "type mismatch" => {
-            let hint = expr_matches_return_type_ref_hint(expr, type_ref, types, structs, constants)
+            let hint = expr_matches_return_type_hint(expr, type_ref, types, structs, constants)
                 .map(|hint| format!("; {hint}"))
                 .unwrap_or_default();
             CompilerError::Unsupported(format!("{kind} '{}' expects {}{}", name, type_name, hint))
@@ -746,25 +739,23 @@ fn map_declared_type_error<'i>(
 }
 
 fn ensure_array_elements_have_known_size(type_ref: &TypeRef, structs: &StructRegistry, type_name: &str) -> Result<(), CompilerError> {
-    if type_ref.is_array() && fixed_type_size_ref(type_ref.array_element_type().as_ref().unwrap_or(type_ref), structs).is_none() {
+    if type_ref.is_array() && fixed_type_size(type_ref.array_element_type().as_ref().unwrap_or(type_ref), structs).is_none() {
         return Err(CompilerError::Unsupported(format!("array element type must have known size: {type_name}")));
     }
     Ok(())
 }
 
-fn fixed_type_size_ref(type_ref: &TypeRef, structs: &StructRegistry) -> Option<i64> {
+fn fixed_type_size(type_ref: &TypeRef, structs: &StructRegistry) -> Option<i64> {
     match &type_ref.base {
         TypeBase::Int => Some(8),
         TypeBase::Bool | TypeBase::Byte => Some(1),
-        TypeBase::Pubkey => Some(32),
-        TypeBase::Sig => Some(65),
-        TypeBase::Datasig => Some(64),
+        TypeBase::Pubkey | TypeBase::Sig | TypeBase::Datasig => type_ref.base.fixed_byte_sequence_len().map(|size| size as i64),
         TypeBase::String => None,
         TypeBase::Custom(name) if !type_ref.is_array() => {
             let struct_spec = structs.get(name)?;
             let mut total = 0i64;
             for field in &struct_spec.fields {
-                total += fixed_type_size_ref(&field.type_ref, structs)?;
+                total += fixed_type_size(&field.type_ref, structs)?;
             }
             Some(total)
         }
@@ -791,14 +782,10 @@ fn statement_contains_return(stmt: &Statement<'_>) -> bool {
     }
 }
 
-fn type_name_from_ref(type_ref: &TypeRef) -> String {
-    type_ref.type_name()
-}
-
-fn expr_matches_return_type_ref_hint<'i>(
+fn expr_matches_return_type_hint<'i>(
     expr: &Expr<'i>,
     type_ref: &TypeRef,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
 ) -> Option<String> {

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -173,7 +173,7 @@ fn validate_contract_field_initializers<'i>(
             &contract.fields,
         )?;
         ensure_array_elements_have_known_size(&field.type_ref, structs, &type_name)?;
-        validate_expr_assignable_to_type(&field.expr, &field.type_ref, &types, structs, constants, &HashMap::new(), &contract.fields)
+        validate_expr_matches_type(&field.expr, &field.type_ref, &types, structs, constants, &HashMap::new(), &contract.fields)
             .map_err(|_| CompilerError::Unsupported(format!("contract field '{}' expects {}", field.name, type_name)))?;
         types.insert(field.name.clone(), type_name);
     }
@@ -275,7 +275,7 @@ fn validate_variable_definition_statement_shape<'i>(
             ctx.functions,
             ctx.contract_fields,
         )?;
-        validate_expr_assignable_to_type(expr, type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
+        validate_expr_matches_type(expr, type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
             .map_err(|err| {
                 map_declared_type_error(
                     err,
@@ -305,9 +305,9 @@ fn validate_array_initializer<'i>(
     match expr {
         Some(Expr { kind: ExprKind::Identifier(other), .. }) => match types.get(other) {
             Some(other_type) => match parse_type_ref(other_type) {
-                Ok(other_type_ref) if is_type_assignable_ref(&other_type_ref, type_ref, constants) => Ok(()),
-                Ok(_) => Err(CompilerError::Unsupported("array assignment requires compatible array types".to_string())),
-                Err(_) => Err(CompilerError::Unsupported("array assignment requires compatible array types".to_string())),
+                Ok(other_type_ref) if type_refs_equal(&other_type_ref, type_ref, constants) => Ok(()),
+                Ok(_) => Err(CompilerError::Unsupported("array assignment requires identical array types".to_string())),
+                Err(_) => Err(CompilerError::Unsupported("array assignment requires identical array types".to_string())),
             },
             None => Err(CompilerError::UndefinedIdentifier(other.clone())),
         },
@@ -578,10 +578,10 @@ fn validate_assign_statement_shape<'i>(
     )?;
     if let Some(type_name) = ctx.types.get(name).cloned() {
         let type_ref = parse_type_ref(&type_name)?;
-        validate_expr_assignable_to_type(expr, &type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
+        validate_expr_matches_type(expr, &type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
             .map_err(|err| {
-            map_declared_type_error(err, "variable", name, &type_name, expr, &type_ref, ctx.types, ctx.structs, ctx.constants)
-        })?;
+                map_declared_type_error(err, "variable", name, &type_name, expr, &type_ref, ctx.types, ctx.structs, ctx.constants)
+            })?;
     }
     ctx.env.insert(name.to_string(), expr.clone());
     ctx.prefer_env_for_comparison.remove(name);
@@ -991,13 +991,14 @@ fn validate_expr_semantics<'i>(
             };
             for arg in args {
                 validate_expr_semantics(arg, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-                validate_expr_assignable_to_type(arg, &element_type, types, structs, &HashMap::new(), functions, contract_fields)
-                    .map_err(|_| {
+                validate_expr_matches_type(arg, &element_type, types, structs, &HashMap::new(), functions, contract_fields).map_err(
+                    |_| {
                         CompilerError::Unsupported(format!(
                             "array append element type mismatch: expected {}",
                             type_name_from_ref(&element_type)
                         ))
-                    })?;
+                    },
+                )?;
             }
             Ok(())
         }
@@ -1360,15 +1361,13 @@ fn validate_internal_call<'i>(
 
     for (param, arg) in function.params.iter().zip(args.iter()) {
         let param_type_name = type_name_from_ref(&param.type_ref);
-        validate_expr_assignable_to_type(arg, &param.type_ref, types, structs, constants, functions, contract_fields).map_err(
-            |err| {
-                if matches!(&arg.kind, ExprKind::Call { name, .. } if name == "readInputStateWithTemplate") {
-                    err
-                } else {
-                    CompilerError::Unsupported(format!("function argument '{}' expects {}", param.name, param_type_name))
-                }
-            },
-        )?;
+        validate_expr_matches_type(arg, &param.type_ref, types, structs, constants, functions, contract_fields).map_err(|err| {
+            if matches!(&arg.kind, ExprKind::Call { name, .. } if name == "readInputStateWithTemplate") {
+                err
+            } else {
+                CompilerError::Unsupported(format!("function argument '{}' expects {}", param.name, param_type_name))
+            }
+        })?;
     }
 
     Ok(function)
@@ -1401,7 +1400,7 @@ fn validate_builtin_call<'i>(
         let actual_type =
             infer_expr_type_ref_for_comparison_ref(arg, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
                 .ok_or_else(|| CompilerError::Unsupported(format!("{name}() argument '{arg_name}' expects {expected_type_name}")))?;
-        if !is_type_assignable_ref(&actual_type, &expected_type, constants) && !expr_matches_type_ref(arg, &expected_type) {
+        if !type_refs_equal(&actual_type, &expected_type, constants) && !expr_matches_type_ref(arg, &expected_type) {
             return Err(CompilerError::Unsupported(format!(
                 "{name}() argument '{arg_name}' expects {expected_type_name}, got {}",
                 type_name_from_ref(&actual_type)
@@ -1420,7 +1419,7 @@ fn typed_builtin_return_type_ref(name: &str) -> Option<TypeRef> {
     }
 }
 
-fn validate_expr_assignable_to_type<'i>(
+fn validate_expr_matches_type<'i>(
     expr: &Expr<'i>,
     type_ref: &TypeRef,
     types: &HashMap<String, String>,
@@ -1447,7 +1446,7 @@ fn validate_expr_assignable_to_type<'i>(
                 name
             )));
         }
-        if is_type_assignable_ref(&function.return_types[0], type_ref, constants) {
+        if type_refs_equal(&function.return_types[0], type_ref, constants) {
             return Ok(());
         }
         return Err(CompilerError::Unsupported("type mismatch".to_string()));
@@ -1456,7 +1455,7 @@ fn validate_expr_assignable_to_type<'i>(
     if let ExprKind::Call { name, .. } = &expr.kind
         && let Some(actual_type) = typed_builtin_return_type_ref(name)
     {
-        return if is_type_assignable_ref(&actual_type, type_ref, constants) {
+        return if type_refs_equal(&actual_type, type_ref, constants) {
             Ok(())
         } else {
             Err(CompilerError::Unsupported("type mismatch".to_string()))
@@ -1475,7 +1474,7 @@ fn validate_expr_assignable_to_type<'i>(
         && let Some(actual_type) =
             infer_expr_type_ref_for_comparison_ref(expr, &HashMap::new(), &HashSet::new(), types, structs, functions, contract_fields)
     {
-        return if is_type_assignable_ref(&actual_type, type_ref, constants) {
+        return if type_refs_equal(&actual_type, type_ref, constants) {
             Ok(())
         } else {
             Err(CompilerError::Unsupported("type mismatch".to_string()))
@@ -1486,7 +1485,7 @@ fn validate_expr_assignable_to_type<'i>(
         && let Some(actual_type) =
             infer_expr_type_ref_for_comparison_ref(expr, &HashMap::new(), &HashSet::new(), types, structs, functions, contract_fields)
     {
-        return if is_type_assignable_ref(&actual_type, type_ref, constants) {
+        return if type_refs_equal(&actual_type, type_ref, constants) {
             Ok(())
         } else {
             Err(CompilerError::Unsupported("type mismatch".to_string()))
@@ -1537,7 +1536,7 @@ fn validate_expr_assignable_to_type<'i>(
             ExprKind::Identifier(name) => types
                 .get(name)
                 .and_then(|type_name| parse_type_ref(type_name).ok())
-                .is_some_and(|actual_type| is_type_assignable_ref(&actual_type, type_ref, constants)),
+                .is_some_and(|actual_type| type_refs_equal(&actual_type, type_ref, constants)),
             ExprKind::Append { source, args, .. } => infer_expr_type_ref_for_comparison_ref(
                 source,
                 &HashMap::new(),
@@ -1547,18 +1546,8 @@ fn validate_expr_assignable_to_type<'i>(
                 functions,
                 contract_fields,
             )
-            .is_some_and(|source_type| {
-                if source_type.array_element_type() != type_ref.array_element_type() {
-                    return false;
-                }
-                if !has_explicit_array_size_ref(type_ref) {
-                    return true;
-                }
-                match (array_size_with_constants_ref(&source_type, constants), array_size_with_constants_ref(type_ref, constants)) {
-                    (Some(source_size), Some(expected_size)) => source_size.checked_add(args.len()) == Some(expected_size),
-                    _ => false,
-                }
-            }),
+            .and_then(|source_type| type_after_append(&source_type, args.len(), constants))
+            .is_some_and(|actual_type| type_refs_equal(&actual_type, type_ref, constants)),
             _ => expr_matches_declared_type_ref(expr, type_ref, structs),
         };
         if matches { Ok(()) } else { Err(CompilerError::Unsupported("type mismatch".to_string())) }
@@ -1567,7 +1556,7 @@ fn validate_expr_assignable_to_type<'i>(
             && let Ok(actual_type_name) =
                 super::debug_value_types::infer_debug_expr_value_type(expr, &HashMap::new(), types, &mut HashSet::new())
             && let Ok(actual_type) = parse_type_ref(&actual_type_name)
-            && is_type_assignable_ref(&actual_type, type_ref, constants)
+            && type_refs_equal(&actual_type, type_ref, constants)
         {
             return Ok(());
         }
@@ -1604,7 +1593,7 @@ fn validate_struct_literal_matches_type<'i>(
         let Some(value) = provided.remove(&field.name) else {
             return Err(CompilerError::Unsupported(format!("struct field '{}' must be initialized", field.name)));
         };
-        validate_expr_assignable_to_type(value, &field.type_ref, types, structs, constants, &HashMap::new(), &[]).map_err(|_| {
+        validate_expr_matches_type(value, &field.type_ref, types, structs, constants, &HashMap::new(), &[]).map_err(|_| {
             CompilerError::Unsupported(format!("struct field '{}' expects {}", field.name, field.type_ref.type_name()))
         })?;
     }
@@ -1757,7 +1746,7 @@ pub(super) fn expr_matches_return_type_ref<'i>(
         return types
             .get(name)
             .and_then(|type_name| parse_type_ref(type_name).ok())
-            .is_some_and(|actual| is_type_assignable_ref(&actual, type_ref, constants));
+            .is_some_and(|actual| type_refs_equal(&actual, type_ref, constants));
     }
 
     if let Some(struct_name) = struct_name_from_type_ref(type_ref, structs) {
@@ -1793,7 +1782,7 @@ pub(super) fn expr_matches_return_type_ref<'i>(
                 super::debug_value_types::infer_debug_expr_value_type(expr, &HashMap::new(), types, &mut HashSet::new())
                 && let Ok(actual_type) = parse_type_ref(&actual_type_name)
             {
-                return is_type_assignable_ref(&actual_type, type_ref, constants);
+                return type_refs_equal(&actual_type, type_ref, constants);
             }
             false
         }
@@ -1804,9 +1793,9 @@ pub(super) fn expr_matches_return_type_ref<'i>(
         ExprKind::Int(_) | ExprKind::DateLiteral(_) | ExprKind::Bool(_) | ExprKind::Byte(_) | ExprKind::String(_) => {
             expr_matches_type_ref(expr, type_ref)
         }
-        ExprKind::Call { name, .. } => typed_builtin_return_type_ref(name)
-            .map(|actual_type| is_type_assignable_ref(&actual_type, type_ref, constants))
-            .unwrap_or(true),
+        ExprKind::Call { name, .. } => {
+            typed_builtin_return_type_ref(name).map(|actual_type| type_refs_equal(&actual_type, type_ref, constants)).unwrap_or(true)
+        }
         _ => true,
     }
 }
@@ -1901,13 +1890,9 @@ fn array_literal_matches_type_with_env_ref<'i>(
         ExprKind::Identifier(name) => types
             .get(name)
             .and_then(|value_type| parse_type_ref(value_type).ok())
-            .is_some_and(|value_type| is_type_assignable_ref(&value_type, &element_type, constants)),
+            .is_some_and(|value_type| type_refs_equal(&value_type, &element_type, constants)),
         _ => expr_matches_type_ref(value, &element_type),
     })
-}
-
-fn has_explicit_array_size_ref(type_ref: &TypeRef) -> bool {
-    !matches!(type_ref.array_size(), Some(ArrayDim::Dynamic | ArrayDim::Inferred) | None)
 }
 
 fn array_size_with_constants_ref<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
@@ -1921,31 +1906,47 @@ fn array_size_with_constants_ref<'i>(type_ref: &TypeRef, constants: &HashMap<Str
     }
 }
 
-fn is_array_type_assignable_ref<'i>(actual: &TypeRef, expected: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> bool {
-    if actual == expected {
-        return true;
-    }
+fn type_refs_equal<'i>(left: &TypeRef, right: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> bool {
+    left.base == right.base
+        && left.array_dims.len() == right.array_dims.len()
+        && left.array_dims.iter().zip(&right.array_dims).all(|(left, right)| array_dims_equal(left, right, constants))
+}
 
-    if !is_array_type_ref(actual) || !is_array_type_ref(expected) {
-        return false;
+fn type_after_append<'i>(source: &TypeRef, appended: usize, constants: &HashMap<String, Expr<'i>>) -> Option<TypeRef> {
+    let mut result = source.clone();
+    let dimension = result.array_dims.last_mut()?;
+    match dimension {
+        ArrayDim::Fixed(size) => *size = size.checked_add(appended)?,
+        ArrayDim::Constant(name) => {
+            let size = usize::try_from(const_array_dim_value(name, constants)?).ok()?;
+            *dimension = ArrayDim::Fixed(size.checked_add(appended)?);
+        }
+        ArrayDim::Dynamic => {}
+        ArrayDim::Inferred => return None,
     }
+    Some(result)
+}
 
-    if array_element_type_ref(actual) != array_element_type_ref(expected) {
-        return false;
-    }
-
-    if !has_explicit_array_size_ref(expected) {
-        return true;
-    }
-
-    match (array_size_with_constants_ref(actual, constants), array_size_with_constants_ref(expected, constants)) {
-        (Some(actual_size), Some(expected_size)) => actual_size == expected_size,
-        _ => actual == expected,
+fn array_dims_equal<'i>(left: &ArrayDim, right: &ArrayDim, constants: &HashMap<String, Expr<'i>>) -> bool {
+    match (left, right) {
+        (ArrayDim::Fixed(left), ArrayDim::Fixed(right)) => left == right,
+        (ArrayDim::Constant(left), ArrayDim::Constant(right)) => {
+            match (const_array_dim_value(left, constants), const_array_dim_value(right, constants)) {
+                (Some(left), Some(right)) => left == right,
+                _ => false,
+            }
+        }
+        (ArrayDim::Fixed(left), ArrayDim::Constant(right)) | (ArrayDim::Constant(right), ArrayDim::Fixed(left)) => {
+            i64::try_from(*left).ok() == const_array_dim_value(right, constants)
+        }
+        (ArrayDim::Dynamic, ArrayDim::Dynamic) | (ArrayDim::Inferred, ArrayDim::Inferred) => true,
+        _ => false,
     }
 }
 
-fn is_type_assignable_ref<'i>(actual: &TypeRef, expected: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> bool {
-    actual == expected || is_array_type_assignable_ref(actual, expected, constants)
+fn const_array_dim_value<'i>(name: &str, constants: &HashMap<String, Expr<'i>>) -> Option<i64> {
+    let expr = constants.get(name)?;
+    eval_const_int(expr, constants).ok().filter(|value| *value >= 0)
 }
 
 fn expr_matches_return_type_ref_hint<'i>(
@@ -1955,7 +1956,7 @@ fn expr_matches_return_type_ref_hint<'i>(
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
 ) -> Option<String> {
-    if validate_expr_assignable_to_type(expr, type_ref, types, structs, constants, &HashMap::new(), &[]).is_ok() {
+    if validate_expr_matches_type(expr, type_ref, types, structs, constants, &HashMap::new(), &[]).is_ok() {
         return None;
     }
     match (&expr.kind, &type_ref.base, !type_ref.is_array()) {

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -132,13 +132,9 @@ fn validate_function_signatures<'i>(
             }
         }
 
-        let mut types = initial_function_types(contract, function, structs)?;
-        let mut env = constants.clone();
-        let mut prefer_env_for_comparison = HashSet::new();
+        let mut types = initial_function_types(contract, function)?;
         validate_statement_shapes(
             &function.body,
-            &mut env,
-            &mut prefer_env_for_comparison,
             &mut types,
             &function.return_types,
             structs,
@@ -166,16 +162,6 @@ fn validate_contract_field_initializers<'i>(
 
     for field in &contract.fields {
         let type_name = type_name_from_ref(&field.type_ref);
-        validate_expr_semantics(
-            &field.expr,
-            constants,
-            &HashSet::new(),
-            &types,
-            structs,
-            constants,
-            &HashMap::new(),
-            &contract.fields,
-        )?;
         ensure_array_elements_have_known_size(&field.type_ref, structs, &type_name)?;
         validate_expr_matches_type(&field.expr, &field.type_ref, &types, structs, constants, &HashMap::new(), &contract.fields)
             .map_err(|_| CompilerError::Unsupported(format!("contract field '{}' expects {}", field.name, type_name)))?;
@@ -188,8 +174,6 @@ fn validate_contract_field_initializers<'i>(
 #[allow(clippy::too_many_arguments)]
 fn validate_statement_shapes<'i>(
     statements: &[Statement<'i>],
-    env: &mut HashMap<String, Expr<'i>>,
-    prefer_env_for_comparison: &mut HashSet<String>,
     types: &mut HashMap<String, String>,
     return_types: &[TypeRef],
     structs: &StructRegistry,
@@ -197,16 +181,7 @@ fn validate_statement_shapes<'i>(
     functions: &HashMap<String, &FunctionAst<'i>>,
     contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
-    let mut ctx = ValidateStatementShapesContext {
-        env,
-        prefer_env_for_comparison,
-        types,
-        return_types,
-        structs,
-        constants,
-        functions,
-        contract_fields,
-    };
+    let mut ctx = ValidateStatementShapesContext { types, return_types, structs, constants, functions, contract_fields };
 
     for stmt in statements {
         match stmt {
@@ -232,8 +207,8 @@ fn validate_statement_shapes<'i>(
             Statement::Console { args, .. } => validate_console_statement_shape(&mut ctx, args)?,
             Statement::Assign { name, expr, .. } => validate_assign_statement_shape(&mut ctx, name, expr)?,
             Statement::Block { body, .. } => validate_block_statement_shape(&mut ctx, body)?,
-            Statement::If { then_branch, else_branch, .. } => {
-                validate_if_statement_shape(&mut ctx, stmt, then_branch, else_branch.as_deref())?
+            Statement::If { condition, then_branch, else_branch, .. } => {
+                validate_if_statement_shape(&mut ctx, condition, then_branch, else_branch.as_deref())?
             }
             Statement::For { ident, start, end, max_iterations, body, .. } => {
                 validate_for_statement_shape(&mut ctx, ident, start, end, max_iterations, body)?
@@ -245,8 +220,6 @@ fn validate_statement_shapes<'i>(
 }
 
 struct ValidateStatementShapesContext<'a, 'i> {
-    env: &'a mut HashMap<String, Expr<'i>>,
-    prefer_env_for_comparison: &'a mut HashSet<String>,
     types: &'a mut HashMap<String, String>,
     return_types: &'a [TypeRef],
     structs: &'a StructRegistry,
@@ -255,89 +228,60 @@ struct ValidateStatementShapesContext<'a, 'i> {
     contract_fields: &'a [ContractFieldAst<'i>],
 }
 
+impl<'a, 'i> ValidateStatementShapesContext<'a, 'i> {
+    fn type_check_context(&self) -> type_check::TypeCheckContext<'_, 'i> {
+        type_check::TypeCheckContext {
+            types: self.types,
+            structs: self.structs,
+            constants: self.constants,
+            functions: self.functions,
+            contract_fields: self.contract_fields,
+        }
+    }
+
+    fn check_expr(&self, expr: &Expr<'i>, expected: Option<&TypeRef>) -> Result<TypeRef, CompilerError> {
+        type_check::check_expr(expr, expected, &self.type_check_context())
+    }
+
+    fn check_call(&self, name: &str, args: &[Expr<'i>], expected: Option<&TypeRef>) -> Result<Option<TypeRef>, CompilerError> {
+        type_check::check_call(name, name, args, expected, &self.type_check_context())
+    }
+}
+
 fn validate_variable_definition_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
     type_ref: &TypeRef,
     name: &str,
     expr: Option<&Expr<'i>>,
 ) -> Result<(), CompilerError> {
-    let effective_type_ref = infer_fixed_array_type_from_initializer_type_check(type_ref, expr, ctx.types, ctx.constants)
-        .unwrap_or_else(|| type_ref.clone());
-    let type_name = type_name_from_ref(&effective_type_ref);
-    ensure_array_elements_have_known_size(&effective_type_ref, ctx.structs, &type_name)?;
-    if effective_type_ref.is_array() {
-        validate_array_initializer(expr, &effective_type_ref, ctx.types, ctx.constants)?;
+    let type_name = type_name_from_ref(type_ref);
+    ensure_array_elements_have_known_size(type_ref, ctx.structs, &type_name)?;
+    if expr.is_none() && type_ref.is_array() && array_type_size(type_ref, ctx.constants).is_some() {
+        return Err(CompilerError::Unsupported("variable definition requires initializer".to_string()));
     }
     if let Some(expr) = expr {
-        validate_expr_semantics(
-            expr,
-            ctx.env,
-            ctx.prefer_env_for_comparison,
-            ctx.types,
-            ctx.structs,
-            ctx.constants,
-            ctx.functions,
-            ctx.contract_fields,
-        )?;
-        validate_expr_matches_type(expr, type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
-            .map_err(|err| {
-                if type_ref.is_array()
-                    && matches!(expr.kind, ExprKind::Array(_))
-                    && !matches!(&err, CompilerError::Unsupported(message) if message == "size mismatch")
-                {
-                    return CompilerError::Unsupported(format!("array element type mismatch for type {type_name}"));
-                }
-                map_declared_type_error(
-                    err,
-                    "variable",
-                    name,
-                    &type_name_from_ref(type_ref),
-                    expr,
-                    type_ref,
-                    ctx.types,
-                    ctx.structs,
-                    ctx.constants,
-                )
-            })?;
-        ctx.env.insert(name.to_string(), expr.clone());
-        ctx.prefer_env_for_comparison.remove(name);
-    }
-    insert_type_binding(ctx.types, name, &effective_type_ref, ctx.structs)
-}
-
-fn validate_array_initializer<'i>(
-    expr: Option<&Expr<'i>>,
-    type_ref: &TypeRef,
-    types: &HashMap<String, String>,
-    constants: &HashMap<String, Expr<'i>>,
-) -> Result<(), CompilerError> {
-    let type_name = type_name_from_ref(type_ref);
-    match expr {
-        Some(Expr { kind: ExprKind::Identifier(other), .. }) => match types.get(other) {
-            Some(other_type) => match parse_type_ref(other_type) {
-                Ok(other_type_ref) if type_refs_equal(&other_type_ref, type_ref, constants) => Ok(()),
-                Ok(_) => Err(CompilerError::Unsupported("array assignment requires identical array types".to_string())),
-                Err(_) => Err(CompilerError::Unsupported("array assignment requires identical array types".to_string())),
-            },
-            None => Err(CompilerError::UndefinedIdentifier(other.clone())),
-        },
-        Some(Expr { kind: ExprKind::Array(values), .. }) => {
-            if let Some(expected_size) = array_size_with_constants_ref(type_ref, constants)
-                && values.len() != expected_size
+        ctx.check_expr(expr, Some(type_ref)).map_err(|err| {
+            if type_ref.is_array()
+                && matches!(expr.kind, ExprKind::Array(_))
+                && !matches!(&err, CompilerError::Unsupported(message) if message == "size mismatch")
             {
-                return Err(CompilerError::Unsupported(format!(
-                    "array size mismatch: expected {} elements for type {}, got {}",
-                    expected_size,
-                    type_name,
-                    values.len()
-                )));
+                return CompilerError::Unsupported(format!("array element type mismatch for type {type_name}"));
             }
-            Ok(())
-        }
-        Some(_) => Ok(()),
-        None if array_size_with_constants_ref(type_ref, constants).is_none() => Ok(()),
-        None => Err(CompilerError::Unsupported("variable definition requires initializer".to_string())),
+            map_declared_type_error(
+                err,
+                "variable",
+                name,
+                &type_name_from_ref(type_ref),
+                expr,
+                type_ref,
+                ctx.types,
+                ctx.structs,
+                ctx.constants,
+            )
+        })?;
     }
+    insert_type_binding(ctx.types, name, type_ref);
+    Ok(())
 }
 
 fn validate_tuple_assignment_statement_shape<'i>(
@@ -348,34 +292,12 @@ fn validate_tuple_assignment_statement_shape<'i>(
     right_name: &str,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(
-        expr,
-        ctx.env,
-        ctx.prefer_env_for_comparison,
-        ctx.types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )?;
+    ctx.check_expr(expr, None)?;
     ensure_array_elements_have_known_size(left_type_ref, ctx.structs, &type_name_from_ref(left_type_ref))?;
     ensure_array_elements_have_known_size(right_type_ref, ctx.structs, &type_name_from_ref(right_type_ref))?;
-    if let ExprKind::Split { source, index, span: split_span, .. } = &expr.kind {
-        let left_expr = Expr::new(
-            ExprKind::Split { source: source.clone(), index: index.clone(), part: SplitPart::Left, span: *split_span },
-            span::Span::default(),
-        );
-        let right_expr = Expr::new(
-            ExprKind::Split { source: source.clone(), index: index.clone(), part: SplitPart::Right, span: *split_span },
-            span::Span::default(),
-        );
-        ctx.env.insert(left_name.to_string(), left_expr);
-        ctx.env.insert(right_name.to_string(), right_expr);
-        ctx.prefer_env_for_comparison.insert(left_name.to_string());
-        ctx.prefer_env_for_comparison.insert(right_name.to_string());
-    }
-    insert_type_binding(ctx.types, left_name, left_type_ref, ctx.structs)?;
-    insert_type_binding(ctx.types, right_name, right_type_ref, ctx.structs)
+    insert_type_binding(ctx.types, left_name, left_type_ref);
+    insert_type_binding(ctx.types, right_name, right_type_ref);
+    Ok(())
 }
 
 fn validate_state_function_call_assign_statement_shape<'i>(
@@ -384,22 +306,25 @@ fn validate_state_function_call_assign_statement_shape<'i>(
     name: &str,
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
-    for arg in args {
-        validate_expr_semantics(
-            arg,
-            ctx.env,
-            ctx.prefer_env_for_comparison,
-            ctx.types,
-            ctx.structs,
-            ctx.constants,
-            ctx.functions,
-            ctx.contract_fields,
-        )?;
+    match name {
+        "readInputState" => {
+            ctx.check_call(name, args, None)?;
+        }
+        "readInputStateWithTemplate" => {
+            let struct_name = struct_name_for_state_bindings_ref(bindings, ctx.structs, ctx.constants)?;
+            let expected = TypeRef { base: TypeBase::Custom(struct_name), array_dims: Vec::new() };
+            ctx.check_call(name, args, Some(&expected))?;
+        }
+        _ => {
+            return Err(CompilerError::Unsupported(format!(
+                "state destructuring assignment is only supported for readInputState()/readInputStateWithTemplate(), got '{name}()'"
+            )));
+        }
     }
     validate_state_function_call_assign(bindings, name, args, ctx.structs, ctx.constants, ctx.contract_fields)?;
     for binding in bindings {
         ensure_array_elements_have_known_size(&binding.type_ref, ctx.structs, &type_name_from_ref(&binding.type_ref))?;
-        insert_type_binding(ctx.types, &binding.name, &binding.type_ref, ctx.structs)?;
+        insert_type_binding(ctx.types, &binding.name, &binding.type_ref);
     }
     Ok(())
 }
@@ -409,20 +334,12 @@ fn validate_struct_destructure_statement_shape<'i>(
     bindings: &[StructBindingAst<'i>],
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(
-        expr,
-        ctx.env,
-        ctx.prefer_env_for_comparison,
-        ctx.types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )?;
-    validate_struct_destructure_bindings(bindings, expr, ctx.types, ctx.structs, ctx.constants, ctx.contract_fields)?;
+    let expr_type = ctx.check_expr(expr, None)?;
+    let direct_read_input_state = matches!(&expr.kind, ExprKind::Call { name, .. } if name == "readInputState");
+    validate_struct_destructure_bindings(bindings, &expr_type, direct_read_input_state, ctx.structs, ctx.constants)?;
     for binding in bindings {
         ensure_array_elements_have_known_size(&binding.type_ref, ctx.structs, &type_name_from_ref(&binding.type_ref))?;
-        insert_type_binding(ctx.types, &binding.name, &binding.type_ref, ctx.structs)?;
+        insert_type_binding(ctx.types, &binding.name, &binding.type_ref);
     }
     Ok(())
 }
@@ -432,34 +349,53 @@ fn validate_function_call_statement_shape<'i>(
     name: &str,
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
-    reject_read_input_state_with_template_call_args(args)?;
-    for arg in args {
-        validate_expr_semantics(
-            arg,
-            ctx.env,
-            ctx.prefer_env_for_comparison,
-            ctx.types,
-            ctx.structs,
-            ctx.constants,
-            ctx.functions,
-            ctx.contract_fields,
-        )?;
+    if matches!(name, "validateOutputState" | "validateOutputStateWithTemplate") {
+        return validate_output_state_call(ctx, name, args);
     }
-    validate_builtin_call(
-        name,
-        args,
-        ctx.env,
-        ctx.prefer_env_for_comparison,
-        ctx.types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )?;
-    if ctx.functions.contains_key(name) {
-        validate_internal_call(name, args, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)?;
+    ctx.check_call(name, args, None).map(|_| ())
+}
+
+fn validate_output_state_call<'i>(
+    ctx: &ValidateStatementShapesContext<'_, 'i>,
+    name: &str,
+    args: &[Expr<'i>],
+) -> Result<(), CompilerError> {
+    let int_type = parse_type_ref("int")?;
+    match (name, args) {
+        ("validateOutputState", [output_index, state]) => {
+            let state_type = TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: Vec::new() };
+            ctx.check_expr(output_index, Some(&int_type))?;
+            ctx.check_expr(state, Some(&state_type)).map_err(|err| {
+                if matches!(state.kind, ExprKind::StructLiteral(_)) {
+                    err
+                } else {
+                    CompilerError::Unsupported("validateOutputState requires a State value".to_string())
+                }
+            })?;
+            Ok(())
+        }
+        ("validateOutputState", _) => {
+            Err(CompilerError::Unsupported("validateOutputState(output_idx, new_state) expects 2 arguments".to_string()))
+        }
+        ("validateOutputStateWithTemplate", [output_index, state, prefix, suffix, template_hash]) => {
+            ctx.check_expr(output_index, Some(&int_type))?;
+            let state_type = ctx.check_expr(state, None)?;
+            if !is_struct(&state_type, ctx.structs) {
+                return Err(CompilerError::Unsupported(
+                    "validateOutputStateWithTemplate requires a struct value".to_string(),
+                ));
+            }
+            for expression in [prefix, suffix, template_hash] {
+                ctx.check_expr(expression, None)?;
+            }
+            Ok(())
+        }
+        ("validateOutputStateWithTemplate", _) => Err(CompilerError::Unsupported(
+            "validateOutputStateWithTemplate(output_idx, new_state, template_prefix, template_suffix, expected_template_hash) expects 5 arguments"
+                .to_string(),
+        )),
+        _ => unreachable!(),
     }
-    Ok(())
 }
 
 fn validate_function_call_assign_statement_shape<'i>(
@@ -468,24 +404,17 @@ fn validate_function_call_assign_statement_shape<'i>(
     name: &str,
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
-    reject_read_input_state_with_template_call_args(args)?;
-    for arg in args {
-        validate_expr_semantics(
-            arg,
-            ctx.env,
-            ctx.prefer_env_for_comparison,
-            ctx.types,
-            ctx.structs,
-            ctx.constants,
-            ctx.functions,
-            ctx.contract_fields,
-        )?;
+    if !ctx.functions.contains_key(name) {
+        return Err(CompilerError::Unsupported(format!("function '{name}' not found")));
     }
-    let function = validate_internal_call(name, args, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)?;
-    if bindings.len() != function.return_types.len() {
+    let return_type = ctx
+        .check_call(name, args, None)?
+        .ok_or_else(|| CompilerError::Unsupported(format!("function '{name}' does not return a value")))?;
+    let return_types = return_type.tuple_elements().map(<[_]>::to_vec).unwrap_or_else(|| vec![return_type.clone()]);
+    if bindings.len() != return_types.len() {
         return Err(CompilerError::Unsupported("function call assignment return count mismatch".to_string()));
     }
-    for (binding, return_type) in bindings.iter().zip(function.return_types.iter()) {
+    for (binding, return_type) in bindings.iter().zip(&return_types) {
         if !type_refs_equal(&binding.type_ref, return_type, ctx.constants) {
             return Err(CompilerError::Unsupported(format!(
                 "function return binding '{}' expects {}",
@@ -493,7 +422,7 @@ fn validate_function_call_assign_statement_shape<'i>(
                 type_name_from_ref(return_type)
             )));
         }
-        insert_type_binding(ctx.types, &binding.name, &binding.type_ref, ctx.structs)?;
+        insert_type_binding(ctx.types, &binding.name, &binding.type_ref);
     }
     Ok(())
 }
@@ -502,18 +431,6 @@ fn validate_return_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
     exprs: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
-    for expr in exprs {
-        validate_expr_semantics(
-            expr,
-            ctx.env,
-            ctx.prefer_env_for_comparison,
-            ctx.types,
-            ctx.structs,
-            ctx.constants,
-            ctx.functions,
-            ctx.contract_fields,
-        )?;
-    }
     validate_return_types(exprs, ctx.return_types, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
 }
 
@@ -521,32 +438,14 @@ fn validate_require_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(
-        expr,
-        ctx.env,
-        ctx.prefer_env_for_comparison,
-        ctx.types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )
+    ctx.check_expr(expr, Some(&parse_type_ref("bool")?)).map(|_| ())
 }
 
 fn validate_time_op_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(
-        expr,
-        ctx.env,
-        ctx.prefer_env_for_comparison,
-        ctx.types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )
+    ctx.check_expr(expr, Some(&parse_type_ref("int")?)).map(|_| ())
 }
 
 fn validate_console_statement_shape<'i>(
@@ -554,16 +453,7 @@ fn validate_console_statement_shape<'i>(
     args: &[Expr<'i>],
 ) -> Result<(), CompilerError> {
     for arg in args {
-        validate_expr_semantics(
-            arg,
-            ctx.env,
-            ctx.prefer_env_for_comparison,
-            ctx.types,
-            ctx.structs,
-            ctx.constants,
-            ctx.functions,
-            ctx.contract_fields,
-        )?;
+        ctx.check_expr(arg, None)?;
     }
     Ok(())
 }
@@ -573,53 +463,25 @@ fn validate_assign_statement_shape<'i>(
     name: &str,
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(
-        expr,
-        ctx.env,
-        ctx.prefer_env_for_comparison,
-        ctx.types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )?;
     if let Some(type_name) = ctx.types.get(name).cloned() {
         let type_ref = parse_type_ref(&type_name)?;
-        validate_expr_matches_type(expr, &type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
-            .map_err(|err| {
-                map_declared_type_error(err, "variable", name, &type_name, expr, &type_ref, ctx.types, ctx.structs, ctx.constants)
-            })?;
+        ctx.check_expr(expr, Some(&type_ref)).map_err(|err| {
+            map_declared_type_error(err, "variable", name, &type_name, expr, &type_ref, ctx.types, ctx.structs, ctx.constants)
+        })?;
     }
-    ctx.env.insert(name.to_string(), expr.clone());
-    ctx.prefer_env_for_comparison.remove(name);
     Ok(())
 }
 
 fn validate_if_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
-    stmt: &Statement<'i>,
+    condition: &Expr<'i>,
     then_branch: &[Statement<'i>],
     else_branch: Option<&[Statement<'i>]>,
 ) -> Result<(), CompilerError> {
-    if let Statement::If { condition, .. } = stmt {
-        validate_expr_semantics(
-            condition,
-            ctx.env,
-            ctx.prefer_env_for_comparison,
-            ctx.types,
-            ctx.structs,
-            ctx.constants,
-            ctx.functions,
-            ctx.contract_fields,
-        )?;
-    }
+    ctx.check_expr(condition, Some(&parse_type_ref("bool")?))?;
     let mut then_types = ctx.types.clone();
-    let mut then_env = ctx.env.clone();
-    let mut then_prefer_env = ctx.prefer_env_for_comparison.clone();
     validate_statement_shapes(
         then_branch,
-        &mut then_env,
-        &mut then_prefer_env,
         &mut then_types,
         ctx.return_types,
         ctx.structs,
@@ -629,12 +491,8 @@ fn validate_if_statement_shape<'i>(
     )?;
     if let Some(else_branch) = else_branch {
         let mut else_types = ctx.types.clone();
-        let mut else_env = ctx.env.clone();
-        let mut else_prefer_env = ctx.prefer_env_for_comparison.clone();
         validate_statement_shapes(
             else_branch,
-            &mut else_env,
-            &mut else_prefer_env,
             &mut else_types,
             ctx.return_types,
             ctx.structs,
@@ -651,19 +509,7 @@ fn validate_block_statement_shape<'i>(
     body: &[Statement<'i>],
 ) -> Result<(), CompilerError> {
     let mut block_types = ctx.types.clone();
-    let mut block_env = ctx.env.clone();
-    let mut block_prefer_env = ctx.prefer_env_for_comparison.clone();
-    validate_statement_shapes(
-        body,
-        &mut block_env,
-        &mut block_prefer_env,
-        &mut block_types,
-        ctx.return_types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )
+    validate_statement_shapes(body, &mut block_types, ctx.return_types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
 }
 
 fn validate_for_statement_shape<'i>(
@@ -674,66 +520,25 @@ fn validate_for_statement_shape<'i>(
     max_iterations: &Expr<'i>,
     body: &[Statement<'i>],
 ) -> Result<(), CompilerError> {
-    validate_expr_semantics(
-        start,
-        ctx.env,
-        ctx.prefer_env_for_comparison,
-        ctx.types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )?;
-    validate_expr_semantics(
-        end,
-        ctx.env,
-        ctx.prefer_env_for_comparison,
-        ctx.types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )?;
-    validate_expr_semantics(
-        max_iterations,
-        ctx.env,
-        ctx.prefer_env_for_comparison,
-        ctx.types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )?;
+    let int_type = parse_type_ref("int")?;
+    ctx.check_expr(start, Some(&int_type))?;
+    ctx.check_expr(end, Some(&int_type))?;
+    ctx.check_expr(max_iterations, Some(&int_type))?;
     let mut body_types = ctx.types.clone();
-    let mut body_env = ctx.env.clone();
-    let mut body_prefer_env = ctx.prefer_env_for_comparison.clone();
     body_types.insert(ident.to_string(), "int".to_string());
-    validate_statement_shapes(
-        body,
-        &mut body_env,
-        &mut body_prefer_env,
-        &mut body_types,
-        ctx.return_types,
-        ctx.structs,
-        ctx.constants,
-        ctx.functions,
-        ctx.contract_fields,
-    )
+    validate_statement_shapes(body, &mut body_types, ctx.return_types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
 }
 
 fn validate_struct_destructure_bindings<'i>(
     bindings: &[StructBindingAst<'i>],
-    expr: &Expr<'i>,
-    types: &HashMap<String, String>,
+    expr_type: &TypeRef,
+    direct_read_input_state: bool,
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
-    contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
-    let expr_type = infer_struct_destructure_expr_type(expr, types, structs, contract_fields)?;
-    let struct_name = struct_name_from_type_ref(&expr_type, structs)
+    let struct_name = struct_name_from_type_ref(expr_type, structs)
         .ok_or_else(|| CompilerError::Unsupported("struct destructuring requires a struct value".to_string()))?;
     let struct_ast = structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
-    let direct_read_input_state = matches!(&expr.kind, ExprKind::Call { name, .. } if name == "readInputState");
     let mut seen_fields = HashSet::new();
     let mut seen_names = HashSet::new();
 
@@ -770,6 +575,7 @@ fn validate_struct_destructure_bindings<'i>(
     Ok(())
 }
 
+// TODO: Remove this special case and destructure the State struct like any other struct.
 fn validate_state_function_call_assign<'i>(
     bindings: &[StructBindingAst<'i>],
     name: &str,
@@ -847,380 +653,6 @@ fn validate_state_function_call_assign<'i>(
     }
 }
 
-fn validate_expr_semantics<'i>(
-    expr: &Expr<'i>,
-    env: &HashMap<String, Expr<'i>>,
-    prefer_env_for_comparison: &HashSet<String>,
-    types: &HashMap<String, String>,
-    structs: &StructRegistry,
-    constants: &HashMap<String, Expr<'i>>,
-    functions: &HashMap<String, &FunctionAst<'i>>,
-    contract_fields: &[ContractFieldAst<'i>],
-) -> Result<(), CompilerError> {
-    match &expr.kind {
-        ExprKind::Binary { op, left, right } => {
-            validate_expr_semantics(left, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            validate_expr_semantics(right, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            let left_value_type = super::debug_value_types::infer_debug_expr_value_type(left, env, types, &mut HashSet::new()).ok();
-            let right_value_type = super::debug_value_types::infer_debug_expr_value_type(right, env, types, &mut HashSet::new()).ok();
-            if matches!(op, BinaryOp::Add)
-                && (left_value_type.as_deref() == Some("byte") || right_value_type.as_deref() == Some("byte"))
-            {
-                return Err(CompilerError::Unsupported("byte values do not support '+'".to_string()));
-            }
-            if matches!(op, BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge) {
-                let left_type = infer_expr_type_ref_for_comparison_ref(
-                    left,
-                    env,
-                    prefer_env_for_comparison,
-                    types,
-                    structs,
-                    functions,
-                    contract_fields,
-                );
-                let coerced_right = coerce_rhs_byte_literal_for_comparison_ref(left_type.as_ref(), right);
-                let right_type = infer_expr_type_ref_for_comparison_ref(
-                    &coerced_right,
-                    env,
-                    prefer_env_for_comparison,
-                    types,
-                    structs,
-                    functions,
-                    contract_fields,
-                );
-                if let (Some(left_type), Some(right_type)) = (left_type, right_type)
-                    && !type_refs_equal(&left_type, &right_type, constants)
-                {
-                    return Err(CompilerError::Unsupported(format!(
-                        "type mismatch: cannot compare {} and {}",
-                        type_name_from_ref(&left_type),
-                        type_name_from_ref(&right_type)
-                    )));
-                }
-            }
-            Ok(())
-        }
-        ExprKind::Unary { expr, .. } => {
-            validate_expr_semantics(expr, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)
-        }
-        ExprKind::IfElse { condition, then_expr, else_expr } => {
-            validate_expr_semantics(condition, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            validate_expr_semantics(then_expr, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            validate_expr_semantics(else_expr, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            let then_type = infer_expr_type_ref_for_comparison_ref(
-                then_expr,
-                env,
-                prefer_env_for_comparison,
-                types,
-                structs,
-                functions,
-                contract_fields,
-            );
-            let else_type = infer_expr_type_ref_for_comparison_ref(
-                else_expr,
-                env,
-                prefer_env_for_comparison,
-                types,
-                structs,
-                functions,
-                contract_fields,
-            );
-            if let (Some(then_type), Some(else_type)) = (then_type, else_type)
-                && !type_refs_equal(&then_type, &else_type, constants)
-            {
-                return Err(CompilerError::Unsupported(format!(
-                    "ternary branch type mismatch: then expression is {}, else expression is {}",
-                    type_name_from_ref(&then_type),
-                    type_name_from_ref(&else_type)
-                )));
-            }
-            Ok(())
-        }
-        ExprKind::Array(values) => {
-            for value in values {
-                validate_expr_semantics(value, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            }
-            Ok(())
-        }
-        ExprKind::Call { name, args, .. } => {
-            reject_read_input_state_with_template_call_args(args)?;
-            for arg in args {
-                validate_expr_semantics(arg, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            }
-            validate_builtin_call(name, args, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            if let Some(function) = functions.get(name) {
-                if function.entrypoint {
-                    return Err(CompilerError::Unsupported(format!("entrypoint function '{}' cannot be called", name)));
-                }
-                if function.returns_tuple {
-                    return Err(CompilerError::Unsupported(format!(
-                        "function '{}' returns a tuple and cannot be used directly in expressions; access a tuple field instead",
-                        name
-                    )));
-                }
-                if function.return_types.len() != 1 {
-                    return Err(CompilerError::Unsupported(format!(
-                        "function '{}' with multiple return values cannot be used in expressions",
-                        name
-                    )));
-                }
-            }
-            Ok(())
-        }
-        ExprKind::New { args, .. } => {
-            for arg in args {
-                validate_expr_semantics(arg, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            }
-            Ok(())
-        }
-        ExprKind::Split { source, index, .. } => {
-            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            validate_expr_semantics(index, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)
-        }
-        ExprKind::Slice { source, start, end, .. } => {
-            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            validate_expr_semantics(start, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            validate_expr_semantics(end, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)
-        }
-        ExprKind::Append { source, args, .. } => {
-            reject_read_input_state_with_template_call_args(args)?;
-            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            let source_type = infer_expr_type_ref_for_comparison_ref(
-                source,
-                env,
-                prefer_env_for_comparison,
-                types,
-                structs,
-                functions,
-                contract_fields,
-            )
-            .ok_or_else(|| CompilerError::Unsupported("append target must be an array".to_string()))?;
-            let Some(element_type) = source_type.array_element_type() else {
-                return Err(CompilerError::Unsupported("append target must be an array".to_string()));
-            };
-            for arg in args {
-                validate_expr_semantics(arg, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-                validate_expr_matches_type(arg, &element_type, types, structs, &HashMap::new(), functions, contract_fields).map_err(
-                    |_| {
-                        CompilerError::Unsupported(format!(
-                            "array append element type mismatch: expected {}",
-                            type_name_from_ref(&element_type)
-                        ))
-                    },
-                )?;
-            }
-            Ok(())
-        }
-        ExprKind::ArrayIndex { source, index } => {
-            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-            validate_expr_semantics(index, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)
-        }
-        ExprKind::Introspection { index, .. } => {
-            validate_expr_semantics(index, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)
-        }
-        ExprKind::StructLiteral(fields) => {
-            for field in fields {
-                validate_expr_semantics(
-                    &field.expr,
-                    env,
-                    prefer_env_for_comparison,
-                    types,
-                    structs,
-                    constants,
-                    functions,
-                    contract_fields,
-                )?;
-            }
-            Ok(())
-        }
-        ExprKind::FieldAccess { source, field, .. } => {
-            if tuple_field_index(field).is_some() {
-                return validate_tuple_field_access(
-                    source,
-                    field,
-                    env,
-                    prefer_env_for_comparison,
-                    types,
-                    structs,
-                    constants,
-                    functions,
-                    contract_fields,
-                );
-            }
-            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)
-        }
-        ExprKind::UnarySuffix { source, .. } => {
-            validate_expr_semantics(source, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)
-        }
-        ExprKind::Identifier(name) => {
-            if types.contains_key(name) || env.contains_key(name) {
-                Ok(())
-            } else {
-                Err(CompilerError::UndefinedIdentifier(name.clone()))
-            }
-        }
-        _ => Ok(()),
-    }
-}
-
-fn reject_read_input_state_with_template_call_args(args: &[Expr<'_>]) -> Result<(), CompilerError> {
-    if args.iter().any(|arg| matches!(&arg.kind, ExprKind::Call { name, .. } if name == "readInputStateWithTemplate")) {
-        return Err(CompilerError::Unsupported(
-            "readInputStateWithTemplate must be assigned to a struct variable or destructured directly".to_string(),
-        ));
-    }
-    Ok(())
-}
-
-fn infer_expr_type_ref_for_comparison_ref<'i>(
-    expr: &Expr<'i>,
-    env: &HashMap<String, Expr<'i>>,
-    prefer_env_for_comparison: &HashSet<String>,
-    types: &HashMap<String, String>,
-    structs: &StructRegistry,
-    functions: &HashMap<String, &FunctionAst<'i>>,
-    contract_fields: &[ContractFieldAst<'i>],
-) -> Option<TypeRef> {
-    match &expr.kind {
-        ExprKind::Identifier(name) => {
-            if prefer_env_for_comparison.contains(name)
-                && let Some(value) = env.get(name)
-            {
-                let type_name = super::debug_value_types::infer_debug_expr_value_type(value, env, types, &mut HashSet::new()).ok()?;
-                parse_type_ref(&type_name).ok()
-            } else {
-                types.get(name).and_then(|type_name| parse_type_ref(type_name).ok())
-            }
-        }
-        ExprKind::FieldAccess { source, field, .. } if tuple_field_index(field).is_some() => {
-            infer_tuple_field_access_type(source, field, functions)
-        }
-        ExprKind::FieldAccess { source, field, .. } => {
-            let source_type = infer_expr_type_ref_for_comparison_ref(
-                source,
-                env,
-                prefer_env_for_comparison,
-                types,
-                structs,
-                functions,
-                contract_fields,
-            )?;
-            let struct_name = struct_name_from_type_ref(&source_type, structs)?;
-            let struct_ast = structs.get(struct_name)?;
-            struct_ast.fields.iter().find(|candidate| candidate.name == *field).map(|candidate| candidate.type_ref.clone())
-        }
-        ExprKind::ArrayIndex { source, .. } => {
-            infer_expr_type_ref_for_comparison_ref(source, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
-                .and_then(|type_ref| type_ref.array_element_type())
-        }
-        ExprKind::Append { source, .. } => {
-            infer_expr_type_ref_for_comparison_ref(source, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
-        }
-        ExprKind::IfElse { then_expr, else_expr, .. } => {
-            let then_type = infer_expr_type_ref_for_comparison_ref(
-                then_expr,
-                env,
-                prefer_env_for_comparison,
-                types,
-                structs,
-                functions,
-                contract_fields,
-            )?;
-            let else_type = infer_expr_type_ref_for_comparison_ref(
-                else_expr,
-                env,
-                prefer_env_for_comparison,
-                types,
-                structs,
-                functions,
-                contract_fields,
-            )?;
-            (then_type == else_type).then_some(then_type)
-        }
-        ExprKind::New { name, .. } => typed_constructor_return_type_ref(name),
-        ExprKind::Call { name, .. } if name == "readInputState" && !contract_fields.is_empty() => {
-            Some(TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: Vec::new() })
-        }
-        ExprKind::Call { name, .. } => {
-            if let Some(function) = functions.get(name) {
-                if function.entrypoint || function.returns_tuple || function.return_types.len() != 1 {
-                    return None;
-                }
-                return Some(function.return_types[0].clone());
-            }
-            let type_name = super::debug_value_types::infer_debug_expr_value_type(expr, env, types, &mut HashSet::new()).ok()?;
-            parse_type_ref(&type_name).ok()
-        }
-        _ => {
-            let type_name = super::debug_value_types::infer_debug_expr_value_type(expr, env, types, &mut HashSet::new()).ok()?;
-            parse_type_ref(&type_name).ok()
-        }
-    }
-}
-
-fn tuple_field_index(field: &str) -> Option<usize> {
-    (!field.is_empty() && field.chars().all(|ch| ch.is_ascii_digit())).then(|| field.parse().ok()).flatten()
-}
-
-fn infer_tuple_field_access_type<'i>(
-    source: &Expr<'i>,
-    field: &str,
-    functions: &HashMap<String, &FunctionAst<'i>>,
-) -> Option<TypeRef> {
-    let ExprKind::Call { name, .. } = &source.kind else {
-        return None;
-    };
-    let function = functions.get(name)?;
-    let index = tuple_field_index(field)?;
-    if function.entrypoint || !function.returns_tuple {
-        return None;
-    }
-    function.return_types.get(index).cloned()
-}
-
-fn validate_tuple_field_access<'i>(
-    source: &Expr<'i>,
-    field: &str,
-    env: &HashMap<String, Expr<'i>>,
-    prefer_env_for_comparison: &HashSet<String>,
-    types: &HashMap<String, String>,
-    structs: &StructRegistry,
-    constants: &HashMap<String, Expr<'i>>,
-    functions: &HashMap<String, &FunctionAst<'i>>,
-    contract_fields: &[ContractFieldAst<'i>],
-) -> Result<(), CompilerError> {
-    let ExprKind::Call { name, args, .. } = &source.kind else {
-        return Err(CompilerError::Unsupported("tuple field access requires a tuple-returning function call".to_string()));
-    };
-    for arg in args {
-        validate_expr_semantics(arg, env, prefer_env_for_comparison, types, structs, constants, functions, contract_fields)?;
-    }
-    let Some(function) = functions.get(name) else {
-        return Err(CompilerError::Unsupported(format!("function '{}' not found", name)));
-    };
-    if function.entrypoint {
-        return Err(CompilerError::Unsupported(format!("entrypoint function '{}' cannot be called", name)));
-    }
-    if !function.returns_tuple {
-        return Err(CompilerError::Unsupported(format!("function '{}' does not return a tuple", name)));
-    }
-    let index = tuple_field_index(field).expect("checked");
-    if index >= function.return_types.len() {
-        return Err(CompilerError::Unsupported(format!("tuple index {index} out of bounds for function '{}'", name)));
-    }
-    Ok(())
-}
-
-fn coerce_rhs_byte_literal_for_comparison_ref<'i>(left_type: Option<&TypeRef>, right: &Expr<'i>) -> Expr<'i> {
-    if left_type.is_some_and(|type_ref| matches!(type_ref.base, TypeBase::Byte) && !type_ref.is_array())
-        && let ExprKind::Int(value) = right.kind
-        && (0..=255).contains(&value)
-    {
-        return Expr::new(ExprKind::Byte(value as u8), right.span);
-    }
-    right.clone()
-}
-
 fn struct_name_for_state_bindings_ref<'i>(
     bindings: &[StructBindingAst<'i>],
     structs: &StructRegistry,
@@ -1252,187 +684,30 @@ fn struct_name_for_state_bindings_ref<'i>(
     }
 }
 
-fn infer_struct_destructure_expr_type<'i>(
-    expr: &Expr<'i>,
-    types: &HashMap<String, String>,
-    structs: &StructRegistry,
-    contract_fields: &[ContractFieldAst<'i>],
-) -> Result<TypeRef, CompilerError> {
-    match &expr.kind {
-        ExprKind::Identifier(name) => types
-            .get(name)
-            .ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))
-            .and_then(|type_name| parse_type_ref(type_name)),
-        ExprKind::FieldAccess { source, field, .. } => {
-            let source_type = infer_struct_destructure_expr_type(source, types, structs, contract_fields)?;
-            let struct_name = struct_name_from_type_ref(&source_type, structs)
-                .ok_or_else(|| CompilerError::Unsupported("field access requires a struct value".to_string()))?;
-            let struct_ast =
-                structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
-            struct_ast
-                .fields
-                .iter()
-                .find(|candidate| candidate.name == *field)
-                .map(|candidate| candidate.type_ref.clone())
-                .ok_or_else(|| CompilerError::Unsupported(format!("struct '{}' has no field '{}'", struct_name, field)))
-        }
-        ExprKind::ArrayIndex { source, .. } => match &source.kind {
-            ExprKind::Identifier(name) => types
-                .get(name)
-                .ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))
-                .and_then(|type_name| parse_type_ref(type_name))
-                .and_then(|type_ref| {
-                    type_ref
-                        .array_element_type()
-                        .ok_or_else(|| CompilerError::Unsupported("struct destructuring requires a struct value".to_string()))
-                }),
-            _ => Err(CompilerError::Unsupported("struct destructuring requires a struct value".to_string())),
-        },
-        ExprKind::Call { name, .. } if name == "readInputState" => {
-            if contract_fields.is_empty() {
-                return Err(CompilerError::Unsupported("readInputState requires contract fields".to_string()));
-            }
-            Ok(TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: Vec::new() })
-        }
-        ExprKind::Call { name, .. } if name == "readInputStateWithTemplate" => Err(CompilerError::Unsupported(
-            "readInputStateWithTemplate must be assigned to a struct variable or destructured directly".to_string(),
-        )),
-        _ => Err(CompilerError::Unsupported("struct destructuring requires a struct value".to_string())),
-    }
-}
-
 fn initial_function_types<'i>(
     contract: &ContractAst<'i>,
     function: &FunctionAst<'i>,
-    structs: &StructRegistry,
 ) -> Result<HashMap<String, String>, CompilerError> {
     let mut types = HashMap::new();
 
     for param in &contract.params {
-        insert_type_binding(&mut types, &param.name, &param.type_ref, structs)?;
+        insert_type_binding(&mut types, &param.name, &param.type_ref);
     }
     for field in &contract.fields {
-        insert_type_binding(&mut types, &field.name, &field.type_ref, structs)?;
+        insert_type_binding(&mut types, &field.name, &field.type_ref);
     }
     for constant in &contract.constants {
-        insert_type_binding(&mut types, &constant.name, &constant.type_ref, structs)?;
+        insert_type_binding(&mut types, &constant.name, &constant.type_ref);
     }
     for param in &function.params {
-        insert_type_binding(&mut types, &param.name, &param.type_ref, structs)?;
+        insert_type_binding(&mut types, &param.name, &param.type_ref);
     }
 
     Ok(types)
 }
 
-fn insert_type_binding(
-    types: &mut HashMap<String, String>,
-    name: &str,
-    type_ref: &TypeRef,
-    structs: &StructRegistry,
-) -> Result<(), CompilerError> {
+fn insert_type_binding(types: &mut HashMap<String, String>, name: &str, type_ref: &TypeRef) {
     types.insert(name.to_string(), type_name_from_ref(type_ref));
-    if (is_struct(type_ref, structs) || is_struct_array(type_ref, structs))
-        && let Ok(leaves) = flatten_type_ref_leaves(type_ref, structs)
-    {
-        for (path, leaf_type) in leaves {
-            types.insert(flattened_struct_name(name, &path), type_name_from_ref(&leaf_type));
-        }
-    }
-    Ok(())
-}
-
-fn validate_internal_call<'i>(
-    name: &str,
-    args: &[Expr<'i>],
-    types: &HashMap<String, String>,
-    structs: &StructRegistry,
-    constants: &HashMap<String, Expr<'i>>,
-    functions: &'i HashMap<String, &'i FunctionAst<'i>>,
-    contract_fields: &[ContractFieldAst<'i>],
-) -> Result<&'i FunctionAst<'i>, CompilerError> {
-    let Some(function) = functions.get(name).copied() else {
-        return Err(CompilerError::Unsupported(format!("function '{}' not found", name)));
-    };
-    if function.entrypoint {
-        return Err(CompilerError::Unsupported(format!("entrypoint function '{}' cannot be called", name)));
-    }
-    if function.params.len() != args.len() {
-        return Err(CompilerError::Unsupported(format!("function '{}' expects {} arguments", name, function.params.len())));
-    }
-
-    for (param, arg) in function.params.iter().zip(args.iter()) {
-        let param_type_name = type_name_from_ref(&param.type_ref);
-        validate_expr_matches_type(arg, &param.type_ref, types, structs, constants, functions, contract_fields).map_err(|err| {
-            if matches!(&arg.kind, ExprKind::Call { name, .. } if name == "readInputStateWithTemplate") {
-                err
-            } else {
-                CompilerError::Unsupported(format!("function argument '{}' expects {}", param.name, param_type_name))
-            }
-        })?;
-    }
-
-    Ok(function)
-}
-
-fn validate_builtin_call<'i>(
-    name: &str,
-    args: &[Expr<'i>],
-    env: &HashMap<String, Expr<'i>>,
-    prefer_env_for_comparison: &HashSet<String>,
-    types: &HashMap<String, String>,
-    structs: &StructRegistry,
-    constants: &HashMap<String, Expr<'i>>,
-    functions: &HashMap<String, &FunctionAst<'i>>,
-    contract_fields: &[ContractFieldAst<'i>],
-) -> Result<(), CompilerError> {
-    let expected_args: &[(&str, &str)] = match name {
-        // TODO: Use constants for all builtins
-        "checkSigFromStack" => &[("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "pubkey")],
-        "checkSigFromStackECDSA" => &[("signature", "datasig"), ("digest", "byte[32]"), ("publicKey", "byte[33]")],
-        "blake3WithKey" => &[("data", "byte[]"), ("key", "byte[32]")],
-        _ => return Ok(()),
-    };
-    if args.len() != expected_args.len() {
-        return Err(CompilerError::Unsupported(format!("{name}() expects {} arguments", expected_args.len())));
-    }
-
-    for (arg, &(arg_name, expected_type_name)) in args.iter().zip(expected_args) {
-        let expected_type = parse_type_ref(expected_type_name)?;
-        if validate_expr_matches_type(arg, &expected_type, types, structs, constants, functions, contract_fields).is_err() {
-            let actual_type = infer_expr_type_ref_for_comparison_ref(
-                arg,
-                env,
-                prefer_env_for_comparison,
-                types,
-                structs,
-                functions,
-                contract_fields,
-            );
-            let actual_type = actual_type.as_ref().map(type_name_from_ref).unwrap_or_else(|| "unknown".to_string());
-            return Err(CompilerError::Unsupported(format!(
-                "{name}() argument '{arg_name}' expects {expected_type_name}, got {actual_type}"
-            )));
-        }
-    }
-
-    Ok(())
-}
-
-fn typed_builtin_return_type_ref(name: &str) -> Option<TypeRef> {
-    match name {
-        "checkSigFromStack" | "checkSigFromStackECDSA" => parse_type_ref("bool").ok(),
-        "templateHash" => parse_type_ref("byte[32]").ok(),
-        "int" | "bool" | "byte" | "string" | "pubkey" | "sig" | "datasig" | "byte[]" => parse_type_ref(name).ok(),
-        _ => None,
-    }
-}
-
-fn typed_constructor_return_type_ref(name: &str) -> Option<TypeRef> {
-    match name {
-        "ScriptPubKeyP2PK" => parse_type_ref("byte[34]").ok(),
-        "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript" => parse_type_ref("byte[35]").ok(),
-        _ => None,
-    }
 }
 
 pub(crate) fn validate_expr_matches_type<'i>(
@@ -1444,204 +719,8 @@ pub(crate) fn validate_expr_matches_type<'i>(
     functions: &HashMap<String, &FunctionAst<'i>>,
     contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
-    if let ExprKind::Call { name, name_span, .. } = &expr.kind
-        && name == "byte[1]"
-        && name_span.as_str() == "byte"
-    {
-        let scalar_byte = parse_type_ref("byte")?;
-        return if type_refs_equal(&scalar_byte, type_ref, constants) {
-            Ok(())
-        } else {
-            Err(CompilerError::Unsupported("type mismatch".to_string()))
-        };
-    }
-
-    if let ExprKind::Call { name, .. } = &expr.kind
-        && let Some(function) = functions.get(name)
-    {
-        if function.entrypoint {
-            return Err(CompilerError::Unsupported(format!("entrypoint function '{}' cannot be called", name)));
-        }
-        if function.returns_tuple {
-            return Err(CompilerError::Unsupported(format!(
-                "function '{}' returns a tuple and cannot be used directly in expressions; access a tuple field instead",
-                name
-            )));
-        }
-        if function.return_types.len() != 1 {
-            return Err(CompilerError::Unsupported(format!(
-                "function '{}' with multiple return values cannot be used in expressions",
-                name
-            )));
-        }
-        if type_refs_equal(&function.return_types[0], type_ref, constants) {
-            return Ok(());
-        }
-        return Err(CompilerError::Unsupported("type mismatch".to_string()));
-    }
-
-    if let ExprKind::Call { name, .. } = &expr.kind
-        && let Some(actual_type) = typed_builtin_return_type_ref(name)
-    {
-        return if type_refs_equal(&actual_type, type_ref, constants) {
-            Ok(())
-        } else {
-            Err(CompilerError::Unsupported("type mismatch".to_string()))
-        };
-    }
-
-    if matches!(type_ref.base, TypeBase::Byte)
-        && !type_ref.is_array()
-        && matches!(expr.kind, ExprKind::Int(value) if (0..=255).contains(&value))
-    {
-        return Ok(());
-    }
-
-    if let ExprKind::FieldAccess { field, .. } = &expr.kind
-        && tuple_field_index(field).is_some()
-        && let Some(actual_type) =
-            infer_expr_type_ref_for_comparison_ref(expr, &HashMap::new(), &HashSet::new(), types, structs, functions, contract_fields)
-    {
-        return if type_refs_equal(&actual_type, type_ref, constants) {
-            Ok(())
-        } else {
-            Err(CompilerError::Unsupported("type mismatch".to_string()))
-        };
-    }
-
-    if let ExprKind::IfElse { .. } = &expr.kind
-        && let Some(actual_type) =
-            infer_expr_type_ref_for_comparison_ref(expr, &HashMap::new(), &HashSet::new(), types, structs, functions, contract_fields)
-    {
-        return if type_refs_equal(&actual_type, type_ref, constants) {
-            Ok(())
-        } else {
-            Err(CompilerError::Unsupported("type mismatch".to_string()))
-        };
-    }
-
-    if type_ref.is_array()
-        && let ExprKind::Array(values) = &expr.kind
-    {
-        if let Some(expected_size) = array_size_with_constants_ref(type_ref, constants)
-            && values.len() != expected_size
-        {
-            return Err(CompilerError::Unsupported("size mismatch".to_string()));
-        }
-        let element_type = type_ref.array_element_type().expect("array type has an element type");
-        for value in values {
-            validate_expr_matches_type(value, &element_type, types, structs, constants, functions, contract_fields)?;
-        }
-        return Ok(());
-    }
-
-    if is_struct(type_ref, structs) {
-        if let ExprKind::Call { name, args, .. } = &expr.kind
-            && name == "readInputState"
-            && struct_name_from_type_ref(type_ref, structs) == Some(STATE_TYPE_NAME)
-            && !contract_fields.is_empty()
-            && args.len() == 1
-        {
-            return Ok(());
-        }
-        if let ExprKind::Call { name, args, .. } = &expr.kind
-            && name == "readInputStateWithTemplate"
-        {
-            return compile::read_input_state_with_template_values(args, type_ref, structs, constants).map(|_| ());
-        }
-        if matches!(expr.kind, ExprKind::StructLiteral(_)) {
-            return validate_struct_literal_matches_type(expr, type_ref, types, structs, constants, functions, contract_fields);
-        }
-        lower_runtime_struct_expr(expr, type_ref, types, structs, contract_fields, constants, 0).map(|_| ())
-    } else if is_struct_array(type_ref, structs) {
-        if let ExprKind::Call { name, .. } = &expr.kind
-            && name == "readInputStateWithTemplate"
-        {
-            return Err(CompilerError::Unsupported(
-                "readInputStateWithTemplate does not support struct array assignments".to_string(),
-            ));
-        }
-        let matches = match &expr.kind {
-            ExprKind::Identifier(name) => types
-                .get(name)
-                .and_then(|type_name| parse_type_ref(type_name).ok())
-                .is_some_and(|actual_type| type_refs_equal(&actual_type, type_ref, constants)),
-            ExprKind::Append { source, args, .. } => infer_expr_type_ref_for_comparison_ref(
-                source,
-                &HashMap::new(),
-                &HashSet::new(),
-                types,
-                structs,
-                functions,
-                contract_fields,
-            )
-            .and_then(|source_type| type_after_append(&source_type, args.len(), constants))
-            .is_some_and(|actual_type| type_refs_equal(&actual_type, type_ref, constants)),
-            _ => false,
-        };
-        if matches { Ok(()) } else { Err(CompilerError::Unsupported("type mismatch".to_string())) }
-    } else {
-        if let Some(actual_type) =
-            infer_expr_type_ref_for_comparison_ref(expr, &HashMap::new(), &HashSet::new(), types, structs, functions, contract_fields)
-            && type_refs_equal(&actual_type, type_ref, constants)
-        {
-            return Ok(());
-        }
-        if let Some(actual_type) = super::infer_array::infer_expr_type_ref(expr, types, constants, functions)
-            && type_refs_equal(&actual_type, type_ref, constants)
-        {
-            return Ok(());
-        }
-        let lowered = lower_runtime_expr(expr, types, structs)?;
-        if value_matches_type_ref(&lowered, type_ref) {
-            return Ok(());
-        }
-        let actual_type_name =
-            super::debug_value_types::infer_debug_expr_value_type(&lowered, &HashMap::new(), types, &mut HashSet::new())
-                .map_err(|_| CompilerError::Unsupported("type mismatch".to_string()))?;
-        let actual_type = parse_type_ref(&actual_type_name)?;
-        if type_refs_equal(&actual_type, type_ref, constants) {
-            Ok(())
-        } else {
-            Err(CompilerError::Unsupported("type mismatch".to_string()))
-        }
-    }
-}
-
-fn validate_struct_literal_matches_type<'i>(
-    expr: &Expr<'i>,
-    type_ref: &TypeRef,
-    types: &HashMap<String, String>,
-    structs: &StructRegistry,
-    constants: &HashMap<String, Expr<'i>>,
-    functions: &HashMap<String, &FunctionAst<'i>>,
-    contract_fields: &[ContractFieldAst<'i>],
-) -> Result<(), CompilerError> {
-    let Some(struct_name) = struct_name_from_type_ref(type_ref, structs) else {
-        return Err(CompilerError::Unsupported("type mismatch".to_string()));
-    };
-    let item = structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
-    let ExprKind::StructLiteral(fields) = &expr.kind else {
-        return Err(CompilerError::Unsupported("type mismatch".to_string()));
-    };
-    let mut provided = HashMap::new();
-    for field in fields {
-        if provided.insert(field.name.clone(), &field.expr).is_some() {
-            return Err(CompilerError::Unsupported(format!("duplicate struct field '{}'", field.name)));
-        }
-    }
-    for field in &item.fields {
-        let Some(value) = provided.remove(&field.name) else {
-            return Err(CompilerError::Unsupported(format!("struct field '{}' must be initialized", field.name)));
-        };
-        validate_expr_matches_type(value, &field.type_ref, types, structs, constants, functions, contract_fields).map_err(|_| {
-            CompilerError::Unsupported(format!("struct field '{}' expects {}", field.name, field.type_ref.type_name()))
-        })?;
-    }
-    if let Some(extra) = provided.keys().next() {
-        return Err(CompilerError::Unsupported(format!("unknown struct field '{}'", extra)));
-    }
-    Ok(())
+    let ctx = type_check::TypeCheckContext { types, structs, constants, functions, contract_fields };
+    type_check::check_expr(expr, Some(type_ref), &ctx).map(|_| ())
 }
 
 fn map_declared_type_error<'i>(
@@ -1673,39 +752,6 @@ fn ensure_array_elements_have_known_size(type_ref: &TypeRef, structs: &StructReg
     Ok(())
 }
 
-fn infer_fixed_array_type_from_initializer_type_check<'i>(
-    declared_type: &TypeRef,
-    initializer: Option<&Expr<'i>>,
-    types: &HashMap<String, String>,
-    constants: &HashMap<String, Expr<'i>>,
-) -> Option<TypeRef> {
-    if !matches!(declared_type.array_size(), Some(ArrayDim::Inferred)) {
-        return None;
-    }
-
-    let element_type = declared_type.array_element_type()?;
-    let init = initializer?;
-
-    match &init.kind {
-        ExprKind::Array(values) => {
-            let mut inferred = element_type.clone();
-            inferred.array_dims.push(ArrayDim::Fixed(values.len()));
-            Some(inferred)
-        }
-        ExprKind::Identifier(name) => {
-            let other_type = parse_type_ref(types.get(name)?).ok()?;
-            if !other_type.is_array() || array_element_type_ref(&other_type) != Some(element_type.clone()) {
-                return None;
-            }
-            let size = array_size_with_constants_ref(&other_type, constants)?;
-            let mut inferred = element_type;
-            inferred.array_dims.push(ArrayDim::Fixed(size));
-            Some(inferred)
-        }
-        _ => None,
-    }
-}
-
 fn fixed_type_size_ref(type_ref: &TypeRef, structs: &StructRegistry) -> Option<i64> {
     match &type_ref.base {
         TypeBase::Int => Some(8),
@@ -1722,7 +768,7 @@ fn fixed_type_size_ref(type_ref: &TypeRef, structs: &StructRegistry) -> Option<i
             }
             Some(total)
         }
-        TypeBase::Custom(_) => None,
+        TypeBase::Tuple(_) | TypeBase::Custom(_) => None,
     }
     .and_then(|base_size| {
         type_ref.array_dims.iter().try_fold(base_size, |acc, dim| match dim {
@@ -1745,106 +791,8 @@ fn statement_contains_return(stmt: &Statement<'_>) -> bool {
     }
 }
 
-pub(super) fn value_matches_type_ref<'i>(expr: &Expr<'i>, type_ref: &TypeRef) -> bool {
-    if type_ref.is_array() {
-        if let Some(size) = fixed_array_size(type_ref) {
-            if let Some(element_type) = type_ref.array_element_type() {
-                if element_type.base == TypeBase::Byte {
-                    return byte_array_len(expr) == Some(size);
-                }
-                return matches!(&expr.kind, ExprKind::Array(values) if values.len() == size && values.iter().all(|value| value_matches_type_ref(value, &element_type)));
-            }
-        }
-        return byte_array_len(expr).is_some()
-            || matches!(&expr.kind, ExprKind::Array(values) if type_ref.array_element_type().is_some_and(|element_type| values.iter().all(|value| value_matches_type_ref(value, &element_type))));
-    }
-
-    match type_ref.base {
-        TypeBase::Int => matches!(&expr.kind, ExprKind::Int(_) | ExprKind::DateLiteral(_)),
-        TypeBase::Bool => matches!(&expr.kind, ExprKind::Bool(_)),
-        TypeBase::String => matches!(&expr.kind, ExprKind::String(_)),
-        TypeBase::Byte => matches!(&expr.kind, ExprKind::Byte(_)),
-        TypeBase::Pubkey => byte_array_len(expr) == Some(32),
-        TypeBase::Sig => byte_array_len(expr) == Some(65),
-        TypeBase::Datasig => byte_array_len(expr) == Some(64),
-        TypeBase::Custom(_) => false,
-    }
-}
-
 fn type_name_from_ref(type_ref: &TypeRef) -> String {
     type_ref.type_name()
-}
-
-fn byte_array_len<'i>(expr: &Expr<'i>) -> Option<usize> {
-    match &expr.kind {
-        ExprKind::Array(values) if values.iter().all(|value| matches!(&value.kind, ExprKind::Byte(_))) => Some(values.len()),
-        _ => None,
-    }
-}
-
-fn fixed_array_size(type_ref: &TypeRef) -> Option<usize> {
-    match type_ref.array_dims.last() {
-        Some(ArrayDim::Fixed(size)) => Some(*size),
-        _ => None,
-    }
-}
-
-fn array_element_type_ref(type_ref: &TypeRef) -> Option<TypeRef> {
-    type_ref.array_element_type()
-}
-
-fn array_size_with_constants_ref<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
-    match type_ref.array_size() {
-        Some(ArrayDim::Fixed(size)) => Some(*size),
-        Some(ArrayDim::Constant(name)) => constants.get(name).and_then(|expr| match expr.kind {
-            ExprKind::Int(value) if value >= 0 => Some(value as usize),
-            _ => None,
-        }),
-        _ => None,
-    }
-}
-
-fn type_refs_equal<'i>(left: &TypeRef, right: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> bool {
-    left.base == right.base
-        && left.array_dims.len() == right.array_dims.len()
-        && left.array_dims.iter().zip(&right.array_dims).all(|(left, right)| array_dims_equal(left, right, constants))
-}
-
-fn type_after_append<'i>(source: &TypeRef, appended: usize, constants: &HashMap<String, Expr<'i>>) -> Option<TypeRef> {
-    let mut result = source.clone();
-    let dimension = result.array_dims.last_mut()?;
-    match dimension {
-        ArrayDim::Fixed(size) => *size = size.checked_add(appended)?,
-        ArrayDim::Constant(name) => {
-            let size = usize::try_from(const_array_dim_value(name, constants)?).ok()?;
-            *dimension = ArrayDim::Fixed(size.checked_add(appended)?);
-        }
-        ArrayDim::Dynamic => {}
-        ArrayDim::Inferred => return None,
-    }
-    Some(result)
-}
-
-fn array_dims_equal<'i>(left: &ArrayDim, right: &ArrayDim, constants: &HashMap<String, Expr<'i>>) -> bool {
-    match (left, right) {
-        (ArrayDim::Fixed(left), ArrayDim::Fixed(right)) => left == right,
-        (ArrayDim::Constant(left), ArrayDim::Constant(right)) => {
-            match (const_array_dim_value(left, constants), const_array_dim_value(right, constants)) {
-                (Some(left), Some(right)) => left == right,
-                _ => false,
-            }
-        }
-        (ArrayDim::Fixed(left), ArrayDim::Constant(right)) | (ArrayDim::Constant(right), ArrayDim::Fixed(left)) => {
-            i64::try_from(*left).ok() == const_array_dim_value(right, constants)
-        }
-        (ArrayDim::Dynamic, ArrayDim::Dynamic) | (ArrayDim::Inferred, ArrayDim::Inferred) => true,
-        _ => false,
-    }
-}
-
-fn const_array_dim_value<'i>(name: &str, constants: &HashMap<String, Expr<'i>>) -> Option<i64> {
-    let expr = constants.get(name)?;
-    eval_const_int(expr, constants).ok().filter(|value| *value >= 0)
 }
 
 fn expr_matches_return_type_ref_hint<'i>(

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -26,7 +26,9 @@ pub(super) fn static_check_contract<'i>(
 
     for (param, value) in contract.params.iter().zip(constructor_args.iter()) {
         let param_type_name = type_name_from_ref(&param.type_ref);
-        if !expr_matches_declared_type_ref(value, &param.type_ref, &structs) {
+        if validate_expr_matches_type(value, &param.type_ref, &HashMap::new(), &structs, &constants, &HashMap::new(), &contract.fields)
+            .is_err()
+        {
             return Err(CompilerError::Unsupported(format!("constructor argument '{}' expects {}", param.name, param_type_name)));
         }
     }
@@ -65,6 +67,8 @@ pub(crate) fn validate_return_types<'i>(
     types: &HashMap<String, String>,
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
+    functions: &HashMap<String, &FunctionAst<'i>>,
+    contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
     if return_types.is_empty() {
         return Err(CompilerError::Unsupported("return requires function return types".to_string()));
@@ -73,7 +77,7 @@ pub(crate) fn validate_return_types<'i>(
         return Err(CompilerError::Unsupported("return values count must match function return types".to_string()));
     }
     for (expr, return_type) in exprs.iter().zip(return_types.iter()) {
-        if !expr_matches_return_type_ref(expr, return_type, types, structs, constants) {
+        if validate_expr_matches_type(expr, return_type, types, structs, constants, functions, contract_fields).is_err() {
             let type_name = type_name_from_ref(return_type);
             return Err(CompilerError::Unsupported(format!("return value expects {type_name}")));
         }
@@ -277,6 +281,12 @@ fn validate_variable_definition_statement_shape<'i>(
         )?;
         validate_expr_matches_type(expr, type_ref, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
             .map_err(|err| {
+                if type_ref.is_array()
+                    && matches!(expr.kind, ExprKind::Array(_))
+                    && !matches!(&err, CompilerError::Unsupported(message) if message == "size mismatch")
+                {
+                    return CompilerError::Unsupported(format!("array element type mismatch for type {type_name}"));
+                }
                 map_declared_type_error(
                     err,
                     "variable",
@@ -321,9 +331,6 @@ fn validate_array_initializer<'i>(
                     type_name,
                     values.len()
                 )));
-            }
-            if !array_literal_matches_type_with_env_ref(values, type_ref, types, constants) {
-                return Err(CompilerError::Unsupported(format!("array element type mismatch for type {}", type_name)));
             }
             Ok(())
         }
@@ -389,7 +396,7 @@ fn validate_state_function_call_assign_statement_shape<'i>(
             ctx.contract_fields,
         )?;
     }
-    validate_state_function_call_assign(bindings, name, args, ctx.structs, ctx.contract_fields)?;
+    validate_state_function_call_assign(bindings, name, args, ctx.structs, ctx.constants, ctx.contract_fields)?;
     for binding in bindings {
         ensure_array_elements_have_known_size(&binding.type_ref, ctx.structs, &type_name_from_ref(&binding.type_ref))?;
         insert_type_binding(ctx.types, &binding.name, &binding.type_ref, ctx.structs)?;
@@ -412,7 +419,7 @@ fn validate_struct_destructure_statement_shape<'i>(
         ctx.functions,
         ctx.contract_fields,
     )?;
-    validate_struct_destructure_bindings(bindings, expr, ctx.types, ctx.structs, ctx.contract_fields)?;
+    validate_struct_destructure_bindings(bindings, expr, ctx.types, ctx.structs, ctx.constants, ctx.contract_fields)?;
     for binding in bindings {
         ensure_array_elements_have_known_size(&binding.type_ref, ctx.structs, &type_name_from_ref(&binding.type_ref))?;
         insert_type_binding(ctx.types, &binding.name, &binding.type_ref, ctx.structs)?;
@@ -479,7 +486,7 @@ fn validate_function_call_assign_statement_shape<'i>(
         return Err(CompilerError::Unsupported("function call assignment return count mismatch".to_string()));
     }
     for (binding, return_type) in bindings.iter().zip(function.return_types.iter()) {
-        if binding.type_ref != *return_type {
+        if !type_refs_equal(&binding.type_ref, return_type, ctx.constants) {
             return Err(CompilerError::Unsupported(format!(
                 "function return binding '{}' expects {}",
                 binding.name,
@@ -507,7 +514,7 @@ fn validate_return_statement_shape<'i>(
             ctx.contract_fields,
         )?;
     }
-    validate_return_types(exprs, ctx.return_types, ctx.types, ctx.structs, ctx.constants)
+    validate_return_types(exprs, ctx.return_types, ctx.types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
 }
 
 fn validate_require_statement_shape<'i>(
@@ -719,6 +726,7 @@ fn validate_struct_destructure_bindings<'i>(
     expr: &Expr<'i>,
     types: &HashMap<String, String>,
     structs: &StructRegistry,
+    constants: &HashMap<String, Expr<'i>>,
     contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
     let expr_type = infer_struct_destructure_expr_type(expr, types, structs, contract_fields)?;
@@ -747,7 +755,7 @@ fn validate_struct_destructure_bindings<'i>(
         let Some(binding) = bindings.iter().find(|binding| binding.field_name == field.name) else {
             return Err(CompilerError::Unsupported("struct destructuring must bind all fields exactly once".to_string()));
         };
-        if binding.type_ref != field.type_ref {
+        if !type_refs_equal(&binding.type_ref, &field.type_ref, constants) {
             return Err(CompilerError::Unsupported(format!(
                 "struct field '{}' expects {}",
                 field.name,
@@ -767,6 +775,7 @@ fn validate_state_function_call_assign<'i>(
     name: &str,
     args: &[Expr<'i>],
     structs: &StructRegistry,
+    constants: &HashMap<String, Expr<'i>>,
     contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
     match name {
@@ -788,7 +797,7 @@ fn validate_state_function_call_assign<'i>(
                         "readInputState bindings must include all contract fields exactly once".to_string(),
                     ));
                 };
-                if binding.type_ref != field.type_ref {
+                if !type_refs_equal(&binding.type_ref, &field.type_ref, constants) {
                     return Err(CompilerError::Unsupported(format!(
                         "readInputState binding '{}' expects {}",
                         binding.name,
@@ -805,7 +814,7 @@ fn validate_state_function_call_assign<'i>(
                         .to_string(),
                 ));
             };
-            let struct_name = struct_name_for_state_bindings_ref(bindings, structs)?;
+            let struct_name = struct_name_for_state_bindings_ref(bindings, structs, constants)?;
             let struct_spec =
                 structs.get(&struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
             if bindings.len() != struct_spec.fields.len() {
@@ -824,7 +833,7 @@ fn validate_state_function_call_assign<'i>(
                         "readInputStateWithTemplate does not support nested struct fields in destructuring".to_string(),
                     ));
                 }
-                if binding.type_ref != field.type_ref {
+                if !type_refs_equal(&binding.type_ref, &field.type_ref, constants) {
                     return Err(CompilerError::Unsupported(format!(
                         "readInputStateWithTemplate binding '{}' expects {}",
                         binding.name,
@@ -880,7 +889,7 @@ fn validate_expr_semantics<'i>(
                     contract_fields,
                 );
                 if let (Some(left_type), Some(right_type)) = (left_type, right_type)
-                    && !comparison_types_compatible_ref(&left_type, &right_type)
+                    && !type_refs_equal(&left_type, &right_type, constants)
                 {
                     return Err(CompilerError::Unsupported(format!(
                         "type mismatch: cannot compare {} and {}",
@@ -917,7 +926,7 @@ fn validate_expr_semantics<'i>(
                 contract_fields,
             );
             if let (Some(then_type), Some(else_type)) = (then_type, else_type)
-                && then_type != else_type
+                && !type_refs_equal(&then_type, &else_type, constants)
             {
                 return Err(CompilerError::Unsupported(format!(
                     "ternary branch type mismatch: then expression is {}, else expression is {}",
@@ -1128,6 +1137,7 @@ fn infer_expr_type_ref_for_comparison_ref<'i>(
             )?;
             (then_type == else_type).then_some(then_type)
         }
+        ExprKind::New { name, .. } => typed_constructor_return_type_ref(name),
         ExprKind::Call { name, .. } if name == "readInputState" && !contract_fields.is_empty() => {
             Some(TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: Vec::new() })
         }
@@ -1211,19 +1221,10 @@ fn coerce_rhs_byte_literal_for_comparison_ref<'i>(left_type: Option<&TypeRef>, r
     right.clone()
 }
 
-fn comparison_types_compatible_ref(left_type: &TypeRef, right_type: &TypeRef) -> bool {
-    if left_type == right_type {
-        return true;
-    }
-    matches!(
-        (&left_type.base, left_type.array_dims.as_slice(), &right_type.base, right_type.array_dims.as_slice()),
-        (TypeBase::Byte, [], TypeBase::Byte, [ArrayDim::Fixed(1)]) | (TypeBase::Byte, [ArrayDim::Fixed(1)], TypeBase::Byte, [])
-    )
-}
-
 fn struct_name_for_state_bindings_ref<'i>(
     bindings: &[StructBindingAst<'i>],
     structs: &StructRegistry,
+    constants: &HashMap<String, Expr<'i>>,
 ) -> Result<String, CompilerError> {
     let matches = structs
         .iter()
@@ -1235,7 +1236,7 @@ fn struct_name_for_state_bindings_ref<'i>(
                 bindings
                     .iter()
                     .find(|binding| binding.field_name == field.name)
-                    .is_some_and(|binding| binding.type_ref == field.type_ref)
+                    .is_some_and(|binding| type_refs_equal(&binding.type_ref, &field.type_ref, constants))
             });
             all_match.then(|| name.clone())
         })
@@ -1397,13 +1398,19 @@ fn validate_builtin_call<'i>(
 
     for (arg, &(arg_name, expected_type_name)) in args.iter().zip(expected_args) {
         let expected_type = parse_type_ref(expected_type_name)?;
-        let actual_type =
-            infer_expr_type_ref_for_comparison_ref(arg, env, prefer_env_for_comparison, types, structs, functions, contract_fields)
-                .ok_or_else(|| CompilerError::Unsupported(format!("{name}() argument '{arg_name}' expects {expected_type_name}")))?;
-        if !type_refs_equal(&actual_type, &expected_type, constants) && !expr_matches_type_ref(arg, &expected_type) {
+        if validate_expr_matches_type(arg, &expected_type, types, structs, constants, functions, contract_fields).is_err() {
+            let actual_type = infer_expr_type_ref_for_comparison_ref(
+                arg,
+                env,
+                prefer_env_for_comparison,
+                types,
+                structs,
+                functions,
+                contract_fields,
+            );
+            let actual_type = actual_type.as_ref().map(type_name_from_ref).unwrap_or_else(|| "unknown".to_string());
             return Err(CompilerError::Unsupported(format!(
-                "{name}() argument '{arg_name}' expects {expected_type_name}, got {}",
-                type_name_from_ref(&actual_type)
+                "{name}() argument '{arg_name}' expects {expected_type_name}, got {actual_type}"
             )));
         }
     }
@@ -1415,11 +1422,20 @@ fn typed_builtin_return_type_ref(name: &str) -> Option<TypeRef> {
     match name {
         "checkSigFromStack" | "checkSigFromStackECDSA" => parse_type_ref("bool").ok(),
         "templateHash" => parse_type_ref("byte[32]").ok(),
+        "int" | "bool" | "byte" | "string" | "pubkey" | "sig" | "datasig" | "byte[]" => parse_type_ref(name).ok(),
         _ => None,
     }
 }
 
-fn validate_expr_matches_type<'i>(
+fn typed_constructor_return_type_ref(name: &str) -> Option<TypeRef> {
+    match name {
+        "ScriptPubKeyP2PK" => parse_type_ref("byte[34]").ok(),
+        "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript" => parse_type_ref("byte[35]").ok(),
+        _ => None,
+    }
+}
+
+pub(crate) fn validate_expr_matches_type<'i>(
     expr: &Expr<'i>,
     type_ref: &TypeRef,
     types: &HashMap<String, String>,
@@ -1428,6 +1444,18 @@ fn validate_expr_matches_type<'i>(
     functions: &HashMap<String, &FunctionAst<'i>>,
     contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
+    if let ExprKind::Call { name, name_span, .. } = &expr.kind
+        && name == "byte[1]"
+        && name_span.as_str() == "byte"
+    {
+        let scalar_byte = parse_type_ref("byte")?;
+        return if type_refs_equal(&scalar_byte, type_ref, constants) {
+            Ok(())
+        } else {
+            Err(CompilerError::Unsupported("type mismatch".to_string()))
+        };
+    }
+
     if let ExprKind::Call { name, .. } = &expr.kind
         && let Some(function) = functions.get(name)
     {
@@ -1500,8 +1528,9 @@ fn validate_expr_matches_type<'i>(
         {
             return Err(CompilerError::Unsupported("size mismatch".to_string()));
         }
-        if !array_literal_matches_type_with_env_ref(values, type_ref, types, constants) {
-            return Err(CompilerError::Unsupported("type mismatch".to_string()));
+        let element_type = type_ref.array_element_type().expect("array type has an element type");
+        for value in values {
+            validate_expr_matches_type(value, &element_type, types, structs, constants, functions, contract_fields)?;
         }
         return Ok(());
     }
@@ -1521,7 +1550,7 @@ fn validate_expr_matches_type<'i>(
             return compile::read_input_state_with_template_values(args, type_ref, structs, constants).map(|_| ());
         }
         if matches!(expr.kind, ExprKind::StructLiteral(_)) {
-            return validate_struct_literal_matches_type(expr, type_ref, types, structs, constants);
+            return validate_struct_literal_matches_type(expr, type_ref, types, structs, constants, functions, contract_fields);
         }
         lower_runtime_struct_expr(expr, type_ref, types, structs, contract_fields, constants, 0).map(|_| ())
     } else if is_struct_array(type_ref, structs) {
@@ -1548,20 +1577,30 @@ fn validate_expr_matches_type<'i>(
             )
             .and_then(|source_type| type_after_append(&source_type, args.len(), constants))
             .is_some_and(|actual_type| type_refs_equal(&actual_type, type_ref, constants)),
-            _ => expr_matches_declared_type_ref(expr, type_ref, structs),
+            _ => false,
         };
         if matches { Ok(()) } else { Err(CompilerError::Unsupported("type mismatch".to_string())) }
     } else {
-        if type_ref.is_array()
-            && let Ok(actual_type_name) =
-                super::debug_value_types::infer_debug_expr_value_type(expr, &HashMap::new(), types, &mut HashSet::new())
-            && let Ok(actual_type) = parse_type_ref(&actual_type_name)
+        if let Some(actual_type) =
+            infer_expr_type_ref_for_comparison_ref(expr, &HashMap::new(), &HashSet::new(), types, structs, functions, contract_fields)
+            && type_refs_equal(&actual_type, type_ref, constants)
+        {
+            return Ok(());
+        }
+        if let Some(actual_type) = super::infer_array::infer_expr_type_ref(expr, types, constants, functions)
             && type_refs_equal(&actual_type, type_ref, constants)
         {
             return Ok(());
         }
         let lowered = lower_runtime_expr(expr, types, structs)?;
-        if expr_matches_return_type_ref(&lowered, type_ref, types, structs, constants) {
+        if value_matches_type_ref(&lowered, type_ref) {
+            return Ok(());
+        }
+        let actual_type_name =
+            super::debug_value_types::infer_debug_expr_value_type(&lowered, &HashMap::new(), types, &mut HashSet::new())
+                .map_err(|_| CompilerError::Unsupported("type mismatch".to_string()))?;
+        let actual_type = parse_type_ref(&actual_type_name)?;
+        if type_refs_equal(&actual_type, type_ref, constants) {
             Ok(())
         } else {
             Err(CompilerError::Unsupported("type mismatch".to_string()))
@@ -1575,6 +1614,8 @@ fn validate_struct_literal_matches_type<'i>(
     types: &HashMap<String, String>,
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
+    functions: &HashMap<String, &FunctionAst<'i>>,
+    contract_fields: &[ContractFieldAst<'i>],
 ) -> Result<(), CompilerError> {
     let Some(struct_name) = struct_name_from_type_ref(type_ref, structs) else {
         return Err(CompilerError::Unsupported("type mismatch".to_string()));
@@ -1593,7 +1634,7 @@ fn validate_struct_literal_matches_type<'i>(
         let Some(value) = provided.remove(&field.name) else {
             return Err(CompilerError::Unsupported(format!("struct field '{}' must be initialized", field.name)));
         };
-        validate_expr_matches_type(value, &field.type_ref, types, structs, constants, &HashMap::new(), &[]).map_err(|_| {
+        validate_expr_matches_type(value, &field.type_ref, types, structs, constants, functions, contract_fields).map_err(|_| {
             CompilerError::Unsupported(format!("struct field '{}' expects {}", field.name, field.type_ref.type_name()))
         })?;
     }
@@ -1649,11 +1690,11 @@ fn infer_fixed_array_type_from_initializer_type_check<'i>(
         ExprKind::Array(values) => {
             let mut inferred = element_type.clone();
             inferred.array_dims.push(ArrayDim::Fixed(values.len()));
-            if array_literal_matches_type_with_env_ref(values, &inferred, types, constants) { Some(inferred) } else { None }
+            Some(inferred)
         }
         ExprKind::Identifier(name) => {
             let other_type = parse_type_ref(types.get(name)?).ok()?;
-            if !is_array_type_ref(&other_type) || array_element_type_ref(&other_type) != Some(element_type.clone()) {
+            if !other_type.is_array() || array_element_type_ref(&other_type) != Some(element_type.clone()) {
                 return None;
             }
             let size = array_size_with_constants_ref(&other_type, constants)?;
@@ -1704,114 +1745,18 @@ fn statement_contains_return(stmt: &Statement<'_>) -> bool {
     }
 }
 
-pub(crate) fn expr_matches_declared_type_ref<'i>(expr: &Expr<'i>, type_ref: &TypeRef, structs: &StructRegistry) -> bool {
-    if let Some(struct_name) = struct_name_from_type_ref(type_ref, structs) {
-        let Some(item) = structs.get(struct_name) else {
-            return false;
-        };
-        let ExprKind::StructLiteral(fields) = &expr.kind else {
-            return false;
-        };
-        if fields.len() != item.fields.len() {
-            return false;
-        }
-        for field in &item.fields {
-            let Some(value) = fields.iter().find(|entry| entry.name == field.name).map(|entry| &entry.expr) else {
-                return false;
-            };
-            if !expr_matches_declared_type_ref(value, &field.type_ref, structs) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    if let Some(element_type) = type_ref.array_element_type() {
-        if is_struct(&element_type, structs) {
-            return matches!(&expr.kind, ExprKind::Array(values) if values.iter().all(|value| expr_matches_declared_type_ref(value, &element_type, structs)));
-        }
-    }
-
-    expr_matches_type_ref(expr, type_ref)
-}
-
-pub(super) fn expr_matches_return_type_ref<'i>(
-    expr: &Expr<'i>,
-    type_ref: &TypeRef,
-    types: &HashMap<String, String>,
-    structs: &StructRegistry,
-    constants: &HashMap<String, Expr<'i>>,
-) -> bool {
-    if let ExprKind::Identifier(name) = &expr.kind {
-        return types
-            .get(name)
-            .and_then(|type_name| parse_type_ref(type_name).ok())
-            .is_some_and(|actual| type_refs_equal(&actual, type_ref, constants));
-    }
-
-    if let Some(struct_name) = struct_name_from_type_ref(type_ref, structs) {
-        let Some(item) = structs.get(struct_name) else {
-            return false;
-        };
-        let ExprKind::StructLiteral(fields) = &expr.kind else {
-            return false;
-        };
-        if fields.len() != item.fields.len() {
-            return false;
-        }
-        for field in &item.fields {
-            let Some(value) = fields.iter().find(|entry| entry.name == field.name).map(|entry| &entry.expr) else {
-                return false;
-            };
-            if !expr_matches_return_type_ref(value, &field.type_ref, types, structs, constants) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    if let Some(element_type) = type_ref.array_element_type()
-        && is_struct(&element_type, structs)
-    {
-        return matches!(&expr.kind, ExprKind::Array(values) if values.iter().all(|value| expr_matches_return_type_ref(value, &element_type, types, structs, constants)));
-    }
-
-    match &expr.kind {
-        ExprKind::IfElse { .. } => {
-            if let Ok(actual_type_name) =
-                super::debug_value_types::infer_debug_expr_value_type(expr, &HashMap::new(), types, &mut HashSet::new())
-                && let Ok(actual_type) = parse_type_ref(&actual_type_name)
-            {
-                return type_refs_equal(&actual_type, type_ref, constants);
-            }
-            false
-        }
-        ExprKind::Array(values) => {
-            expr_matches_declared_type_ref(expr, type_ref, structs)
-                || (is_array_type_ref(type_ref) && array_literal_matches_type_ref(values, type_ref))
-        }
-        ExprKind::Int(_) | ExprKind::DateLiteral(_) | ExprKind::Bool(_) | ExprKind::Byte(_) | ExprKind::String(_) => {
-            expr_matches_type_ref(expr, type_ref)
-        }
-        ExprKind::Call { name, .. } => {
-            typed_builtin_return_type_ref(name).map(|actual_type| type_refs_equal(&actual_type, type_ref, constants)).unwrap_or(true)
-        }
-        _ => true,
-    }
-}
-
-pub(super) fn expr_matches_type_ref<'i>(expr: &Expr<'i>, type_ref: &TypeRef) -> bool {
+pub(super) fn value_matches_type_ref<'i>(expr: &Expr<'i>, type_ref: &TypeRef) -> bool {
     if type_ref.is_array() {
         if let Some(size) = fixed_array_size(type_ref) {
             if let Some(element_type) = type_ref.array_element_type() {
                 if element_type.base == TypeBase::Byte {
                     return byte_array_len(expr) == Some(size);
                 }
-                return matches!(&expr.kind, ExprKind::Array(values) if values.len() == size && values.iter().all(|value| expr_matches_type_ref(value, &element_type)));
+                return matches!(&expr.kind, ExprKind::Array(values) if values.len() == size && values.iter().all(|value| value_matches_type_ref(value, &element_type)));
             }
         }
         return byte_array_len(expr).is_some()
-            || matches!(&expr.kind, ExprKind::Array(values) if type_ref.array_element_type().is_some_and(|element_type| values.iter().all(|value| expr_matches_type_ref(value, &element_type))));
+            || matches!(&expr.kind, ExprKind::Array(values) if type_ref.array_element_type().is_some_and(|element_type| values.iter().all(|value| value_matches_type_ref(value, &element_type))));
     }
 
     match type_ref.base {
@@ -1824,10 +1769,6 @@ pub(super) fn expr_matches_type_ref<'i>(expr: &Expr<'i>, type_ref: &TypeRef) -> 
         TypeBase::Datasig => byte_array_len(expr) == Some(64),
         TypeBase::Custom(_) => false,
     }
-}
-
-pub(super) fn value_matches_type_ref<'i>(expr: &Expr<'i>, type_ref: &TypeRef) -> bool {
-    expr_matches_type_ref(expr, type_ref)
 }
 
 fn type_name_from_ref(type_ref: &TypeRef) -> String {
@@ -1848,51 +1789,8 @@ fn fixed_array_size(type_ref: &TypeRef) -> Option<usize> {
     }
 }
 
-fn is_array_type_ref(type_ref: &TypeRef) -> bool {
-    type_ref.is_array()
-}
-
 fn array_element_type_ref(type_ref: &TypeRef) -> Option<TypeRef> {
     type_ref.array_element_type()
-}
-
-pub(super) fn array_literal_matches_type_ref<'i>(values: &[Expr<'i>], type_ref: &TypeRef) -> bool {
-    let Some(element_type) = array_element_type_ref(type_ref) else {
-        return false;
-    };
-
-    if let Some(expected_size) = fixed_array_size(type_ref)
-        && values.len() != expected_size
-    {
-        return false;
-    }
-
-    values.iter().all(|value| expr_matches_type_ref(value, &element_type))
-}
-
-fn array_literal_matches_type_with_env_ref<'i>(
-    values: &[Expr<'i>],
-    type_ref: &TypeRef,
-    types: &HashMap<String, String>,
-    constants: &HashMap<String, Expr<'i>>,
-) -> bool {
-    let Some(element_type) = array_element_type_ref(type_ref) else {
-        return false;
-    };
-
-    if let Some(expected_size) = array_size_with_constants_ref(type_ref, constants)
-        && values.len() != expected_size
-    {
-        return false;
-    }
-
-    values.iter().all(|value| match &value.kind {
-        ExprKind::Identifier(name) => types
-            .get(name)
-            .and_then(|value_type| parse_type_ref(value_type).ok())
-            .is_some_and(|value_type| type_refs_equal(&value_type, &element_type, constants)),
-        _ => expr_matches_type_ref(value, &element_type),
-    })
 }
 
 fn array_size_with_constants_ref<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {

--- a/silverscript-lang/src/compiler/structs.rs
+++ b/silverscript-lang/src/compiler/structs.rs
@@ -4,7 +4,7 @@ use super::compile::read_input_state_field_expr_symbolic;
 use super::*;
 use crate::ast::{
     ConstantAst, ContractAst, ContractFieldAst, Expr, ExprKind, FunctionAst, ParamAst, STATE_TYPE_NAME, Statement, StructBindingAst,
-    TypeBase, TypeRef, parse_type_ref,
+    TypeBase, TypeRef,
 };
 use crate::span;
 
@@ -64,7 +64,7 @@ pub(crate) fn build_struct_registry<'i>(contract: &ContractAst<'i>) -> Result<St
     Ok(registry)
 }
 
-pub(crate) fn struct_name_from_type_ref<'a>(type_ref: &'a TypeRef, structs: &'a StructRegistry) -> Option<&'a str> {
+pub(crate) fn struct_name<'a>(type_ref: &'a TypeRef, structs: &'a StructRegistry) -> Option<&'a str> {
     if type_ref.is_array() {
         return None;
     }
@@ -76,16 +76,16 @@ pub(crate) fn struct_name_from_type_ref<'a>(type_ref: &'a TypeRef, structs: &'a 
 }
 
 pub fn is_struct(type_ref: &TypeRef, structs: &StructRegistry) -> bool {
-    struct_name_from_type_ref(type_ref, structs).is_some()
+    struct_name(type_ref, structs).is_some()
 }
 
-pub(crate) fn struct_array_name_from_type_ref(type_ref: &TypeRef, structs: &StructRegistry) -> Option<String> {
+pub(crate) fn struct_array_name(type_ref: &TypeRef, structs: &StructRegistry) -> Option<String> {
     let element_type = type_ref.array_element_type()?;
-    struct_name_from_type_ref(&element_type, structs).map(ToOwned::to_owned)
+    struct_name(&element_type, structs).map(ToOwned::to_owned)
 }
 
 pub fn is_struct_array(type_ref: &TypeRef, structs: &StructRegistry) -> bool {
-    struct_array_name_from_type_ref(type_ref, structs).is_some()
+    struct_array_name(type_ref, structs).is_some()
 }
 
 pub(crate) fn ensure_known_or_builtin_type(type_ref: &TypeRef, structs: &StructRegistry, context: &str) -> Result<(), CompilerError> {
@@ -121,7 +121,7 @@ pub(crate) fn validate_struct_graph(structs: &StructRegistry) -> Result<(), Comp
         let item = structs.get(name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{name}'")))?;
         for field in &item.fields {
             ensure_known_or_builtin_type(&field.type_ref, structs, "struct field")?;
-            if let Some(child) = struct_name_from_type_ref(&field.type_ref, structs) {
+            if let Some(child) = struct_name(&field.type_ref, structs) {
                 visit(child, structs, visiting, visited)?;
             }
         }
@@ -153,7 +153,7 @@ fn flatten_struct_fields(
     prefix: &mut Vec<String>,
     out: &mut Vec<(Vec<String>, TypeRef)>,
 ) -> Result<(), CompilerError> {
-    if let Some(struct_name) = struct_name_from_type_ref(type_ref, structs) {
+    if let Some(struct_name) = struct_name(type_ref, structs) {
         let item = structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
         for field in &item.fields {
             prefix.push(field.name.clone());
@@ -181,7 +181,7 @@ pub(crate) fn resolve_struct_access<'i>(
         }
         ExprKind::FieldAccess { source, field, .. } => {
             let (base, mut path, current_type) = resolve_struct_access(source, scope, structs)?;
-            let struct_name = struct_name_from_type_ref(&current_type, structs)
+            let struct_name = struct_name(&current_type, structs)
                 .ok_or_else(|| CompilerError::Unsupported("field access requires a struct value".to_string()))?;
             let item =
                 structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
@@ -213,7 +213,7 @@ fn lower_expr<'i>(expr: &Expr<'i>, scope: &LoweringScope, structs: &StructRegist
         ExprKind::FieldAccess { source, field, .. } => {
             if let ExprKind::ArrayIndex { source: array_source, index } = &source.as_ref().kind {
                 let (base, mut path, array_type) = resolve_struct_access(array_source, scope, structs)?;
-                let struct_name = struct_array_name_from_type_ref(&array_type, structs)
+                let struct_name = struct_array_name(&array_type, structs)
                     .ok_or_else(|| CompilerError::Unsupported("field access requires a struct value".to_string()))?;
                 let item =
                     structs.get(&struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
@@ -323,7 +323,7 @@ fn lower_expr<'i>(expr: &Expr<'i>, scope: &LoweringScope, structs: &StructRegist
                 && let Some(type_ref) = scope.vars.get(name)
                 && is_struct_array(type_ref, structs)
             {
-                let first_leaf = flatten_type_ref_leaves(type_ref, structs)?
+                let first_leaf = flatten_type_leaves(type_ref, structs)?
                     .into_iter()
                     .next()
                     .ok_or_else(|| CompilerError::Unsupported("struct array must contain fields".to_string()))?;
@@ -354,7 +354,7 @@ pub(crate) fn lower_struct_value_expr<'i>(
     contract_constants: &HashMap<String, Expr<'i>>,
     contract_field_prefix_len: usize,
 ) -> Result<Vec<Expr<'i>>, CompilerError> {
-    let expected_struct_name = struct_name_from_type_ref(expected_type, structs)
+    let expected_struct_name = struct_name(expected_type, structs)
         .ok_or_else(|| CompilerError::Unsupported(format!("expected struct type '{}'", expected_type.type_name())))?;
     match &expr.kind {
         ExprKind::Call { name, args, .. } if name == "readInputState" => {
@@ -387,7 +387,7 @@ pub(crate) fn lower_struct_value_expr<'i>(
         )),
         ExprKind::Identifier(_) | ExprKind::FieldAccess { .. } => {
             let (base, path, actual_type) = resolve_struct_access(expr, scope, structs)?;
-            let actual_struct_name = struct_name_from_type_ref(&actual_type, structs)
+            let actual_struct_name = struct_name(&actual_type, structs)
                 .ok_or_else(|| CompilerError::Unsupported("expression is not a struct".to_string()))?;
             if actual_struct_name != expected_struct_name {
                 return Err(CompilerError::Unsupported(format!(
@@ -414,7 +414,7 @@ pub(crate) fn lower_struct_value_expr<'i>(
                     .ok_or_else(|| CompilerError::Unsupported(format!("undefined identifier '{}'", name)))?,
                 _ => return Err(CompilerError::Unsupported(format!("expression expects struct {}", expected_type.type_name()))),
             };
-            let actual_struct_name = struct_array_name_from_type_ref(&source_type, structs)
+            let actual_struct_name = struct_array_name(&source_type, structs)
                 .ok_or_else(|| CompilerError::Unsupported("expression is not a struct".to_string()))?;
             if actual_struct_name != expected_struct_name {
                 return Err(CompilerError::Unsupported(format!(
@@ -523,7 +523,7 @@ pub(crate) fn lower_struct_destructure_statement<'i>(
     contract_field_prefix_len: usize,
 ) -> Result<Vec<Statement<'i>>, CompilerError> {
     let expr_type = infer_struct_expr_type(expr, scope, structs, contract_fields)?;
-    let struct_name = struct_name_from_type_ref(&expr_type, structs)
+    let struct_name = struct_name(&expr_type, structs)
         .ok_or_else(|| CompilerError::Unsupported("struct destructuring requires a struct value".to_string()))?;
     let struct_ast = structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
     let direct_field_values = if matches!(&expr.kind, ExprKind::Call { name, .. } if name == "readInputState") {
@@ -628,18 +628,15 @@ pub(crate) fn lower_struct_destructure_statement<'i>(
 }
 
 // TODO: Make a dedicated type for the flattened struct field spec, which includes the path and type_ref.
-pub(crate) fn flatten_type_ref_leaves(
-    type_ref: &TypeRef,
-    structs: &StructRegistry,
-) -> Result<Vec<(Vec<String>, TypeRef)>, CompilerError> {
-    if let Some(struct_name) = struct_array_name_from_type_ref(type_ref, structs) {
+pub(crate) fn flatten_type_leaves(type_ref: &TypeRef, structs: &StructRegistry) -> Result<Vec<(Vec<String>, TypeRef)>, CompilerError> {
+    if let Some(struct_name) = struct_array_name(type_ref, structs) {
         let outer_dims = type_ref.array_dims.clone();
         let item = structs.get(&struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
         let mut leaves = Vec::new();
         for field in &item.fields {
             let mut field_type = field.type_ref.clone();
             field_type.array_dims.extend(outer_dims.iter().cloned());
-            for (mut path, leaf_type) in flatten_type_ref_leaves(&field_type, structs)? {
+            for (mut path, leaf_type) in flatten_type_leaves(&field_type, structs)? {
                 path.insert(0, field.name.clone());
                 leaves.push((path, leaf_type));
             }
@@ -652,19 +649,15 @@ pub(crate) fn flatten_type_ref_leaves(
     Ok(leaves)
 }
 
-pub(crate) fn lowering_scope_from_types(types: &HashMap<String, String>) -> Result<LoweringScope, CompilerError> {
+pub(crate) fn lowering_scope_from_types(types: &TypeMap) -> Result<LoweringScope, CompilerError> {
     let mut scope = LoweringScope::default();
-    for (name, type_name) in types {
-        scope.vars.insert(name.clone(), parse_type_ref(type_name)?);
+    for (name, type_ref) in types {
+        scope.vars.insert(name.clone(), type_ref.clone());
     }
     Ok(scope)
 }
 
-pub(crate) fn lower_runtime_expr<'i>(
-    expr: &Expr<'i>,
-    types: &HashMap<String, String>,
-    structs: &StructRegistry,
-) -> Result<Expr<'i>, CompilerError> {
+pub(crate) fn lower_runtime_expr<'i>(expr: &Expr<'i>, types: &TypeMap, structs: &StructRegistry) -> Result<Expr<'i>, CompilerError> {
     let scope = lowering_scope_from_types(types)?;
     lower_expr(expr, &scope, structs)
 }
@@ -672,7 +665,7 @@ pub(crate) fn lower_runtime_expr<'i>(
 pub(crate) fn lower_runtime_struct_expr<'i>(
     expr: &Expr<'i>,
     expected_type: &TypeRef,
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     structs: &StructRegistry,
     contract_fields: &[ContractFieldAst<'i>],
     contract_constants: &HashMap<String, Expr<'i>>,
@@ -715,7 +708,7 @@ fn lower_struct_array_value_expr<'i>(
 ) -> Result<Vec<Expr<'i>>, CompilerError> {
     match &expr.kind {
         ExprKind::Identifier(name) => {
-            let leaves = flatten_type_ref_leaves(expected_type, structs)?;
+            let leaves = flatten_type_leaves(expected_type, structs)?;
             Ok(leaves
                 .into_iter()
                 .map(|(path, _)| Expr::new(ExprKind::Identifier(flattened_struct_name(name, &path)), span::Span::default()))
@@ -725,7 +718,7 @@ fn lower_struct_array_value_expr<'i>(
             let element_type = expected_type
                 .array_element_type()
                 .ok_or_else(|| CompilerError::Unsupported(format!("expected struct type '{}'", expected_type.type_name())))?;
-            let leaf_specs = flatten_type_ref_leaves(&element_type, structs)?;
+            let leaf_specs = flatten_type_leaves(&element_type, structs)?;
             let mut grouped: Vec<Vec<Expr<'i>>> = vec![Vec::with_capacity(values.len()); leaf_specs.len()];
             for value in values {
                 let lowered = lower_struct_value_expr(
@@ -780,7 +773,7 @@ fn lower_struct_array_value_expr<'i>(
 pub(crate) fn flatten_runtime_return_exprs<'i>(
     exprs: &[Expr<'i>],
     return_types: &[TypeRef],
-    types: &HashMap<String, String>,
+    types: &TypeMap,
     structs: &StructRegistry,
     contract_fields: &[ContractFieldAst<'i>],
     contract_constants: &HashMap<String, Expr<'i>>,
@@ -805,13 +798,13 @@ pub(crate) fn flatten_runtime_return_exprs<'i>(
     Ok(flattened)
 }
 
-fn scope_type_names(scope: &LoweringScope) -> HashMap<String, String> {
-    scope.vars.iter().map(|(name, type_ref)| (name.clone(), type_name_from_ref(type_ref))).collect()
+fn scope_type_names(scope: &LoweringScope) -> TypeMap {
+    scope.vars.clone()
 }
 
 fn flatten_named_type_like(name: &str, type_ref: &TypeRef, structs: &StructRegistry) -> Result<Vec<(String, TypeRef)>, CompilerError> {
     if is_struct(type_ref, structs) || is_struct_array(type_ref, structs) {
-        Ok(flatten_type_ref_leaves(type_ref, structs)?
+        Ok(flatten_type_leaves(type_ref, structs)?
             .into_iter()
             .map(|(path, leaf_type)| (flattened_struct_name(name, &path), leaf_type))
             .collect())
@@ -841,7 +834,7 @@ fn lower_value_for_named_type<'i>(
             contract_constants,
             contract_field_prefix_len,
         )?;
-        Ok(flatten_type_ref_leaves(type_ref, structs)?
+        Ok(flatten_type_leaves(type_ref, structs)?
             .into_iter()
             .zip(lowered)
             .map(|((path, leaf_type), lowered_expr)| (flattened_struct_name(name, &path), leaf_type, lowered_expr))
@@ -892,7 +885,7 @@ fn lower_function_call_bindings<'i>(
     let mut lowered = Vec::new();
     for (binding, return_type) in bindings.iter().zip(callee_return_types.iter()) {
         if is_struct(return_type, structs) || is_struct_array(return_type, structs) {
-            for (path, leaf_type) in flatten_type_ref_leaves(return_type, structs)? {
+            for (path, leaf_type) in flatten_type_leaves(return_type, structs)? {
                 lowered.push(ParamAst {
                     type_ref: leaf_type,
                     name: flattened_struct_name(&binding.name, &path),
@@ -940,7 +933,7 @@ fn lower_statements<'i>(
                 if is_struct(type_ref, structs) || is_struct_array(type_ref, structs) {
                     if let Some(Expr { kind: ExprKind::Call { name: builtin_name, args, .. }, .. }) = expr
                         && matches!(builtin_name.as_str(), "readInputState" | "readInputStateWithTemplate")
-                        && let Some(struct_name) = struct_name_from_type_ref(type_ref, structs)
+                        && let Some(struct_name) = struct_name(type_ref, structs)
                         && let Some(item) = structs.get(struct_name)
                         && item
                             .fields
@@ -1141,7 +1134,7 @@ fn lower_statements<'i>(
                         // group them by leaf and append them in one go, to avoid multiple appends for the same leaf.
                         for arg in args {
                             for ((path, _leaf_type), leaf_expr) in
-                                flatten_type_ref_leaves(&element_type, structs)?.into_iter().zip(lower_runtime_struct_expr(
+                                flatten_type_leaves(&element_type, structs)?.into_iter().zip(lower_runtime_struct_expr(
                                     arg,
                                     &element_type,
                                     &scope_type_names(scope),
@@ -1426,7 +1419,7 @@ pub(crate) fn lower_structs_contract<'i>(
 
         let mut lowered_return_types = Vec::new();
         for return_type in &function.return_types {
-            for (_path, leaf_type) in flatten_type_ref_leaves(return_type, structs)? {
+            for (_path, leaf_type) in flatten_type_leaves(return_type, structs)? {
                 lowered_return_types.push(leaf_type);
             }
         }

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -1,0 +1,434 @@
+use std::collections::HashMap;
+
+use crate::ast::{ArrayDim, BinaryOp, ContractFieldAst, Expr, ExprKind, FunctionAst, TypeBase, TypeRef, UnaryOp, UnarySuffixKind};
+
+use super::builtin_types::{builtin_parameters, builtin_return_type, constructor_return_type, introspection_type, nullary_type};
+use super::compile;
+use super::structs::{StructRegistry, is_struct, struct_name_from_type_ref};
+use super::{CompilerError, STATE_TYPE_NAME, append_type, array_type_size, concat_types, parse_type_ref, type_refs_equal};
+
+pub(super) struct TypeCheckContext<'a, 'i> {
+    pub types: &'a HashMap<String, String>,
+    pub structs: &'a StructRegistry,
+    pub constants: &'a HashMap<String, Expr<'i>>,
+    pub functions: &'a HashMap<String, &'a FunctionAst<'i>>,
+    pub contract_fields: &'a [ContractFieldAst<'i>],
+}
+
+pub(super) fn check_expr<'i>(
+    expr: &Expr<'i>,
+    expected: Option<&TypeRef>,
+    ctx: &TypeCheckContext<'_, 'i>,
+) -> Result<TypeRef, CompilerError> {
+    let actual = match &expr.kind {
+        ExprKind::Int(value) if expected.is_some_and(is_scalar_byte) && (0..=255).contains(value) => scalar_type("byte")?,
+        ExprKind::Int(_) | ExprKind::DateLiteral(_) | ExprKind::NumberWithUnit { .. } => scalar_type("int")?,
+        ExprKind::Bool(_) => scalar_type("bool")?,
+        ExprKind::Byte(_) => scalar_type("byte")?,
+        ExprKind::String(_) => scalar_type("string")?,
+        ExprKind::Identifier(name) => ctx
+            .types
+            .get(name)
+            .ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))
+            .and_then(|name| parse_type_ref(name))?,
+        ExprKind::Array(values) => check_array_literal(values, expected, ctx)?,
+        ExprKind::Call { name, args, name_span } => check_call(name, name_span.as_str(), args, expected, ctx)?
+            .ok_or_else(|| CompilerError::Unsupported(format!("function '{name}' does not return a value")))?,
+        ExprKind::New { name, args, .. } => {
+            if name == "LockingBytecodeNullData" {
+                for arg in args {
+                    if let ExprKind::Array(values) = &arg.kind {
+                        check_all(values, ctx)?;
+                    } else {
+                        check_expr(arg, None, ctx)?;
+                    }
+                }
+            } else {
+                check_all(args, ctx)?;
+            }
+            constructor_return_type(name).ok_or_else(|| CompilerError::Unsupported(format!("unknown constructor '{name}'")))?
+        }
+        ExprKind::Split { source, index, .. } => {
+            let source_type = check_expr(source, None, ctx)?;
+            check_expr(index, Some(&scalar_type("int")?), ctx)?;
+            sequence_part_type(&source_type, "split")?
+        }
+        ExprKind::Slice { source, start, end, .. } => {
+            let source_type = check_expr(source, None, ctx)?;
+            let int_type = scalar_type("int")?;
+            check_expr(start, Some(&int_type), ctx)?;
+            check_expr(end, Some(&int_type), ctx)?;
+            sequence_part_type(&source_type, "slice")?
+        }
+        ExprKind::Append { source, args, .. } => {
+            let source_type = check_expr(source, None, ctx)?;
+            let element_type = source_type
+                .array_element_type()
+                .ok_or_else(|| CompilerError::Unsupported("append target must be an array".to_string()))?;
+            for arg in args {
+                check_expr(arg, Some(&element_type), ctx).map_err(|_| {
+                    CompilerError::Unsupported(format!("array append element type mismatch: expected {}", element_type.type_name()))
+                })?;
+            }
+            append_type(&source_type, args.len(), ctx.constants)
+                .ok_or_else(|| CompilerError::Unsupported("cannot determine appended array type".to_string()))?
+        }
+        ExprKind::ArrayIndex { source, index } => {
+            let source_type = check_expr(source, None, ctx)?;
+            check_expr(index, Some(&scalar_type("int")?), ctx)?;
+            source_type
+                .array_element_type()
+                .ok_or_else(|| CompilerError::Unsupported("array index source must be an array".to_string()))?
+        }
+        ExprKind::Unary { op, expr } => match op {
+            UnaryOp::Not => {
+                let bool_type = scalar_type("bool")?;
+                check_expr(expr, Some(&bool_type), ctx)?;
+                bool_type
+            }
+            UnaryOp::Neg => {
+                let int_type = scalar_type("int")?;
+                check_expr(expr, Some(&int_type), ctx)?;
+                int_type
+            }
+        },
+        ExprKind::Binary { op, left, right } => check_binary(*op, left, right, ctx)?,
+        ExprKind::IfElse { condition, then_expr, else_expr } => {
+            check_expr(condition, Some(&scalar_type("bool")?), ctx)?;
+            if let Some(expected) = expected {
+                check_expr(then_expr, Some(expected), ctx)?;
+                check_expr(else_expr, Some(expected), ctx)?;
+                expected.clone()
+            } else {
+                let then_type = check_expr(then_expr, None, ctx)?;
+                let else_type = check_expr(else_expr, None, ctx)?;
+                if !type_refs_equal(&then_type, &else_type, ctx.constants) {
+                    return Err(CompilerError::Unsupported(format!(
+                        "ternary branch type mismatch: then expression is {}, else expression is {}",
+                        then_type.type_name(),
+                        else_type.type_name()
+                    )));
+                }
+                then_type
+            }
+        }
+        ExprKind::Nullary(kind) => nullary_type(*kind),
+        ExprKind::Introspection { kind, index, .. } => {
+            check_expr(index, Some(&scalar_type("int")?), ctx)?;
+            introspection_type(*kind)
+        }
+        ExprKind::StructLiteral(_) => check_struct_literal(expr, expected, ctx)?,
+        ExprKind::FieldAccess { source, field, .. } => {
+            let source_type = check_expr(source, None, ctx)?;
+            if let Some(elements) = source_type.tuple_elements() {
+                let index = tuple_index(field)?;
+                elements.get(index).cloned().ok_or_else(|| CompilerError::Unsupported(format!("tuple index {index} out of bounds")))?
+            } else {
+                if field.chars().all(|character| character.is_ascii_digit()) {
+                    return Err(CompilerError::Unsupported("function does not return a tuple".to_string()));
+                }
+                let struct_name = struct_name_from_type_ref(&source_type, ctx.structs)
+                    .ok_or_else(|| CompilerError::Unsupported("field access requires a struct or tuple value".to_string()))?;
+                ctx.structs
+                    .get(struct_name)
+                    .and_then(|item| item.fields.iter().find(|candidate| candidate.name == *field))
+                    .map(|field| field.type_ref.clone())
+                    .ok_or_else(|| CompilerError::Unsupported(format!("struct '{struct_name}' has no field '{field}'")))?
+            }
+        }
+        ExprKind::UnarySuffix { source, kind, .. } => {
+            let source_type = check_expr(source, None, ctx)?;
+            match kind {
+                UnarySuffixKind::Length if is_sequence_type(&source_type) => scalar_type("int")?,
+                UnarySuffixKind::Reverse if is_sequence_type(&source_type) => source_type,
+                UnarySuffixKind::Length => {
+                    return Err(CompilerError::Unsupported("length requires an array or string".to_string()));
+                }
+                UnarySuffixKind::Reverse => {
+                    return Err(CompilerError::Unsupported("reverse requires an array".to_string()));
+                }
+            }
+        }
+    };
+
+    ensure_expected(&actual, expected, ctx.constants)?;
+    Ok(actual)
+}
+
+fn check_array_literal<'i>(
+    values: &[Expr<'i>],
+    expected: Option<&TypeRef>,
+    ctx: &TypeCheckContext<'_, 'i>,
+) -> Result<TypeRef, CompilerError> {
+    if let Some(expected) = expected {
+        if !expected.is_array() {
+            let fixed_bytes = match expected.base {
+                TypeBase::Pubkey => Some(32),
+                TypeBase::Sig => Some(65),
+                TypeBase::Datasig => Some(64),
+                _ => None,
+            };
+            if fixed_bytes == Some(values.len()) && values.iter().all(|value| matches!(value.kind, ExprKind::Byte(_))) {
+                return Ok(expected.clone());
+            }
+            return Err(CompilerError::Unsupported("type mismatch".to_string()));
+        }
+        let element_type = expected
+            .array_element_type()
+            .ok_or_else(|| CompilerError::Unsupported("array literal requires an array type".to_string()))?;
+        if let Some(size) = array_type_size(expected, ctx.constants)
+            && size != values.len()
+        {
+            return Err(CompilerError::Unsupported("size mismatch".to_string()));
+        }
+        for value in values {
+            check_expr(value, Some(&element_type), ctx)?;
+        }
+        return Ok(expected.clone());
+    }
+
+    let Some(first) = values.first() else {
+        return Ok(TypeRef { base: TypeBase::Byte, array_dims: vec![crate::ast::ArrayDim::Fixed(0)] });
+    };
+    let element_type = check_expr(first, None, ctx)?;
+    for value in &values[1..] {
+        check_expr(value, Some(&element_type), ctx)?;
+    }
+    let mut result = element_type;
+    result.array_dims.push(crate::ast::ArrayDim::Fixed(values.len()));
+    Ok(result)
+}
+
+pub(super) fn check_call<'i>(
+    name: &str,
+    source_name: &str,
+    args: &[Expr<'i>],
+    expected: Option<&TypeRef>,
+    ctx: &TypeCheckContext<'_, 'i>,
+) -> Result<Option<TypeRef>, CompilerError> {
+    // TODO: Consider removing this special case
+    if name == "byte[1]" && source_name == "byte" {
+        check_arity(name, args, 1)?;
+        check_expr(&args[0], None, ctx)?;
+        return scalar_type("byte").map(Some);
+    }
+    if name == "readInputState" && !ctx.contract_fields.is_empty() {
+        check_arity(name, args, 1)?;
+        check_expr(&args[0], Some(&scalar_type("int")?), ctx)?;
+        return Ok(Some(TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: Vec::new() }));
+    }
+    if name == "readInputStateWithTemplate" {
+        let expected = expected.ok_or_else(|| {
+            CompilerError::Unsupported("readInputStateWithTemplate must be assigned to an explicitly typed struct".to_string())
+        })?;
+        return if is_struct(expected, ctx.structs) {
+            compile::read_input_state_with_template_values(args, expected, ctx.structs, ctx.constants)?;
+            Ok(Some(expected.clone()))
+        } else {
+            Err(CompilerError::Unsupported("readInputStateWithTemplate requires a struct type".to_string()))
+        };
+    }
+    if let Some(function) = ctx.functions.get(name).copied() {
+        if function.entrypoint {
+            return Err(CompilerError::Unsupported(format!("entrypoint function '{name}' cannot be called")));
+        }
+        if function.params.len() != args.len() {
+            return Err(CompilerError::Unsupported(format!("function '{name}' expects {} arguments", function.params.len())));
+        }
+        for (param, arg) in function.params.iter().zip(args) {
+            if matches!(&arg.kind, ExprKind::Call { name, .. } if name == "readInputStateWithTemplate") {
+                return Err(CompilerError::Unsupported(
+                    "readInputStateWithTemplate must be assigned to a struct variable or destructured directly".to_string(),
+                ));
+            }
+            check_expr(arg, Some(&param.type_ref), ctx).map_err(|_| {
+                CompilerError::Unsupported(format!("function argument '{}' expects {}", param.name, param.type_ref.type_name()))
+            })?;
+        }
+        return Ok(function.return_type_ref());
+    }
+    if let Ok(cast_type) = parse_type_ref(name)
+        && !matches!(cast_type.base, TypeBase::Custom(_))
+    {
+        let variable_size_byte_cast =
+            matches!(cast_type.base, TypeBase::Byte) && matches!(cast_type.array_dims.as_slice(), [ArrayDim::Dynamic]);
+        if variable_size_byte_cast {
+            match args {
+                [value] => {
+                    check_expr(value, None, ctx)?;
+                }
+                [value, size] => {
+                    check_expr(value, None, ctx)?;
+                    check_expr(size, Some(&scalar_type("int")?), ctx)?;
+                }
+                _ => return Err(CompilerError::Unsupported(format!("{name}() expects 1 or 2 arguments"))),
+            }
+            return Ok(Some(cast_type));
+        }
+        check_arity(name, args, 1)?;
+        check_expr(&args[0], None, ctx)?;
+        return Ok(Some(cast_type));
+    }
+    if let Some(parameters) = builtin_parameters(name) {
+        if parameters.len() != args.len() {
+            return Err(CompilerError::Unsupported(format!("{name}() expects {} arguments", parameters.len())));
+        }
+        for (arg, &(parameter, expected)) in args.iter().zip(parameters) {
+            let expected_type = parse_type_ref(expected)?;
+            if check_expr(arg, Some(&expected_type), ctx).is_err() {
+                let actual = check_expr(arg, None, ctx).map(|type_ref| type_ref.type_name()).unwrap_or_else(|_| "unknown".to_string());
+                return Err(CompilerError::Unsupported(format!("{name}() argument '{parameter}' expects {expected}, got {actual}")));
+            }
+        }
+    } else {
+        check_all(args, ctx)?;
+    }
+    builtin_return_type(name).map(Some).ok_or_else(|| CompilerError::Unsupported(format!("function '{name}' not found")))
+}
+
+fn check_binary<'i>(
+    op: BinaryOp,
+    left: &Expr<'i>,
+    right: &Expr<'i>,
+    ctx: &TypeCheckContext<'_, 'i>,
+) -> Result<TypeRef, CompilerError> {
+    let left_type = check_expr(left, None, ctx)?;
+    if left_type.tuple_elements().is_some() {
+        return Err(CompilerError::Unsupported(
+            "function returns a tuple and cannot be used directly in expressions; access a tuple field instead".to_string(),
+        ));
+    }
+    let right_expected =
+        matches!(op, BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge).then_some(&left_type);
+    let right_type = check_expr(right, right_expected, ctx).map_err(|_| {
+        let actual = check_expr(right, None, ctx).map(|type_ref| type_ref.type_name()).unwrap_or_else(|_| "unknown".to_string());
+        CompilerError::Unsupported(format!("type mismatch: cannot compare {} and {actual}", left_type.type_name()))
+    })?;
+    match op {
+        BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => Ok(scalar_type("bool")?),
+        BinaryOp::Or | BinaryOp::And => {
+            let bool_type = scalar_type("bool")?;
+            ensure_expected(&left_type, Some(&bool_type), ctx.constants)?;
+            ensure_expected(&right_type, Some(&bool_type), ctx.constants)?;
+            Ok(bool_type)
+        }
+        BinaryOp::Add if left_type.is_array() && right_type.is_array() => concat_types(&left_type, &right_type, ctx.constants)
+            .ok_or_else(|| CompilerError::Unsupported("array concatenation requires identical element types".to_string())),
+        BinaryOp::Add if is_scalar_byte(&left_type) || is_scalar_byte(&right_type) => {
+            Err(CompilerError::Unsupported("byte values do not support '+'".to_string()))
+        }
+        BinaryOp::Add if matches!(left_type.base, TypeBase::String) && matches!(right_type.base, TypeBase::String) => {
+            Ok(scalar_type("string")?)
+        }
+        BinaryOp::BitOr | BinaryOp::BitXor | BinaryOp::BitAnd
+            if matches!(left_type.base, TypeBase::Byte)
+                && left_type.is_array()
+                && type_refs_equal(&left_type, &right_type, ctx.constants) =>
+        {
+            Ok(left_type)
+        }
+        BinaryOp::Add
+        | BinaryOp::Sub
+        | BinaryOp::Mul
+        | BinaryOp::Div
+        | BinaryOp::Mod
+        | BinaryOp::BitOr
+        | BinaryOp::BitXor
+        | BinaryOp::BitAnd => {
+            let int_type = scalar_type("int")?;
+            ensure_expected(&left_type, Some(&int_type), ctx.constants)?;
+            ensure_expected(&right_type, Some(&int_type), ctx.constants)?;
+            Ok(int_type)
+        }
+    }
+}
+
+fn check_struct_literal<'i>(
+    expr: &Expr<'i>,
+    expected: Option<&TypeRef>,
+    ctx: &TypeCheckContext<'_, 'i>,
+) -> Result<TypeRef, CompilerError> {
+    let expected = expected.ok_or_else(|| CompilerError::Unsupported("struct literal requires an expected type".to_string()))?;
+    let struct_name = struct_name_from_type_ref(expected, ctx.structs)
+        .ok_or_else(|| CompilerError::Unsupported("struct literal requires a struct type".to_string()))?;
+    let item = ctx.structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
+    let ExprKind::StructLiteral(fields) = &expr.kind else { unreachable!() };
+    let mut provided = HashMap::new();
+    for field in fields {
+        if provided.insert(field.name.as_str(), &field.expr).is_some() {
+            return Err(CompilerError::Unsupported(format!("duplicate struct field '{}'", field.name)));
+        }
+    }
+    for field in &item.fields {
+        let value = provided
+            .remove(field.name.as_str())
+            .ok_or_else(|| CompilerError::Unsupported(format!("struct field '{}' must be initialized", field.name)))?;
+        check_expr(value, Some(&field.type_ref), ctx).map_err(|_| {
+            CompilerError::Unsupported(format!("struct field '{}' expects {}", field.name, field.type_ref.type_name()))
+        })?;
+    }
+    if let Some(extra) = provided.keys().next() {
+        return Err(CompilerError::Unsupported(format!("unknown struct field '{extra}'")));
+    }
+    Ok(expected.clone())
+}
+
+fn check_all<'i>(expressions: &[Expr<'i>], ctx: &TypeCheckContext<'_, 'i>) -> Result<(), CompilerError> {
+    for expression in expressions {
+        check_expr(expression, None, ctx)?;
+    }
+    Ok(())
+}
+
+fn ensure_expected<'i>(
+    actual: &TypeRef,
+    expected: Option<&TypeRef>,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<(), CompilerError> {
+    if expected.is_none_or(|expected| type_refs_equal(actual, expected, constants)) {
+        Ok(())
+    } else {
+        Err(CompilerError::Unsupported("type mismatch".to_string()))
+    }
+}
+
+fn scalar_type(name: &str) -> Result<TypeRef, CompilerError> {
+    parse_type_ref(name)
+}
+
+fn is_scalar_byte(type_ref: &TypeRef) -> bool {
+    matches!(type_ref.base, TypeBase::Byte) && !type_ref.is_array()
+}
+
+fn dynamic_array_of(type_ref: &TypeRef) -> Result<TypeRef, CompilerError> {
+    let mut element =
+        type_ref.array_element_type().ok_or_else(|| CompilerError::Unsupported("operation requires an array".to_string()))?;
+    element.array_dims.push(crate::ast::ArrayDim::Dynamic);
+    Ok(element)
+}
+
+fn sequence_part_type(type_ref: &TypeRef, operation: &str) -> Result<TypeRef, CompilerError> {
+    if type_ref.is_array() {
+        return dynamic_array_of(type_ref);
+    }
+    match type_ref.base {
+        TypeBase::String => Ok(type_ref.clone()),
+        TypeBase::Pubkey | TypeBase::Sig | TypeBase::Datasig => parse_type_ref("byte[]"),
+        _ => Err(CompilerError::Unsupported(format!("{operation} source must be a sequence"))),
+    }
+}
+
+fn is_sequence_type(type_ref: &TypeRef) -> bool {
+    type_ref.is_array() || matches!(type_ref.base, TypeBase::String | TypeBase::Pubkey | TypeBase::Sig | TypeBase::Datasig)
+}
+
+fn tuple_index(field: &str) -> Result<usize, CompilerError> {
+    if field.is_empty() || !field.chars().all(|character| character.is_ascii_digit()) {
+        return Err(CompilerError::Unsupported(format!("invalid tuple field '{field}'")));
+    }
+    field.parse().map_err(|_| CompilerError::Unsupported(format!("invalid tuple field '{field}'")))
+}
+
+fn check_arity(name: &str, args: &[Expr<'_>], expected: usize) -> Result<(), CompilerError> {
+    if args.len() == expected { Ok(()) } else { Err(CompilerError::Unsupported(format!("{name}() expects {expected} arguments"))) }
+}

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -2,13 +2,15 @@ use std::collections::HashMap;
 
 use crate::ast::{ArrayDim, BinaryOp, ContractFieldAst, Expr, ExprKind, FunctionAst, TypeBase, TypeRef, UnaryOp, UnarySuffixKind};
 
-use super::builtin_types::{builtin_parameters, builtin_return_type, constructor_return_type, introspection_type, nullary_type};
+use super::builtin_types::{
+    builtin_parameters, builtin_return_type, constructor_parameters, constructor_return_type, introspection_type, nullary_type,
+};
 use super::compile;
-use super::structs::{StructRegistry, is_struct, struct_name_from_type_ref};
-use super::{CompilerError, STATE_TYPE_NAME, append_type, array_type_size, concat_types, parse_type_ref, type_refs_equal};
+use super::structs::{StructRegistry, is_struct, struct_name};
+use super::{CompilerError, STATE_TYPE_NAME, TypeMap, append_type, array_type_size, concat_types, parse_type_ref, type_refs_equal};
 
 pub(super) struct TypeCheckContext<'a, 'i> {
-    pub types: &'a HashMap<String, String>,
+    pub types: &'a TypeMap,
     pub structs: &'a StructRegistry,
     pub constants: &'a HashMap<String, Expr<'i>>,
     pub functions: &'a HashMap<String, &'a FunctionAst<'i>>,
@@ -21,41 +23,24 @@ pub(super) fn check_expr<'i>(
     ctx: &TypeCheckContext<'_, 'i>,
 ) -> Result<TypeRef, CompilerError> {
     let actual = match &expr.kind {
-        ExprKind::Int(value) if expected.is_some_and(is_scalar_byte) && (0..=255).contains(value) => scalar_type("byte")?,
-        ExprKind::Int(_) | ExprKind::DateLiteral(_) | ExprKind::NumberWithUnit { .. } => scalar_type("int")?,
-        ExprKind::Bool(_) => scalar_type("bool")?,
-        ExprKind::Byte(_) => scalar_type("byte")?,
-        ExprKind::String(_) => scalar_type("string")?,
-        ExprKind::Identifier(name) => ctx
-            .types
-            .get(name)
-            .ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))
-            .and_then(|name| parse_type_ref(name))?,
+        ExprKind::Int(value) if expected.is_some_and(TypeRef::is_byte) && (0..=255).contains(value) => scalar_type(TypeBase::Byte),
+        ExprKind::Int(_) | ExprKind::DateLiteral(_) | ExprKind::NumberWithUnit { .. } => scalar_type(TypeBase::Int),
+        ExprKind::Bool(_) => scalar_type(TypeBase::Bool),
+        ExprKind::Byte(_) => scalar_type(TypeBase::Byte),
+        ExprKind::String(_) => scalar_type(TypeBase::String),
+        ExprKind::Identifier(name) => ctx.types.get(name).cloned().ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))?,
         ExprKind::Array(values) => check_array_literal(values, expected, ctx)?,
         ExprKind::Call { name, args, name_span } => check_call(name, name_span.as_str(), args, expected, ctx)?
             .ok_or_else(|| CompilerError::Unsupported(format!("function '{name}' does not return a value")))?,
-        ExprKind::New { name, args, .. } => {
-            if name == "LockingBytecodeNullData" {
-                for arg in args {
-                    if let ExprKind::Array(values) = &arg.kind {
-                        check_all(values, ctx)?;
-                    } else {
-                        check_expr(arg, None, ctx)?;
-                    }
-                }
-            } else {
-                check_all(args, ctx)?;
-            }
-            constructor_return_type(name).ok_or_else(|| CompilerError::Unsupported(format!("unknown constructor '{name}'")))?
-        }
+        ExprKind::New { name, args, .. } => check_constructor(name, args, ctx)?,
         ExprKind::Split { source, index, .. } => {
             let source_type = check_expr(source, None, ctx)?;
-            check_expr(index, Some(&scalar_type("int")?), ctx)?;
+            check_expr(index, Some(&scalar_type(TypeBase::Int)), ctx)?;
             sequence_part_type(&source_type, "split")?
         }
         ExprKind::Slice { source, start, end, .. } => {
             let source_type = check_expr(source, None, ctx)?;
-            let int_type = scalar_type("int")?;
+            let int_type = scalar_type(TypeBase::Int);
             check_expr(start, Some(&int_type), ctx)?;
             check_expr(end, Some(&int_type), ctx)?;
             sequence_part_type(&source_type, "slice")?
@@ -75,26 +60,26 @@ pub(super) fn check_expr<'i>(
         }
         ExprKind::ArrayIndex { source, index } => {
             let source_type = check_expr(source, None, ctx)?;
-            check_expr(index, Some(&scalar_type("int")?), ctx)?;
+            check_expr(index, Some(&scalar_type(TypeBase::Int)), ctx)?;
             source_type
                 .array_element_type()
                 .ok_or_else(|| CompilerError::Unsupported("array index source must be an array".to_string()))?
         }
         ExprKind::Unary { op, expr } => match op {
             UnaryOp::Not => {
-                let bool_type = scalar_type("bool")?;
+                let bool_type = scalar_type(TypeBase::Bool);
                 check_expr(expr, Some(&bool_type), ctx)?;
                 bool_type
             }
             UnaryOp::Neg => {
-                let int_type = scalar_type("int")?;
+                let int_type = scalar_type(TypeBase::Int);
                 check_expr(expr, Some(&int_type), ctx)?;
                 int_type
             }
         },
         ExprKind::Binary { op, left, right } => check_binary(*op, left, right, ctx)?,
         ExprKind::IfElse { condition, then_expr, else_expr } => {
-            check_expr(condition, Some(&scalar_type("bool")?), ctx)?;
+            check_expr(condition, Some(&scalar_type(TypeBase::Bool)), ctx)?;
             if let Some(expected) = expected {
                 check_expr(then_expr, Some(expected), ctx)?;
                 check_expr(else_expr, Some(expected), ctx)?;
@@ -114,7 +99,7 @@ pub(super) fn check_expr<'i>(
         }
         ExprKind::Nullary(kind) => nullary_type(*kind),
         ExprKind::Introspection { kind, index, .. } => {
-            check_expr(index, Some(&scalar_type("int")?), ctx)?;
+            check_expr(index, Some(&scalar_type(TypeBase::Int)), ctx)?;
             introspection_type(*kind)
         }
         ExprKind::StructLiteral(_) => check_struct_literal(expr, expected, ctx)?,
@@ -127,7 +112,7 @@ pub(super) fn check_expr<'i>(
                 if field.chars().all(|character| character.is_ascii_digit()) {
                     return Err(CompilerError::Unsupported("function does not return a tuple".to_string()));
                 }
-                let struct_name = struct_name_from_type_ref(&source_type, ctx.structs)
+                let struct_name = struct_name(&source_type, ctx.structs)
                     .ok_or_else(|| CompilerError::Unsupported("field access requires a struct or tuple value".to_string()))?;
                 ctx.structs
                     .get(struct_name)
@@ -139,7 +124,7 @@ pub(super) fn check_expr<'i>(
         ExprKind::UnarySuffix { source, kind, .. } => {
             let source_type = check_expr(source, None, ctx)?;
             match kind {
-                UnarySuffixKind::Length if is_sequence_type(&source_type) => scalar_type("int")?,
+                UnarySuffixKind::Length if is_sequence_type(&source_type) => scalar_type(TypeBase::Int),
                 UnarySuffixKind::Reverse if is_sequence_type(&source_type) => source_type,
                 UnarySuffixKind::Length => {
                     return Err(CompilerError::Unsupported("length requires an array or string".to_string()));
@@ -162,12 +147,7 @@ fn check_array_literal<'i>(
 ) -> Result<TypeRef, CompilerError> {
     if let Some(expected) = expected {
         if !expected.is_array() {
-            let fixed_bytes = match expected.base {
-                TypeBase::Pubkey => Some(32),
-                TypeBase::Sig => Some(65),
-                TypeBase::Datasig => Some(64),
-                _ => None,
-            };
+            let fixed_bytes = expected.base.fixed_byte_sequence_len();
             if fixed_bytes == Some(values.len()) && values.iter().all(|value| matches!(value.kind, ExprKind::Byte(_))) {
                 return Ok(expected.clone());
             }
@@ -210,11 +190,11 @@ pub(super) fn check_call<'i>(
     if name == "byte[1]" && source_name == "byte" {
         check_arity(name, args, 1)?;
         check_expr(&args[0], None, ctx)?;
-        return scalar_type("byte").map(Some);
+        return Ok(Some(scalar_type(TypeBase::Byte)));
     }
     if name == "readInputState" && !ctx.contract_fields.is_empty() {
         check_arity(name, args, 1)?;
-        check_expr(&args[0], Some(&scalar_type("int")?), ctx)?;
+        check_expr(&args[0], Some(&scalar_type(TypeBase::Int)), ctx)?;
         return Ok(Some(TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: Vec::new() }));
     }
     if name == "readInputStateWithTemplate" {
@@ -245,7 +225,7 @@ pub(super) fn check_call<'i>(
                 CompilerError::Unsupported(format!("function argument '{}' expects {}", param.name, param.type_ref.type_name()))
             })?;
         }
-        return Ok(function.return_type_ref());
+        return Ok(function.return_type());
     }
     if let Ok(cast_type) = parse_type_ref(name)
         && !matches!(cast_type.base, TypeBase::Custom(_))
@@ -259,7 +239,7 @@ pub(super) fn check_call<'i>(
                 }
                 [value, size] => {
                     check_expr(value, None, ctx)?;
-                    check_expr(size, Some(&scalar_type("int")?), ctx)?;
+                    check_expr(size, Some(&scalar_type(TypeBase::Int)), ctx)?;
                 }
                 _ => return Err(CompilerError::Unsupported(format!("{name}() expects 1 or 2 arguments"))),
             }
@@ -273,11 +253,13 @@ pub(super) fn check_call<'i>(
         if parameters.len() != args.len() {
             return Err(CompilerError::Unsupported(format!("{name}() expects {} arguments", parameters.len())));
         }
-        for (arg, &(parameter, expected)) in args.iter().zip(parameters) {
-            let expected_type = parse_type_ref(expected)?;
-            if check_expr(arg, Some(&expected_type), ctx).is_err() {
+        for (arg, (parameter, expected)) in args.iter().zip(parameters) {
+            if check_expr(arg, Some(&expected), ctx).is_err() {
                 let actual = check_expr(arg, None, ctx).map(|type_ref| type_ref.type_name()).unwrap_or_else(|_| "unknown".to_string());
-                return Err(CompilerError::Unsupported(format!("{name}() argument '{parameter}' expects {expected}, got {actual}")));
+                return Err(CompilerError::Unsupported(format!(
+                    "{name}() argument '{parameter}' expects {}, got {actual}",
+                    expected.type_name()
+                )));
             }
         }
     } else {
@@ -305,21 +287,19 @@ fn check_binary<'i>(
         CompilerError::Unsupported(format!("type mismatch: cannot compare {} and {actual}", left_type.type_name()))
     })?;
     match op {
-        BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => Ok(scalar_type("bool")?),
+        BinaryOp::Eq | BinaryOp::Ne | BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => Ok(scalar_type(TypeBase::Bool)),
         BinaryOp::Or | BinaryOp::And => {
-            let bool_type = scalar_type("bool")?;
+            let bool_type = scalar_type(TypeBase::Bool);
             ensure_expected(&left_type, Some(&bool_type), ctx.constants)?;
             ensure_expected(&right_type, Some(&bool_type), ctx.constants)?;
             Ok(bool_type)
         }
         BinaryOp::Add if left_type.is_array() && right_type.is_array() => concat_types(&left_type, &right_type, ctx.constants)
             .ok_or_else(|| CompilerError::Unsupported("array concatenation requires identical element types".to_string())),
-        BinaryOp::Add if is_scalar_byte(&left_type) || is_scalar_byte(&right_type) => {
+        BinaryOp::Add if left_type.is_byte() || right_type.is_byte() => {
             Err(CompilerError::Unsupported("byte values do not support '+'".to_string()))
         }
-        BinaryOp::Add if matches!(left_type.base, TypeBase::String) && matches!(right_type.base, TypeBase::String) => {
-            Ok(scalar_type("string")?)
-        }
+        BinaryOp::Add if left_type.is_string() && right_type.is_string() => Ok(scalar_type(TypeBase::String)),
         BinaryOp::BitOr | BinaryOp::BitXor | BinaryOp::BitAnd
             if matches!(left_type.base, TypeBase::Byte)
                 && left_type.is_array()
@@ -335,7 +315,7 @@ fn check_binary<'i>(
         | BinaryOp::BitOr
         | BinaryOp::BitXor
         | BinaryOp::BitAnd => {
-            let int_type = scalar_type("int")?;
+            let int_type = scalar_type(TypeBase::Int);
             ensure_expected(&left_type, Some(&int_type), ctx.constants)?;
             ensure_expected(&right_type, Some(&int_type), ctx.constants)?;
             Ok(int_type)
@@ -349,7 +329,7 @@ fn check_struct_literal<'i>(
     ctx: &TypeCheckContext<'_, 'i>,
 ) -> Result<TypeRef, CompilerError> {
     let expected = expected.ok_or_else(|| CompilerError::Unsupported("struct literal requires an expected type".to_string()))?;
-    let struct_name = struct_name_from_type_ref(expected, ctx.structs)
+    let struct_name = struct_name(expected, ctx.structs)
         .ok_or_else(|| CompilerError::Unsupported("struct literal requires a struct type".to_string()))?;
     let item = ctx.structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
     let ExprKind::StructLiteral(fields) = &expr.kind else { unreachable!() };
@@ -392,12 +372,8 @@ fn ensure_expected<'i>(
     }
 }
 
-fn scalar_type(name: &str) -> Result<TypeRef, CompilerError> {
-    parse_type_ref(name)
-}
-
-fn is_scalar_byte(type_ref: &TypeRef) -> bool {
-    matches!(type_ref.base, TypeBase::Byte) && !type_ref.is_array()
+fn scalar_type(base: TypeBase) -> TypeRef {
+    TypeRef { base, array_dims: Vec::new() }
 }
 
 fn dynamic_array_of(type_ref: &TypeRef) -> Result<TypeRef, CompilerError> {
@@ -411,15 +387,31 @@ fn sequence_part_type(type_ref: &TypeRef, operation: &str) -> Result<TypeRef, Co
     if type_ref.is_array() {
         return dynamic_array_of(type_ref);
     }
-    match type_ref.base {
-        TypeBase::String => Ok(type_ref.clone()),
-        TypeBase::Pubkey | TypeBase::Sig | TypeBase::Datasig => parse_type_ref("byte[]"),
-        _ => Err(CompilerError::Unsupported(format!("{operation} source must be a sequence"))),
+    if type_ref.is_string() {
+        return Ok(type_ref.clone());
     }
+    if type_ref.is_pubkey() || type_ref.is_sig() || type_ref.is_datasig() {
+        return Ok(TypeRef { base: TypeBase::Byte, array_dims: vec![ArrayDim::Dynamic] });
+    }
+    Err(CompilerError::Unsupported(format!("{operation} source must be a sequence")))
+}
+
+fn check_constructor<'i>(name: &str, args: &[Expr<'i>], ctx: &TypeCheckContext<'_, 'i>) -> Result<TypeRef, CompilerError> {
+    let parameters =
+        constructor_parameters(name).ok_or_else(|| CompilerError::Unsupported(format!("unknown constructor '{name}'")))?;
+    if parameters.len() != args.len() {
+        return Err(CompilerError::Unsupported(format!("{name} constructor expects {} arguments", parameters.len())));
+    }
+    for (arg, (parameter, expected)) in args.iter().zip(parameters) {
+        check_expr(arg, Some(&expected), ctx).map_err(|_| {
+            CompilerError::Unsupported(format!("{name} constructor argument '{parameter}' expects {}", expected.type_name()))
+        })?;
+    }
+    constructor_return_type(name).ok_or_else(|| CompilerError::Unsupported(format!("unknown constructor '{name}'")))
 }
 
 fn is_sequence_type(type_ref: &TypeRef) -> bool {
-    type_ref.is_array() || matches!(type_ref.base, TypeBase::String | TypeBase::Pubkey | TypeBase::Sig | TypeBase::Datasig)
+    type_ref.is_array() || type_ref.is_string() || type_ref.is_pubkey() || type_ref.is_sig() || type_ref.is_datasig()
 }
 
 fn tuple_index(field: &str) -> Result<usize, CompilerError> {

--- a/silverscript-lang/src/compiler/type_system.rs
+++ b/silverscript-lang/src/compiler/type_system.rs
@@ -1,0 +1,68 @@
+use std::collections::HashMap;
+
+use crate::ast::{ArrayDim, Expr, TypeBase, TypeRef};
+
+use super::eval_const_int;
+
+pub(crate) fn type_refs_equal<'i>(left: &TypeRef, right: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> bool {
+    bases_equal(&left.base, &right.base, constants)
+        && left.array_dims.len() == right.array_dims.len()
+        && left.array_dims.iter().zip(&right.array_dims).all(|(left, right)| dimensions_equal(left, right, constants))
+}
+
+fn bases_equal<'i>(left: &TypeBase, right: &TypeBase, constants: &HashMap<String, Expr<'i>>) -> bool {
+    match (left, right) {
+        (TypeBase::Tuple(left), TypeBase::Tuple(right)) => {
+            left.len() == right.len() && left.iter().zip(right).all(|(left, right)| type_refs_equal(left, right, constants))
+        }
+        _ => left == right,
+    }
+}
+
+pub(crate) fn array_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
+    dimension_value(type_ref.array_size()?, constants)
+}
+
+pub(crate) fn concat_types<'i>(left: &TypeRef, right: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<TypeRef> {
+    let element = left.array_element_type()?;
+    if !type_refs_equal(&element, &right.array_element_type()?, constants) {
+        return None;
+    }
+
+    let dimension = match (left.array_size()?, right.array_size()?) {
+        (ArrayDim::Dynamic, _) | (_, ArrayDim::Dynamic) => ArrayDim::Dynamic,
+        (left, right) => ArrayDim::Fixed(dimension_value(left, constants)?.checked_add(dimension_value(right, constants)?)?),
+    };
+    let mut result = element;
+    result.array_dims.push(dimension);
+    Some(result)
+}
+
+pub(crate) fn append_type<'i>(source: &TypeRef, appended: usize, constants: &HashMap<String, Expr<'i>>) -> Option<TypeRef> {
+    let mut result = source.clone();
+    let dimension = result.array_dims.last_mut()?;
+    *dimension = match &*dimension {
+        ArrayDim::Dynamic => ArrayDim::Dynamic,
+        dimension => ArrayDim::Fixed(dimension_value(dimension, constants)?.checked_add(appended)?),
+    };
+    Some(result)
+}
+
+fn dimensions_equal<'i>(left: &ArrayDim, right: &ArrayDim, constants: &HashMap<String, Expr<'i>>) -> bool {
+    match (left, right) {
+        (ArrayDim::Dynamic, ArrayDim::Dynamic) | (ArrayDim::Inferred, ArrayDim::Inferred) => true,
+        (ArrayDim::Dynamic | ArrayDim::Inferred, _) | (_, ArrayDim::Dynamic | ArrayDim::Inferred) => false,
+        _ => match (dimension_value(left, constants), dimension_value(right, constants)) {
+            (Some(left), Some(right)) => left == right,
+            _ => left == right,
+        },
+    }
+}
+
+fn dimension_value<'i>(dimension: &ArrayDim, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
+    match dimension {
+        ArrayDim::Fixed(size) => Some(*size),
+        ArrayDim::Constant(name) => usize::try_from(eval_const_int(constants.get(name)?, constants).ok()?).ok(),
+        ArrayDim::Dynamic | ArrayDim::Inferred => None,
+    }
+}

--- a/silverscript-lang/src/compiler/validate_output_state.rs
+++ b/silverscript-lang/src/compiler/validate_output_state.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::structs::{flatten_type_ref_leaves, resolve_struct_access, struct_name_from_type_ref};
+use super::structs::{flatten_type_leaves, resolve_struct_access, struct_name};
 use super::*;
 use crate::ast::{ContractAst, Expr, ExprKind, FunctionAst, STATE_TYPE_NAME, Statement, TypeBase, TypeRef};
 use crate::span;
@@ -72,7 +72,7 @@ fn lower_statement<'i>(
                 state_expr.clone()
             } else {
                 let temp_name = unique_state_temp_name(scope);
-                let state_type = state_type_ref();
+                let state_type = state_type();
                 scope.vars.insert(temp_name.clone(), state_type.clone());
                 lowered.push(Statement::VariableDefinition {
                     type_ref: state_type,
@@ -250,11 +250,11 @@ fn lower_statement<'i>(
 }
 
 fn flatten_state_expr<'i>(expr: &Expr<'i>, scope: &ValidationScope, structs: &StructRegistry) -> Result<Vec<Expr<'i>>, CompilerError> {
-    let state_type = state_type_ref();
+    let state_type = state_type();
     flatten_struct_expr(expr, &state_type, scope, structs)
 }
 
-fn state_type_ref() -> TypeRef {
+fn state_type() -> TypeRef {
     TypeRef { base: TypeBase::Custom(STATE_TYPE_NAME.to_string()), array_dims: Vec::new() }
 }
 
@@ -300,7 +300,7 @@ fn flatten_struct_expr<'i>(
     scope: &ValidationScope,
     structs: &StructRegistry,
 ) -> Result<Vec<Expr<'i>>, CompilerError> {
-    let expected_struct_name = struct_name_from_type_ref(expected_type, structs)
+    let expected_struct_name = struct_name(expected_type, structs)
         .ok_or_else(|| CompilerError::Unsupported(format!("expected struct type '{}'", expected_type.type_name())))?;
 
     if !matches!(&expr.kind, ExprKind::Identifier(_)) {
@@ -309,8 +309,8 @@ fn flatten_struct_expr<'i>(
 
     let struct_scope = super::structs::LoweringScope { vars: scope.vars.clone() };
     let (base, path, actual_type) = resolve_struct_access(expr, &struct_scope, structs)?;
-    let actual_struct_name = struct_name_from_type_ref(&actual_type, structs)
-        .ok_or_else(|| CompilerError::Unsupported("expression is not a struct".to_string()))?;
+    let actual_struct_name =
+        struct_name(&actual_type, structs).ok_or_else(|| CompilerError::Unsupported("expression is not a struct".to_string()))?;
     if actual_struct_name != expected_struct_name {
         return Err(CompilerError::Unsupported(format!(
             "struct expression expects {}, got {}",
@@ -319,7 +319,7 @@ fn flatten_struct_expr<'i>(
         )));
     }
 
-    let leaves = flatten_type_ref_leaves(&actual_type, structs)?;
+    let leaves = flatten_type_leaves(&actual_type, structs)?;
     Ok(leaves
         .into_iter()
         .map(|(leaf_path, _)| {

--- a/silverscript-lang/tests/apps/chess/chess_castle.sil
+++ b/silverscript-lang/tests/apps/chess/chess_castle.sil
@@ -147,14 +147,15 @@ contract ChessCastle(
         byte[] prefix = prev_board.slice(0, a);
         byte[] middle = prev_board.slice(a + 1, b);
         byte[] suffix = prev_board.slice(d + 1, 64);
-        byte[64] next_board =
+        byte[64] next_board = byte[64](
             prefix +
             byte[1](empty_piece) +
             middle +
             byte[1](vb) +
             byte[1](vc) +
             byte[1](empty_piece) +
-            suffix;
+            suffix
+        );
 
         byte next_white_can_castle_k = castle_rights[0];
         byte next_white_can_castle_q = castle_rights[1];

--- a/silverscript-lang/tests/apps/chess/chess_castle_challenge.sil
+++ b/silverscript-lang/tests/apps/chess/chess_castle_challenge.sil
@@ -149,7 +149,7 @@ contract ChessCastleChallengePrep(
         byte[] mid_bc = prev_dyn.slice(b + 1, c);
         byte[] mid_cd = prev_dyn.slice(c + 1, d);
         byte[] suffix = prev_dyn.slice(d + 1, 64);
-        byte[64] proof_board =
+        byte[64] proof_board = byte[64](
             prefix +
             byte[1](va) +
             mid_ab +
@@ -158,7 +158,8 @@ contract ChessCastleChallengePrep(
             byte[1](vc) +
             mid_cd +
             byte[1](vd) +
-            suffix;
+            suffix
+        );
 
         int from_y = from_idx / 8;
         int from_x = from_idx % 8;

--- a/silverscript-lang/tests/apps/chess/chess_diag.sil
+++ b/silverscript-lang/tests/apps/chess/chess_diag.sil
@@ -149,7 +149,7 @@ contract ChessDiag(
         byte[] prefix = prev_dyn.slice(0, low_idx);
         byte[] middle = prev_dyn.slice(low_idx + 1, high_idx);
         byte[] suffix = prev_dyn.slice(high_idx + 1, 64);
-        byte[64] next_board = prefix + byte[1](first_slot) + middle + byte[1](second_slot) + suffix;
+        byte[64] next_board = byte[64](prefix + byte[1](first_slot) + middle + byte[1](second_slot) + suffix);
 
         // Capturing the enemy king is the on-chain terminal condition.
         // Off-chain clients may enforce stricter classical no-self-check rules,

--- a/silverscript-lang/tests/apps/chess/chess_horiz.sil
+++ b/silverscript-lang/tests/apps/chess/chess_horiz.sil
@@ -142,7 +142,7 @@ contract ChessHoriz(
         byte[] prefix = prev_dyn.slice(0, low_idx);
         byte[] middle = prev_dyn.slice(low_idx + 1, high_idx);
         byte[] suffix = prev_dyn.slice(high_idx + 1, 64);
-        byte[64] next_board = prefix + byte[1](first_slot) + middle + byte[1](second_slot) + suffix;
+        byte[64] next_board = byte[64](prefix + byte[1](first_slot) + middle + byte[1](second_slot) + suffix);
 
         // Capturing the enemy king is the on-chain terminal condition.
         // Off-chain clients may enforce stricter classical no-self-check rules,

--- a/silverscript-lang/tests/apps/chess/chess_king.sil
+++ b/silverscript-lang/tests/apps/chess/chess_king.sil
@@ -130,7 +130,7 @@ contract ChessKing(
         byte[] prefix = prev_dyn.slice(0, low_idx);
         byte[] middle = prev_dyn.slice(low_idx + 1, high_idx);
         byte[] suffix = prev_dyn.slice(high_idx + 1, 64);
-        byte[64] next_board = prefix + byte[1](first_slot) + middle + byte[1](second_slot) + suffix;
+        byte[64] next_board = byte[64](prefix + byte[1](first_slot) + middle + byte[1](second_slot) + suffix);
 
         // Capturing the enemy king is the on-chain terminal condition.
         // Off-chain clients may enforce stricter classical no-self-check rules,

--- a/silverscript-lang/tests/apps/chess/chess_knight.sil
+++ b/silverscript-lang/tests/apps/chess/chess_knight.sil
@@ -131,7 +131,7 @@ contract ChessKnight(
         byte[] prefix = prev_dyn.slice(0, low_idx);
         byte[] middle = prev_dyn.slice(low_idx + 1, high_idx);
         byte[] suffix = prev_dyn.slice(high_idx + 1, 64);
-        byte[64] next_board = prefix + byte[1](first_slot) + middle + byte[1](second_slot) + suffix;
+        byte[64] next_board = byte[64](prefix + byte[1](first_slot) + middle + byte[1](second_slot) + suffix);
 
         int next_status = status;
         if (recent_castle != 0 /*CLEAR*/) {

--- a/silverscript-lang/tests/apps/chess/chess_pawn.sil
+++ b/silverscript-lang/tests/apps/chess/chess_pawn.sil
@@ -294,7 +294,7 @@ contract ChessPawn(
         byte[] middle_xy = prev_dyn.slice(x + 1, y);
         byte[] middle_yz = prev_dyn.slice(y + 1, z);
         byte[] suffix = prev_dyn.slice(z + 1, 64);
-        byte[64] next_board = prefix + byte[1](vx) + middle_xy + byte[1](vy) + middle_yz + byte[1](vz) + suffix;
+        byte[64] next_board = byte[64](prefix + byte[1](vx) + middle_xy + byte[1](vy) + middle_yz + byte[1](vz) + suffix);
 
         State next_state = {
             mux_template: mux_template,

--- a/silverscript-lang/tests/apps/chess/chess_vert.sil
+++ b/silverscript-lang/tests/apps/chess/chess_vert.sil
@@ -142,7 +142,7 @@ contract ChessVert(
         byte[] prefix = prev_dyn.slice(0, low_idx);
         byte[] middle = prev_dyn.slice(low_idx + 1, high_idx);
         byte[] suffix = prev_dyn.slice(high_idx + 1, 64);
-        byte[64] next_board = prefix + byte[1](first_slot) + middle + byte[1](second_slot) + suffix;
+        byte[64] next_board = byte[64](prefix + byte[1](first_slot) + middle + byte[1](second_slot) + suffix);
 
         // Capturing the enemy king is the on-chain terminal condition.
         // Off-chain clients may enforce stricter classical no-self-check rules,

--- a/silverscript-lang/tests/apps/chess/league.sil
+++ b/silverscript-lang/tests/apps/chess/league.sil
@@ -56,7 +56,7 @@ contract League(
         require(checkSig(owner_sig, owner_pk));
 
         byte[32] owner = blake2b(owner_pk);
-        byte[32] spent_outpoint_txid = OpOutpointTxId(this.activeInputIndex);
+        byte[32] spent_outpoint_txid = byte[32](OpOutpointTxId(this.activeInputIndex));
         byte[4] spent_outpoint_index = byte[4](OpOutpointIndex(this.activeInputIndex));
         byte[] player_id_domain = byte[]("LeaguePlayerId");
         byte[32] player_id = blake2b(player_id_domain + spent_outpoint_txid + spent_outpoint_index);

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -1568,6 +1568,39 @@ fn rejects_cast_from_smaller_fixed_byte_array_to_larger_fixed_byte_array() {
 }
 
 #[test]
+fn allows_array_concat_to_matching_size() {
+    let source = r#"
+        contract Arrays() {
+            entrypoint function main() {
+                byte[2] left = 0x0102;
+                byte[2] right = 0x0304;
+                byte[4] combined = left + right;
+                require(combined == 0x01020304);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default()).expect("byte[2] + byte[2] should cast to byte[4]");
+}
+
+#[test]
+fn rejects_cast_from_fixed_byte_array_concat_to_wrong_size() {
+    let source = r#"
+        contract Arrays() {
+            entrypoint function main() {
+                byte[2] left = 0x0102;
+                byte[2] right = 0x0304;
+                byte[5] combined = byte[5](left + right);
+                require(combined.length == 5);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("byte[2] + byte[2] should not cast to byte[5]");
+    assert!(err.to_string().contains("cannot cast byte[4] to byte[5]"), "unexpected error: {err}");
+}
+
+#[test]
 fn rejects_fixed_byte_array_size_mismatch_inside_struct_literal() {
     let source = r#"
         contract Arrays() {
@@ -4083,7 +4116,9 @@ fn branchy_three_slot_splice_repro_matches_current_codegen_shape() {
                 byte[] middle_xy = prev_dyn.slice(x + 1, y);
                 byte[] middle_yz = prev_dyn.slice(y + 1, z);
                 byte[] suffix = prev_dyn.slice(z + 1, 64);
-                byte[64] next_board = prefix + byte[1](vx) + middle_xy + byte[1](vy) + middle_yz + byte[1](vz) + suffix;
+                byte[64] next_board = byte[64](
+                    prefix + byte[1](vx) + middle_xy + byte[1](vy) + middle_yz + byte[1](vz) + suffix
+                );
 
                 require(next_board[10] == 1);
                 require(next_board[20] == 2);
@@ -4280,7 +4315,7 @@ fn allows_concat_of_int_arrays_with_plus() {
             entrypoint function main() {
                 int[] a = [1, 2];
                 int[] b = [3, 4];
-                int[4] c = a + b;
+                int[4] c = int[4](a + b);
 
                 require(c.length == 4);
                 require(c[0] == 1);
@@ -4305,7 +4340,7 @@ fn allows_concat_of_byte_arrays_with_plus() {
             entrypoint function main() {
                 byte[] a = 0x0102;
                 byte[] b = 0x0304;
-                byte[4] c = a + b;
+                byte[4] c = byte[4](a + b);
 
                 require(c.length == 4);
                 require(c == 0x01020304);
@@ -4327,7 +4362,7 @@ fn allows_concat_of_fixed_size_byte_array_elements_with_plus() {
             entrypoint function main() {
                 byte[2][] a = [0x0102, 0x0304];
                 byte[2][] b = [0x0506];
-                byte[2][3] c = a + b;
+                byte[2][3] c = byte[2][3](a + b);
 
                 require(c.length == 3);
                 require(c[0] == 0x0102);
@@ -4351,7 +4386,7 @@ fn allows_concat_of_bool_arrays_with_plus() {
             entrypoint function main() {
                 bool[] a = [true, false];
                 bool[] b = [true, false];
-                bool[4] c = a + b;
+                bool[4] c = bool[4](a + b);
 
                 require(c.length == 4);
                 require(c[0]);
@@ -4379,7 +4414,7 @@ fn allows_concat_of_pubkey_arrays_with_plus() {
 
                 pubkey[] a = [p1];
                 pubkey[] b = [p2];
-                pubkey[2] c = a + b;
+                pubkey[2] c = pubkey[2](a + b);
 
                 require(c.length == 2);
                 require(c[0] == p1);
@@ -4840,7 +4875,7 @@ fn locking_bytecode_p2pk_matches_pay_to_address_script() {
     let source = r#"
         contract Test() {
             entrypoint function main(pubkey pk, byte[] expected) {
-                byte[] spk = new ScriptPubKeyP2PK(pk);
+                byte[] spk = byte[](new ScriptPubKeyP2PK(pk));
                 require(spk == expected);
             }
         }
@@ -4864,7 +4899,7 @@ fn locking_bytecode_p2sh_matches_pay_to_address_script() {
     let source = r#"
         contract Test() {
             entrypoint function main(byte[32] hash, byte[] expected) {
-                byte[] spk = new ScriptPubKeyP2SH(hash);
+                byte[] spk = byte[](new ScriptPubKeyP2SH(hash));
                 require(spk == expected);
             }
         }
@@ -4888,7 +4923,7 @@ fn locking_bytecode_p2sh_from_redeem_script_matches_pay_to_script_hash_script() 
     let source = r#"
         contract Test() {
             entrypoint function main(byte[] redeem_script, byte[] expected) {
-                byte[] spk = new ScriptPubKeyP2SHFromRedeemScript(redeem_script);
+                byte[] spk = byte[](new ScriptPubKeyP2SHFromRedeemScript(redeem_script));
                 require(spk == expected);
             }
         }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -9468,6 +9468,42 @@ fn accepts_byte_array_with_constant_size() {
 }
 
 #[test]
+fn constant_array_dimension_expressions_compare_by_value() {
+    let source = r#"
+        contract Test() {
+            int constant HALF_SIZE = 16;
+            int constant HASH_SIZE = HALF_SIZE * 2;
+
+            function consume(byte[32] hash) {
+                require(hash.length == 32);
+            }
+
+            entrypoint function test(byte[HASH_SIZE] hash) {
+                consume(hash);
+            }
+        }
+    "#;
+    compile_contract(source, &[], CompileOptions::default()).expect("equal compiled array dimensions should match");
+}
+
+#[test]
+fn fixed_and_dynamic_array_types_are_not_identical() {
+    let source = r#"
+        contract Test() {
+            function consume(byte[] hash) {
+                require(hash.length == 32);
+            }
+
+            entrypoint function test(byte[32] hash) {
+                consume(hash);
+            }
+        }
+    "#;
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("fixed and dynamic array types should differ");
+    assert!(err.to_string().contains("function argument 'hash' expects byte[]"), "unexpected error: {err}");
+}
+
+#[test]
 fn blake2b_int_and_byte_cast_forms_compile_to_identical_script() {
     let source_plain = r#"
         contract Test() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -30,6 +30,33 @@ fn script_builder() -> ScriptBuilder {
     ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() })
 }
 
+#[test]
+fn constructors_validate_argument_types() {
+    let cases = [
+        ("ScriptPubKeyP2PK", "1", "publicKey", "pubkey", "byte[34]"),
+        ("ScriptPubKeyP2SH", "byte[31]([0x00])", "scriptHash", "byte[32]", "byte[35]"),
+        ("ScriptPubKeyP2SHFromRedeemScript", "1", "redeemScript", "byte[]", "byte[35]"),
+    ];
+
+    for (constructor, argument, parameter, expected, result_type) in cases {
+        let source = format!(
+            r#"
+            contract Test() {{
+                entrypoint function spend() {{
+                    {result_type} script = new {constructor}({argument});
+                    require(true);
+                }}
+            }}
+            "#
+        );
+        let err = compile_contract(&source, &[], CompileOptions::default()).expect_err("constructor argument should be rejected");
+        assert!(
+            err.to_string().contains(&format!("argument '{parameter}' expects {expected}")),
+            "unexpected error for {constructor}: {err}"
+        );
+    }
+}
+
 fn pay_to_script_hash_signature_script(
     redeem_script: Vec<u8>,
     signature_script: Vec<u8>,

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -9678,7 +9678,7 @@ fn ternary_expression_rejects_mismatched_branch_types() {
     "#;
 
     let err = compile_contract(source, &[], CompileOptions::default()).expect_err("mismatched ternary branches should fail");
-    assert!(err.to_string().contains("ternary branch type mismatch"), "unexpected error: {err}");
+    assert!(err.to_string().contains("variable 'value' expects int"), "unexpected error: {err}");
 }
 
 #[test]

--- a/silverscript-lang/tests/examples/announcement.sil
+++ b/silverscript-lang/tests/examples/announcement.sil
@@ -2,10 +2,9 @@ pragma silverscript ^0.1.0;
 
 contract Announcement() {
     entrypoint function announce() {
-        byte[] announcement = new LockingBytecodeNullData([
-            27906,
-            byte[]('A contract may not injure a human being or, through inaction, allow a human being to come to harm.')
-        ]);
+        // TODO: Change this to check the payload field.
+        byte[] announcement = byte[]([0x00, 0x00, 0x6a, 0x02, 0x02, 0x6d, 0x4c, 0x62])
+            + byte[]('A contract may not injure a human being or, through inaction, allow a human being to come to harm.');
 
         require(tx.outputs[0].value == 0);
         require(tx.outputs[0].scriptPubKey == announcement);

--- a/silverscript-lang/tests/examples/comments.sil
+++ b/silverscript-lang/tests/examples/comments.sil
@@ -9,7 +9,7 @@ contract Test(int x) {
     // Line comments are a thing
     entrypoint function hello(sig s, pubkey pk) {
         int i = 400 + x;
-        byte[] b = 0x07364897987fe87 + byte[](x);
+        byte[] b = byte[](0x07364897987fe87) + byte[](x);
 
         int myVariable = 10 - 4; // they can go at the end of the line
         int myOtherVariable = i + myVariable % 2;

--- a/silverscript-lang/tests/examples/everything.sil
+++ b/silverscript-lang/tests/examples/everything.sil
@@ -7,7 +7,7 @@ contract Test(int x, string y) {
     // Line comments are a thing
     entrypoint function hello(pubkey pk, sig s) {
         int i = 400 + x;
-        byte[] b = 0x007364897987fe87 + byte[](y);
+        byte[] b = byte[](0x007364897987fe87) + byte[](y);
 
         int myVariable = 10 - int(false); // they can go at the end of the line
         int myOtherVariable = (i + myVariable) % 2;

--- a/silverscript-lang/tests/examples/kcc20.sil
+++ b/silverscript-lang/tests/examples/kcc20.sil
@@ -14,9 +14,9 @@ contract KCC20(byte[32] genesisPk, int genesisAmount, byte genesisIdentifierType
                 require(checkSig(sigs[i], prevStates[i].ownerIdentifier));
             } else if(prevStates[i].identifierType == IDENTIFIER_SCRIPT_HASH){
                 byte[] spk = byte[](new ScriptPubKeyP2SH(prevStates[i].ownerIdentifier));
-                require(tx.inputs[witnesses[i]].scriptPubKey == spk);
+                require(tx.inputs[int(witnesses[i])].scriptPubKey == spk);
             } else if(prevStates[i].identifierType == IDENTIFIER_COVENANT_ID){
-                require(OpInputCovenantId(witnesses[i]) == prevStates[i].ownerIdentifier);
+                require(OpInputCovenantId(int(witnesses[i])) == prevStates[i].ownerIdentifier);
             } else {
                 require(false);
             }

--- a/silverscript-lang/tests/examples/kcc20.sil
+++ b/silverscript-lang/tests/examples/kcc20.sil
@@ -13,7 +13,7 @@ contract KCC20(byte[32] genesisPk, int genesisAmount, byte genesisIdentifierType
             if(prevStates[i].identifierType == IDENTIFIER_PUBKEY){
                 require(checkSig(sigs[i], prevStates[i].ownerIdentifier));
             } else if(prevStates[i].identifierType == IDENTIFIER_SCRIPT_HASH){
-                byte[] spk = new ScriptPubKeyP2SH(prevStates[i].ownerIdentifier);
+                byte[] spk = byte[](new ScriptPubKeyP2SH(prevStates[i].ownerIdentifier));
                 require(tx.inputs[witnesses[i]].scriptPubKey == spk);
             } else if(prevStates[i].identifierType == IDENTIFIER_COVENANT_ID){
                 require(OpInputCovenantId(witnesses[i]) == prevStates[i].ownerIdentifier);

--- a/silverscript-lang/tests/examples/mecenas_locktime.sil
+++ b/silverscript-lang/tests/examples/mecenas_locktime.sil
@@ -26,7 +26,7 @@ contract Mecenas(
             require(tx.outputs[0].value == pledge);
             require(tx.outputs[1].value == changeValue);
 
-            byte[] bcValue = 8 + byte[8](tx.locktime) + this.activeScriptPubKey.split(9).1;
+            byte[] bcValue = byte[](8) + byte[8](tx.locktime) + this.activeScriptPubKey.split(9).1;
             byte[35] lockValue = new ScriptPubKeyP2SH(blake2b(bcValue));
             require(tx.outputs[1].scriptPubKey == byte[](lockValue));
         }

--- a/silverscript-lang/tests/examples/simulating_state.sil
+++ b/silverscript-lang/tests/examples/simulating_state.sil
@@ -8,7 +8,7 @@ contract SimulatingState(
 ) {
     entrypoint function receive() {
         // Check that the first output sends to the recipient
-            byte[34] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
+        byte[34] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
         require(tx.outputs[0].scriptPubKey == byte[](recipientScriptPubKey));
 
         // Check that time has passed and that time locks are enabled
@@ -38,11 +38,11 @@ contract SimulatingState(
             // Insert new initialBlock (OP_PUSHBYTES_8 <tx.locktime>)
             // Note that constructor parameters are added in reverse order,
             // so initialBlock is the first statement in the contract bytecode.
-            byte[] newContract = 0x08 + byte[8](tx.locktime) + this.activeScriptPubKey.split(9).1;
+            byte[] newContract = byte[](0x08) + byte[8](tx.locktime) + this.activeScriptPubKey.split(9).1;
 
             // Create the locking bytecode for the new contract and check that
             // the change output sends to that contract
-                byte[35] newContractLock = new ScriptPubKeyP2SH(blake2b(newContract));
+            byte[35] newContractLock = new ScriptPubKeyP2SH(blake2b(newContract));
             require(tx.outputs[1].scriptPubKey == byte[](newContractLock));
         }
     }

--- a/silverscript-lang/tests/examples/slice_optimised.sil
+++ b/silverscript-lang/tests/examples/slice_optimised.sil
@@ -2,7 +2,7 @@ pragma silverscript ^0.1.0;
 
 contract Slice(byte[32] data) {
     entrypoint function spend() {
-        byte[20] pkh = data.slice(0, 20);
+        byte[20] pkh = byte[20](data.slice(0, 20));
         require(pkh == byte[20](0));
     }
 }

--- a/silverscript-lang/tests/examples/split_or_slice_signature.sil
+++ b/silverscript-lang/tests/examples/split_or_slice_signature.sil
@@ -4,7 +4,7 @@ contract Test(sig signature) {
     entrypoint function spend() {
         // Assume Schnorr
         byte[] hashtype1 = signature.split(64).1;
-        byte[1] hashtype2 = signature.slice(64, 65);
+        byte[1] hashtype2 = byte[1](signature.slice(64, 65));
         require(hashtype1 == byte[](0x01));
         require(hashtype2 == 0x01);
     }

--- a/silverscript-lang/tests/examples/split_typed.sil
+++ b/silverscript-lang/tests/examples/split_typed.sil
@@ -2,7 +2,7 @@ pragma silverscript ^0.1.0;
 
 contract SplitTyped(byte[] b) {
     entrypoint function spend() {
-        byte[4] x = b.split(4).0;
+        byte[4] x = byte[4](b.split(4).0);
         require(byte[](x) != b);
     }
 }

--- a/silverscript-lang/tests/examples/tuple_unpacking_single_side_type.sil
+++ b/silverscript-lang/tests/examples/tuple_unpacking_single_side_type.sil
@@ -3,6 +3,6 @@ pragma silverscript ^0.1.0;
 contract Test() {
     entrypoint function split(byte[] b) {
         (byte[16] x, byte[] y) = b.split(16);
-        require(x == y);
+        require(byte[](x) == y);
     }
 }

--- a/silverscript-lang/tests/parser_tests.rs
+++ b/silverscript-lang/tests/parser_tests.rs
@@ -1,4 +1,4 @@
-use silverscript_lang::ast::parse_contract_ast;
+use silverscript_lang::ast::{parse_contract_ast, parse_type_ref};
 use silverscript_lang::parser::parse_source_file;
 
 #[test]
@@ -15,6 +15,23 @@ fn parses_minimal_contract() {
 
     let result = parse_source_file(input);
     assert!(result.is_ok());
+}
+
+#[test]
+fn type_predicates_only_match_scalars() {
+    assert!(parse_type_ref("int").unwrap().is_int());
+    assert!(parse_type_ref("bool").unwrap().is_bool());
+    assert!(parse_type_ref("string").unwrap().is_string());
+    assert!(parse_type_ref("pubkey").unwrap().is_pubkey());
+    assert!(parse_type_ref("sig").unwrap().is_sig());
+    assert!(parse_type_ref("datasig").unwrap().is_datasig());
+    assert!(parse_type_ref("byte").unwrap().is_byte());
+    assert!(parse_type_ref("(int, bool)").unwrap().is_tuple());
+    assert!(parse_type_ref("Record").unwrap().is_custom());
+
+    assert!(!parse_type_ref("int[]").unwrap().is_int());
+    assert!(!parse_type_ref("byte[1]").unwrap().is_byte());
+    assert!(!parse_type_ref("Record[]").unwrap().is_custom());
 }
 
 #[test]

--- a/tree-sitter/queries/highlights.scm
+++ b/tree-sitter/queries/highlights.scm
@@ -15,7 +15,7 @@
 (instantiation
   (identifier) @type.builtin
   (#match? @type.builtin
-    "^(LockingBytecodeNullData|ScriptPubKeyP2PK|ScriptPubKeyP2SH|ScriptPubKeyP2SHFromRedeemScript)$"))
+    "^(ScriptPubKeyP2PK|ScriptPubKeyP2SH|ScriptPubKeyP2SHFromRedeemScript)$"))
 
 (instantiation
   (identifier) @type)


### PR DESCRIPTION
Replace permissive assignability rules with precise expression type inference and exact type comparison. Conversions between different types or array shapes must now be written explicitly.

  ## Language Behavior Changes

  - Fixed and dynamic arrays are distinct types. An explicit cast is required when crossing that boundary.

  ```silverscript
  byte[32] hash = blake2b(data);
  byte[] dynamicHash = byte[](hash);
  ```

  - Constant array dimensions are compared by their evaluated values. For example, `byte[HASH_SIZE]` and `byte[32]` are identical when `HASH_SIZE` evaluates to `32`.

  - Array concatenation now infers its resulting size. Concatenating `T[n]` and `T[m]` produces `T[n + m]`; if either operand is dynamic, the result is `T[]`.

  ```silverscript
  byte[2] left = 0x0102;
  byte[2] right = 0x0304;
  byte[4] combined = left + right;
  ```

  A dynamic concatenation requires an explicit cast when assigned to a fixed array:

  ```silverscript
  byte[64] board = byte[64](prefix + middle + suffix);
  ```

  - Fixed-size casts validate the inferred source size, so an expression known to be `byte[4]` cannot be cast to `byte[5]`.

  - locking-script constructors validate their argument types and expose precise result types:

    - `ScriptPubKeyP2PK(pubkey)` returns `byte[34]`
    - `ScriptPubKeyP2SH(byte[32])` returns `byte[35]`
    - `ScriptPubKeyP2SHFromRedeemScript(byte[])` returns `byte[35]`

  ```silverscript
  byte[34] script = new ScriptPubKeyP2PK(owner);
  ```

  Converting a constructor result to a dynamic byte array must be explicit:

  ```silverscript
  byte[] script = byte[](new ScriptPubKeyP2PK(owner));
  ```

  - Multi-return function calls now carry an explicit tuple type. Tuple fields are inferred individually, while using the entire tuple as a scalar value is rejected.

  - `LockingBytecodeNullData` has been removed.

  - Covenant state-array positions now accept exactly `State[]`; fixed-size and nested forms such as `State[2]` and `State[][]` are rejected.