### PR TITLE
feat(compiler): template hash function is blake3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ kaspa-txscript = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "a41a3
 kaspa-txscript-zk-sdk = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "a41a333b08848f41bf737b72592e463a6011b8ac" }
 kaspa-txscript-errors = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "a41a333b08848f41bf737b72592e463a6011b8ac" }
 blake2b_simd = "1.0.2"
+blake3 = "1.8.5"
 indexmap = "2.7.0"
 rand = "0.8.5"
 secp256k1 = { version = "0.29.0", features = [

--- a/silverscript-lang/Cargo.toml
+++ b/silverscript-lang/Cargo.toml
@@ -17,6 +17,7 @@ kaspa-txscript.workspace = true
 kaspa-txscript-zk-sdk.workspace = true
 kaspa-txscript-errors.workspace = true
 blake2b_simd.workspace = true
+blake3.workspace = true
 indexmap.workspace = true
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 pest = "2.7"
@@ -31,7 +32,6 @@ faster-hex = "0.10"
 semver = "1.0"
 
 [dev-dependencies]
-blake3 = "1.8.5"
 kaspa-addresses.workspace = true
 kaspa-consensus.workspace = true
 kaspa-muhash.workspace = true

--- a/silverscript-lang/src/compiler/compile/expression/builtin.rs
+++ b/silverscript-lang/src/compiler/compile/expression/builtin.rs
@@ -244,7 +244,7 @@ fn compile_template_hash_call<'i>(ctx: &mut CompileExprContext<'_, '_, 'i>, args
         binary_expr(BinaryOp::Add, encoded_suffix_len, suffix.clone()),
     );
     compile_call_arg_with_context(ctx, &preimage)?;
-    ctx.emit_op(OpBlake2b, 0)?;
+    ctx.emit_op(OpBlake3, 0)?;
     Ok(())
 }
 

--- a/silverscript-lang/src/compiler/compile/state.rs
+++ b/silverscript-lang/src/compiler/compile/state.rs
@@ -154,7 +154,7 @@ pub(super) fn cast_read_input_state_expr<'i>(substr: Expr<'i>, type_ref: &TypeRe
 ///   ]
 ///
 ///   actual_template = i64le(prefix.length) || prefix || i64le(suffix.length) || suffix
-///   require blake2b(actual_template) == expected_template_hash
+///   require blake3(actual_template) == expected_template_hash
 ///
 ///   expected_input_spk = ScriptPubKeyP2SHFromRedeemScript(actual_redeem_script)
 ///   require input_script_pubkey(input_idx) == expected_input_spk
@@ -216,7 +216,7 @@ pub(super) fn compile_read_input_state_with_template_validation(
     let mut emitter = ScriptEmitter::new(builder, 0);
     let dynamic_bytes = byte_array_type(ArrayDim::Dynamic);
     let p2sh_script_type = constructor_return_type("ScriptPubKeyP2SHFromRedeemScript").expect("known constructor type");
-    let hash_type = builtin_return_type("blake2b").expect("known builtin type");
+    let hash_type = builtin_return_type("blake3").expect("known builtin type");
 
     compile_expr(&actual_input_spk_expr, Some(&dynamic_bytes), &env, &mut emitter)?;
     compile_expr(&expected_input_spk_expr, Some(&p2sh_script_type), &env, &mut emitter)?;
@@ -224,7 +224,7 @@ pub(super) fn compile_read_input_state_with_template_validation(
 
     compile_expr(expected_template_hash, Some(&hash_type), &env, &mut emitter)?;
     compile_expr(&template_expr, Some(&dynamic_bytes), &env, &mut emitter)?;
-    emitter.emit_op(OpBlake2b, 0)?;
+    emitter.emit_op(OpBlake3, 0)?;
     emitter.emit_op(OpEqualVerify, -2)?;
 
     Ok(())
@@ -366,7 +366,7 @@ pub(super) fn compile_validate_output_state_with_template_inner_statement(
 
     let env = ExprEnv { constants, stack_bindings, types, bytecode_size, contract_constants };
     let dynamic_bytes_type = byte_array_type(ArrayDim::Dynamic);
-    let hash_type = builtin_return_type("blake2b").expect("known builtin type");
+    let hash_type = builtin_return_type("blake3").expect("known builtin type");
     let int_type = scalar_type(TypeBase::Int);
 
     let encoded_prefix_len = int_to_fixed_bytes_expr(Expr::call("length", vec![template_prefix.clone()]), 8);
@@ -380,7 +380,7 @@ pub(super) fn compile_validate_output_state_with_template_inner_statement(
         let mut emitter = ScriptEmitter::new(builder, 0);
         compile_expr(expected_template_hash, Some(&hash_type), &env, &mut emitter)?;
         compile_expr(&template_preimage, Some(&dynamic_bytes_type), &env, &mut emitter)?;
-        emitter.emit_op(OpBlake2b, 0)?;
+        emitter.emit_op(OpBlake3, 0)?;
         emitter.emit_op(OpEqualVerify, -2)?;
     }
     let stack_depth = compile_encoded_flat_state_fields(

--- a/silverscript-lang/src/template.rs
+++ b/silverscript-lang/src/template.rs
@@ -1,4 +1,4 @@
-use blake2b_simd::Params as Blake2bParams;
+use blake3::Hasher as Blake3Hasher;
 use kaspa_txscript::serialize_i64;
 
 const TEMPLATE_PART_LENGTH_BYTES: usize = 8;
@@ -13,25 +13,29 @@ pub fn template_hash(prefix: &[u8], suffix: &[u8]) -> [u8; 32] {
     let encoded_prefix_len = serialize_i64(prefix_len, Some(TEMPLATE_PART_LENGTH_BYTES)).unwrap();
     let encoded_suffix_len = serialize_i64(suffix_len, Some(TEMPLATE_PART_LENGTH_BYTES)).unwrap();
 
-    Blake2bParams::new()
-        .hash_length(32)
-        .to_state()
-        .update(encoded_prefix_len.as_ref())
-        .update(prefix)
-        .update(encoded_suffix_len.as_ref())
-        .update(suffix)
-        .finalize()
-        .as_bytes()
-        .try_into()
-        .unwrap()
+    Blake3Hasher::new().update(&encoded_prefix_len).update(prefix).update(&encoded_suffix_len).update(suffix).finalize().into()
 }
 
 #[cfg(test)]
 mod tests {
     use super::template_hash;
+    use faster_hex::hex_string;
 
     #[test]
     fn binds_template_part_boundary() {
         assert_ne!(template_hash(b"a", b"bc"), template_hash(b"ab", b"c"));
+    }
+
+    #[test]
+    fn golden_empty_parts() {
+        assert_eq!(hex_string(&template_hash(&[], &[])), "e572dff82304700b856a555ac3a4558d0df3646a3727816500270a93c66aac1e");
+    }
+
+    #[test]
+    fn golden_classic() {
+        assert_eq!(
+            hex_string(&template_hash(b"\x00\xff", b"\x10\x00\x80")),
+            "6616a66757315de0221cb2acba729113cebde31f8d3ca7fa93878a0584b96905"
+        );
     }
 }

--- a/silverscript-lang/std/builtins.sil
+++ b/silverscript-lang/std/builtins.sil
@@ -192,11 +192,11 @@ function readInputStateWithTemplate(
  *   1. Convert `templatePrefix.length` and `templateSuffix.length` with
  *      `length as byte[8]`.
  *   2. Build `prefixLen || templatePrefix || suffixLen || templateSuffix`.
- *   3. Return `blake2b` of that preimage.
+ *   3. Return `blake3` of that preimage.
  *
  * Security notes:
  *   - The encoded lengths bind the location where state is inserted.
- *   - `blake2b(templatePrefix || templateSuffix)` is not a valid template hash
+ *   - `blake3(templatePrefix || templateSuffix)` is not a valid template hash
  *     because it does not commit to the prefix/suffix boundary.
  */
 function templateHash(byte[] templatePrefix, byte[] templateSuffix) : (byte[32]);

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -11148,10 +11148,10 @@ fn executes_opcode_builtins_basic() {
 #[test]
 fn template_hash_matches_canonical_rust_and_sil_vectors() {
     let cases: &[(&[u8], &[u8], &str)] = &[
-        (b"", b"", "94c1c088cc9453996779630ad3af45cbd92814828dd784cf2aa12df95d1b8afe"),
-        (b"a", b"bc", "77bbcab7072b897c548327378f11776f4853104c71bdb95a12ded5d2783523bf"),
-        (b"ab", b"c", "20263e794775e4edf2b306c0f306af9e50175c831c857604b481e847f790bf95"),
-        (&[0x00, 0xff], &[0x10, 0x00, 0x80], "81485678b557bcd4a836c2db54ee268e1dc08549f1b8e4d8d67960321b765f25"),
+        (b"", b"", "e572dff82304700b856a555ac3a4558d0df3646a3727816500270a93c66aac1e"),
+        (b"a", b"bc", "405e183e2494cdbe2df89349cc0ffa5b77fb885ad97a1d5660ecd0692ef8142a"),
+        (b"ab", b"c", "a0968c014f3fc7bd1a7d9a8d1ad1177eb379bd2f05e56309eb4e20347c5e7eba"),
+        (&[0x00, 0xff], &[0x10, 0x00, 0x80], "6616a66757315de0221cb2acba729113cebde31f8d3ca7fa93878a0584b96905"),
     ];
 
     let sil_bytes = |bytes: &[u8]| {


### PR DESCRIPTION
As per suggested in kcc-01, template hash should be blake3

#144 doesn't seem to conflict with this as it's built upon underlying utils