### PR TITLE
compiler: preserve bool[N] in validateOutputState state encoding

### DIFF
--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -516,6 +516,9 @@ fn fixed_type_size(type_ref: &TypeRef) -> Option<i64> {
             if elem_type.is_int() {
                 return Some((size * 8) as i64);
             }
+            if elem_type.is_bool() {
+                return Some(size as i64);
+            }
         }
         return None;
     }
@@ -3838,6 +3841,22 @@ mod tests {
     use crate::ast::{BinaryOp, Expr, ExprKind, UnaryOp};
 
     use super::{Op0, OpPushData1, OpPushData2, StackBindings, data_prefix, eval_const_int};
+
+    #[test]
+    fn fixed_type_size_accepts_bool_array() {
+        use crate::ast::TypeRef;
+        use crate::ast::TypeBase;
+        use crate::ast::ArrayDim;
+        // bool[2] → Some(2) (1 byte per element)
+        let bool2 = TypeRef { base: TypeBase::Bool, array_dims: vec![ArrayDim::Fixed(2)] };
+        assert_eq!(super::fixed_type_size(&bool2), Some(2));
+        // bool[4] → Some(4)
+        let bool4 = TypeRef { base: TypeBase::Bool, array_dims: vec![ArrayDim::Fixed(4)] };
+        assert_eq!(super::fixed_type_size(&bool4), Some(4));
+        // scalar bool → Some(1)
+        let bool_scalar = TypeRef { base: TypeBase::Bool, array_dims: vec![] };
+        assert_eq!(super::fixed_type_size(&bool_scalar), Some(1));
+    }
 
     #[test]
     fn data_prefix_encodes_small_pushes() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -5468,6 +5468,28 @@ fn compiles_validate_output_state_to_expected_script() {
 }
 
 #[test]
+fn compiles_validate_output_state_with_bool_array_field() {
+    let source = r#"
+        contract C(bool[2] initW) {
+            bool[2] w = initW;
+
+            entrypoint function main() {
+                validateOutputState(0, { w: w });
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(
+        source,
+        &[vec![Expr::bool(true), Expr::bool(false)].into()],
+        CompileOptions::default(),
+    )
+    .expect("bool[2] field ref in validateOutputState should compile");
+    // Verify script is non-empty (compilation produced output)
+    assert!(!compiled.script.is_empty(), "compiled script must not be empty");
+}
+
+#[test]
 fn runs_validate_output_state() {
     let source = r#"
         contract C(int initX, byte[2] initY) {


### PR DESCRIPTION
## Summary

Adds `bool[N]` arm to `fixed_type_size` in the VOS state encoder, preserving correct byte-width for bool arrays in `validateOutputState` round-trip.

## Motivation

Without this patch, `fixed_type_size` returns `None` for `bool[N]` types, meaning the VOS encoder cannot determine the serialized size of bool array fields. This breaks state encoding round-trip for any covenant contract using `bool[N]` in VOS bodies (e.g., `cov_cash.sil`).

## Changes

- **`silverscript-lang/src/compiler/compile.rs`** (+19 lines):
  - `fixed_type_size`: add `is_bool()` arm returning `Some(size as i64)` — 1 byte per bool element (vs 8 bytes per int)
  - `fixed_type_size_accepts_bool_array` unit test: `bool[2]` → `Some(2)`, `bool[4]` → `Some(4)`, scalar `bool` → `Some(1)`

- **`silverscript-lang/tests/compiler_tests.rs`** (+22 lines):
  - `compiles_validate_output_state_with_bool_array_field` — integration test: `bool[2]` field in VOS compiles

## Verification

- `cargo build --release -p silverscript-lang` ✅
- `cargo test -p silverscript-lang --release` — 497 passed, 0 failed ✅
- Branch based on `2a3961c` (upstream master HEAD at time of branch)

## Encoding Correctness

`fixed_type_size` determines serialized byte width for fixed-size arrays in state encoding:
- `int[N]` → `Some(N * 8)` (8 bytes per int)
- `bool[N]` → `Some(N)` (1 byte per bool) ← **this PR**
- `byte[N]` → `Some(N)` (existing)

Bool encoding uses `OpNum2Bin(1)` per element — same mechanism as `byte[N]`, only the type inference path differs.

## Functional Dependency

Depends on #170 (`Expr::bool_array` + `From<Vec<bool>>`) — that PR enables constructing `bool[N]` values; this PR enables encoding them correctly. Both needed for full VOS round-trip.
