### PR TITLE
Preserve explicit struct types for templated state reads

### DIFF
--- a/silverscript-lang/src/ast/mod.rs
+++ b/silverscript-lang/src/ast/mod.rs
@@ -406,6 +406,9 @@ pub enum Statement<'i> {
         name_span: Span<'i>,
     },
     StateFunctionCallAssign {
+        /// Struct selected by a typed assignment before its fields were flattened.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target_struct: Option<String>,
         bindings: Vec<StructBindingAst<'i>>,
         name: String,
         args: Vec<Expr<'i>>,
@@ -1720,7 +1723,7 @@ fn parse_statement<'i>(pair: Pair<'i, Rule>) -> Result<Statement<'i>, CompilerEr
                 inner.next().ok_or_else(|| CompilerError::Unsupported("missing function call".to_string()).with_span(&span))?;
             let (Identifier { name, span: name_span }, args) =
                 parse_function_call_parts(call_pair).map_err(|err| err.with_span(&span))?;
-            Ok(Statement::StateFunctionCallAssign { bindings, name, args, span, name_span })
+            Ok(Statement::StateFunctionCallAssign { target_struct: None, bindings, name, args, span, name_span })
         }
         Rule::struct_destructure_assignment => {
             let mut inner = pair.into_inner();

--- a/silverscript-lang/src/ast/visit.rs
+++ b/silverscript-lang/src/ast/visit.rs
@@ -213,7 +213,7 @@ pub fn walk_statement_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, st
                 visitor.visit_expr(arg);
             }
         }
-        Statement::StateFunctionCallAssign { bindings, name, args, span, name_span } => {
+        Statement::StateFunctionCallAssign { target_struct: _, bindings, name, args, span, name_span } => {
             visitor.visit_span(span);
             visitor.visit_span(name_span);
             for binding in bindings {

--- a/silverscript-lang/src/compiler/array_append.rs
+++ b/silverscript-lang/src/compiler/array_append.rs
@@ -75,13 +75,16 @@ fn lower_statement<'i>(statement: &Statement<'i>) -> Result<Statement<'i>, Compi
             span: *span,
             name_span: *name_span,
         }),
-        Statement::StateFunctionCallAssign { bindings, name, args, span, name_span } => Ok(Statement::StateFunctionCallAssign {
-            bindings: bindings.clone(),
-            name: name.clone(),
-            args: args.iter().map(lower_expr).collect::<Result<Vec<_>, _>>()?,
-            span: *span,
-            name_span: *name_span,
-        }),
+        Statement::StateFunctionCallAssign { target_struct, bindings, name, args, span, name_span } => {
+            Ok(Statement::StateFunctionCallAssign {
+                target_struct: target_struct.clone(),
+                bindings: bindings.clone(),
+                name: name.clone(),
+                args: args.iter().map(lower_expr).collect::<Result<Vec<_>, _>>()?,
+                span: *span,
+                name_span: *name_span,
+            })
+        }
         Statement::StructDestructure { bindings, expr, span } => {
             Ok(Statement::StructDestructure { bindings: bindings.clone(), expr: lower_expr(expr)?, span: *span })
         }

--- a/silverscript-lang/src/compiler/compile/state.rs
+++ b/silverscript-lang/src/compiler/compile/state.rs
@@ -133,9 +133,17 @@ pub(super) fn cast_read_input_state_expr<'i>(substr: Expr<'i>, type_ref: &TypeRe
 }
 
 pub(super) fn struct_name_for_state_bindings<'i>(
+    target_struct: Option<&str>,
     bindings: &[StructBindingAst<'i>],
     structs: &StructRegistry,
 ) -> Result<String, CompilerError> {
+    if let Some(target_struct) = target_struct {
+        if !structs.contains_key(target_struct) {
+            return Err(CompilerError::Unsupported(format!("unknown struct '{target_struct}'")));
+        }
+        return Ok(target_struct.to_string());
+    }
+
     let matches = structs
         .iter()
         .filter_map(|(name, spec)| {

--- a/silverscript-lang/src/compiler/compile/statement.rs
+++ b/silverscript-lang/src/compiler/compile/statement.rs
@@ -113,8 +113,8 @@ fn compile_statement<'i>(ctx: &mut CompileStatementContext<'_, 'i>, stmt: &State
             compile_tuple_assignment_statement(ctx, left_type_ref, left_name, right_type_ref, right_name, expr)
         }
         Statement::FunctionCall { name, args, .. } => compile_function_call_statement(ctx, name, args),
-        Statement::StateFunctionCallAssign { bindings, name, args, .. } => {
-            compile_state_function_call_assign_statement(ctx, bindings, name, args)
+        Statement::StateFunctionCallAssign { target_struct, bindings, name, args, .. } => {
+            compile_state_function_call_assign_statement(ctx, target_struct.as_deref(), bindings, name, args)
         }
         Statement::StructDestructure { .. } => compile_struct_destructure_statement(),
         Statement::FunctionCallAssign { bindings, name, args, .. } => {
@@ -297,6 +297,7 @@ fn compile_function_call_statement<'i>(
 
 fn compile_state_function_call_assign_statement<'i>(
     ctx: &mut CompileStatementContext<'_, 'i>,
+    target_struct: Option<&str>,
     bindings: &[StructBindingAst<'i>],
     name: &str,
     args: &[Expr<'i>],
@@ -304,6 +305,7 @@ fn compile_state_function_call_assign_statement<'i>(
     if name == "readInputState" || name == "readInputStateWithTemplate" {
         return compile_read_input_state_statement(
             ctx,
+            target_struct,
             bindings,
             name,
             args,
@@ -359,6 +361,7 @@ fn compile_console_statement() -> Result<Vec<String>, CompilerError> {
 
 fn compile_read_input_state_statement<'i>(
     ctx: &mut CompileStatementContext<'_, 'i>,
+    target_struct: Option<&str>,
     bindings: &[StructBindingAst<'i>],
     name: &str,
     args: &[Expr<'i>],
@@ -440,7 +443,7 @@ fn compile_read_input_state_statement<'i>(
                 ));
             };
 
-            let struct_name = struct_name_for_state_bindings(bindings, structs)?;
+            let struct_name = struct_name_for_state_bindings(target_struct, bindings, structs)?;
             let struct_spec =
                 structs.get(&struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
             if bindings_by_field.len() != struct_spec.fields.len() {

--- a/silverscript-lang/src/compiler/inline_functions.rs
+++ b/silverscript-lang/src/compiler/inline_functions.rs
@@ -205,7 +205,7 @@ impl<'i, 'd> Inliner<'i, 'd> {
                     );
                 }
             }
-            Statement::StateFunctionCallAssign { bindings, name, args, span, name_span } => {
+            Statement::StateFunctionCallAssign { target_struct, bindings, name, args, span, name_span } => {
                 let (prelude, renamed_args) = self.lower_exprs(args, scope, visited_functions)?;
                 lowered.extend(prelude);
                 let renamed_bindings = bindings
@@ -218,6 +218,7 @@ impl<'i, 'd> Inliner<'i, 'd> {
                 self.push_lowered_statement(
                     &mut lowered,
                     Statement::StateFunctionCallAssign {
+                        target_struct: target_struct.clone(),
                         bindings: renamed_bindings,
                         name: name.clone(),
                         args: renamed_args,

--- a/silverscript-lang/src/compiler/locals.rs
+++ b/silverscript-lang/src/compiler/locals.rs
@@ -102,11 +102,12 @@ fn lower_statements<'i>(
                     name_span: *name_span,
                 });
             }
-            Statement::StateFunctionCallAssign { bindings, name, args, span, name_span } => {
+            Statement::StateFunctionCallAssign { target_struct, bindings, name, args, span, name_span } => {
                 for binding in bindings {
                     local_aliases.remove(&binding.name);
                 }
                 lowered.push(Statement::StateFunctionCallAssign {
+                    target_struct: target_struct.clone(),
                     bindings: bindings.clone(),
                     name: name.clone(),
                     args: args.iter().map(|arg| substitute_expr(arg, &local_aliases)).collect::<Result<Vec<_>, _>>()?,

--- a/silverscript-lang/src/compiler/read_input_state.rs
+++ b/silverscript-lang/src/compiler/read_input_state.rs
@@ -156,13 +156,16 @@ fn lower_statement<'i>(statement: &Statement<'i>, context: &mut LoweringContext)
             span: *span,
             name_span: *name_span,
         },
-        Statement::StateFunctionCallAssign { bindings, name, args, span, name_span } => Statement::StateFunctionCallAssign {
-            bindings: bindings.clone(),
-            name: name.clone(),
-            args: lower_call_args(args, &mut prefix, context),
-            span: *span,
-            name_span: *name_span,
-        },
+        Statement::StateFunctionCallAssign { target_struct, bindings, name, args, span, name_span } => {
+            Statement::StateFunctionCallAssign {
+                target_struct: target_struct.clone(),
+                bindings: bindings.clone(),
+                name: name.clone(),
+                args: lower_call_args(args, &mut prefix, context),
+                span: *span,
+                name_span: *name_span,
+            }
+        }
         Statement::StructDestructure { bindings, expr, span } => {
             Statement::StructDestructure { bindings: bindings.clone(), expr: lower_expr(expr, &mut prefix, context), span: *span }
         }

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -191,8 +191,8 @@ fn validate_statement_shapes<'i>(
             Statement::TupleAssignment { left_type_ref, left_name, right_type_ref, right_name, expr, .. } => {
                 validate_tuple_assignment_statement_shape(&mut ctx, left_type_ref, left_name, right_type_ref, right_name, expr)?
             }
-            Statement::StateFunctionCallAssign { bindings, name, args, .. } => {
-                validate_state_function_call_assign_statement_shape(&mut ctx, bindings, name, args)?
+            Statement::StateFunctionCallAssign { target_struct, bindings, name, args, .. } => {
+                validate_state_function_call_assign_statement_shape(&mut ctx, target_struct.as_deref(), bindings, name, args)?
             }
             Statement::StructDestructure { bindings, expr, .. } => {
                 validate_struct_destructure_statement_shape(&mut ctx, bindings, expr)?
@@ -302,6 +302,7 @@ fn validate_tuple_assignment_statement_shape<'i>(
 
 fn validate_state_function_call_assign_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
+    target_struct: Option<&str>,
     bindings: &[StructBindingAst<'i>],
     name: &str,
     args: &[Expr<'i>],
@@ -311,7 +312,7 @@ fn validate_state_function_call_assign_statement_shape<'i>(
             ctx.check_call(name, args, None)?;
         }
         "readInputStateWithTemplate" => {
-            let struct_name = struct_name_for_state_bindings(bindings, ctx.structs, ctx.constants)?;
+            let struct_name = struct_name_for_state_bindings(target_struct, bindings, ctx.structs, ctx.constants)?;
             let expected = TypeRef { base: TypeBase::Custom(struct_name), array_dims: Vec::new() };
             ctx.check_call(name, args, Some(&expected))?;
         }
@@ -321,7 +322,7 @@ fn validate_state_function_call_assign_statement_shape<'i>(
             )));
         }
     }
-    validate_state_function_call_assign(bindings, name, args, ctx.structs, ctx.constants, ctx.contract_fields)?;
+    validate_state_function_call_assign(target_struct, bindings, name, args, ctx.structs, ctx.constants, ctx.contract_fields)?;
     for binding in bindings {
         ensure_array_elements_have_known_size(&binding.type_ref, ctx.structs, ctx.constants, &binding.type_ref.type_name())?;
         insert_type_binding(ctx.types, &binding.name, &binding.type_ref);
@@ -595,6 +596,7 @@ fn validate_struct_destructure_bindings<'i>(
 
 // TODO: Remove this special case and destructure the State struct like any other struct.
 fn validate_state_function_call_assign<'i>(
+    target_struct: Option<&str>,
     bindings: &[StructBindingAst<'i>],
     name: &str,
     args: &[Expr<'i>],
@@ -638,7 +640,7 @@ fn validate_state_function_call_assign<'i>(
                         .to_string(),
                 ));
             };
-            let struct_name = struct_name_for_state_bindings(bindings, structs, constants)?;
+            let struct_name = struct_name_for_state_bindings(target_struct, bindings, structs, constants)?;
             let struct_spec =
                 structs.get(&struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
             if bindings.len() != struct_spec.fields.len() {
@@ -672,10 +674,18 @@ fn validate_state_function_call_assign<'i>(
 }
 
 fn struct_name_for_state_bindings<'i>(
+    target_struct: Option<&str>,
     bindings: &[StructBindingAst<'i>],
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
 ) -> Result<String, CompilerError> {
+    if let Some(target_struct) = target_struct {
+        if !structs.contains_key(target_struct) {
+            return Err(CompilerError::Unsupported(format!("unknown struct '{target_struct}'")));
+        }
+        return Ok(target_struct.to_string());
+    }
+
     let matches = structs
         .iter()
         .filter_map(|(name, spec)| {

--- a/silverscript-lang/src/compiler/structs.rs
+++ b/silverscript-lang/src/compiler/structs.rs
@@ -941,6 +941,7 @@ fn lower_statements<'i>(
                             .all(|field| !is_struct(&field.type_ref, structs) && !is_struct_array(&field.type_ref, structs))
                     {
                         lowered.push(Statement::StateFunctionCallAssign {
+                            target_struct: Some(struct_name.to_string()),
                             bindings: item
                                 .fields
                                 .iter()
@@ -1085,11 +1086,12 @@ fn lower_statements<'i>(
                     name_span: *name_span,
                 });
             }
-            Statement::StateFunctionCallAssign { bindings, name, args, span, name_span } => {
+            Statement::StateFunctionCallAssign { target_struct, bindings, name, args, span, name_span } => {
                 for binding in bindings {
                     scope.vars.insert(binding.name.clone(), binding.type_ref.clone());
                 }
                 lowered.push(Statement::StateFunctionCallAssign {
+                    target_struct: target_struct.clone(),
                     bindings: bindings.clone(),
                     name: name.clone(),
                     args: args.iter().map(|arg| lower_expr(arg, scope, structs)).collect::<Result<Vec<_>, _>>()?,

--- a/silverscript-lang/src/compiler/ternary.rs
+++ b/silverscript-lang/src/compiler/ternary.rs
@@ -131,7 +131,7 @@ impl<'a, 'i> TernaryLowerer<'a, 'i> {
                     name_span: *name_span,
                 });
             }
-            Statement::StateFunctionCallAssign { bindings, name, args, span, name_span } => {
+            Statement::StateFunctionCallAssign { bindings, name, args, span, name_span, target_struct } => {
                 let (prelude, args) = self.lower_exprs(args, types)?;
                 lowered.extend(prelude);
                 for binding in bindings {
@@ -143,6 +143,7 @@ impl<'a, 'i> TernaryLowerer<'a, 'i> {
                     args,
                     span: *span,
                     name_span: *name_span,
+                    target_struct: target_struct.clone(),
                 });
             }
             Statement::StructDestructure { bindings, expr, span } => {

--- a/silverscript-lang/src/compiler/validate_output_state.rs
+++ b/silverscript-lang/src/compiler/validate_output_state.rs
@@ -227,11 +227,12 @@ fn lower_statement<'i>(
                 name_span: *name_span,
             }])
         }
-        Statement::StateFunctionCallAssign { bindings, name, args, span, name_span } => {
+        Statement::StateFunctionCallAssign { target_struct, bindings, name, args, span, name_span } => {
             for binding in bindings {
                 scope.vars.insert(binding.name.clone(), binding.type_ref.clone());
             }
             Ok(vec![Statement::StateFunctionCallAssign {
+                target_struct: target_struct.clone(),
                 bindings: bindings.clone(),
                 name: name.clone(),
                 args: args.clone(),

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -7306,6 +7306,93 @@ fn runs_read_input_state_with_template_into_typed_struct_variable() {
 }
 
 #[test]
+fn typed_state_reader_disambiguates_the_implicit_state_layout() {
+    let source = r#"
+        contract Reader() {
+            struct RemoteState {
+                int n;
+            }
+
+            int n = 0;
+
+            entrypoint function main() {
+                RemoteState remote = readInputStateWithTemplate(
+                    1,
+                    0,
+                    0,
+                    0x0000000000000000000000000000000000000000000000000000000000000000
+                );
+                require(remote.n >= 0);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default())
+        .expect("the explicit RemoteState type should disambiguate the identical implicit State layout");
+}
+
+#[test]
+fn typed_state_reader_disambiguates_identical_custom_struct_layouts() {
+    let source = r#"
+        contract Reader() {
+            struct AState {
+                int n;
+            }
+
+            struct BState {
+                int n;
+            }
+
+            int tag = 0;
+
+            entrypoint function main() {
+                AState remote = readInputStateWithTemplate(
+                    1,
+                    0,
+                    0,
+                    0x0000000000000000000000000000000000000000000000000000000000000000
+                );
+                require(remote.n >= 0);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default())
+        .expect("the explicit AState type should disambiguate identical custom layouts");
+}
+
+#[test]
+fn untyped_state_reader_rejects_identical_custom_struct_layouts() {
+    let source = r#"
+        contract Reader() {
+            struct AState {
+                int n;
+            }
+
+            struct BState {
+                int n;
+            }
+
+            int tag = 0;
+
+            entrypoint function main() {
+                {n: int remoteN} = readInputStateWithTemplate(
+                    1,
+                    0,
+                    0,
+                    0x0000000000000000000000000000000000000000000000000000000000000000
+                );
+                require(remoteN >= 0);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default())
+        .expect_err("untyped destructuring cannot select between identical layouts");
+    assert!(err.to_string().contains("bindings match multiple struct layouts"), "unexpected ambiguity error: {err}");
+}
+
+#[test]
 fn runs_read_input_state_with_template_destructuring() {
     let target_hash_value = vec![0x55u8; 32];
     let target_hash_hex = target_hash_value.iter().map(|byte| format!("{byte:02x}")).collect::<String>();


### PR DESCRIPTION
## Summary

Preserve the declared target struct when lowering typed `readInputStateWithTemplate(...)` assignments.

Previously, struct lowering retained only the flattened field bindings. Static checking and code generation then inferred the target by searching for a matching layout, causing explicitly typed assignments to fail when multiple structs shared that layout.

Typed assignments now use their declared struct directly. Untyped destructuring continues to infer by layout and remains ambiguous when multiple layouts match.

## Tests

Added coverage for:

- A foreign struct matching implicit `State`.
- Two custom structs with identical layouts.
- Untyped destructuring remaining ambiguous.

Fixes https://github.com/kaspanet/silverscript/issues/179.