### PR TITLE
Support split/slice on non-byte array, and support struct comparison

### DIFF
--- a/silverscript-lang/src/compiler/compile/expression.rs
+++ b/silverscript-lang/src/compiler/compile/expression.rs
@@ -504,10 +504,20 @@ fn compile_slice_expr<'i>(
     start: &Expr<'i>,
     end: &Expr<'i>,
 ) -> Result<(), CompilerError> {
+    let source_type = infer_expr_type(source, ctx.env.constants, ctx.env.types)?;
+    let element_size = array_element_size(&source_type, ctx.env.contract_constants);
     let int_type = scalar_type(TypeBase::Int);
-    compile_expr_with_context(ctx, source, None)?;
+    compile_expr_with_context(ctx, source, Some(&source_type))?;
     compile_expr_with_context(ctx, start, Some(&int_type))?;
+    if let Some(element_size) = element_size.filter(|size| *size != 1) {
+        ctx.push_int(element_size)?;
+        ctx.emit_op(OpMul, -1)?;
+    }
     compile_expr_with_context(ctx, end, Some(&int_type))?;
+    if let Some(element_size) = element_size.filter(|size| *size != 1) {
+        ctx.push_int(element_size)?;
+        ctx.emit_op(OpMul, -1)?;
+    }
     ctx.emit_op(OpSubstr, -2)?;
     Ok(())
 }
@@ -609,18 +619,28 @@ fn compile_split_part<'i>(
     index: &Expr<'i>,
     part: SplitPart,
 ) -> Result<(), CompilerError> {
+    let source_type = infer_expr_type(source, ctx.env.constants, ctx.env.types)?;
+    let element_size = array_element_size(&source_type, ctx.env.contract_constants);
     let int_type = scalar_type(TypeBase::Int);
-    compile_expr_with_context(ctx, source, None)?;
+    compile_expr_with_context(ctx, source, Some(&source_type))?;
     match part {
         SplitPart::Left => {
             ctx.push_int(0)?;
             compile_expr_with_context(ctx, index, Some(&int_type))?;
+            if let Some(element_size) = element_size.filter(|size| *size != 1) {
+                ctx.push_int(element_size)?;
+                ctx.emit_op(OpMul, -1)?;
+            }
             ctx.emit_op(OpSubstr, -2)?;
             Ok(())
         }
         SplitPart::Right => {
             ctx.emit_op(OpSize, 1)?;
             compile_expr_with_context(ctx, index, Some(&int_type))?;
+            if let Some(element_size) = element_size.filter(|size| *size != 1) {
+                ctx.push_int(element_size)?;
+                ctx.emit_op(OpMul, -1)?;
+            }
             ctx.emit_op(OpSwap, 0)?;
             ctx.emit_op(OpSubstr, -2)?;
             Ok(())

--- a/silverscript-lang/src/compiler/structs.rs
+++ b/silverscript-lang/src/compiler/structs.rs
@@ -245,14 +245,41 @@ fn lower_expr<'i>(expr: &Expr<'i>, scope: &LoweringScope, structs: &StructRegist
         ExprKind::Unary { op, expr } => {
             Ok(Expr::new(ExprKind::Unary { op: *op, expr: Box::new(lower_expr(expr, scope, structs)?) }, span))
         }
-        ExprKind::Binary { op, left, right } => Ok(Expr::new(
-            ExprKind::Binary {
-                op: *op,
-                left: Box::new(lower_expr(left, scope, structs)?),
-                right: Box::new(lower_expr(right, scope, structs)?),
-            },
-            span,
-        )),
+        ExprKind::Binary { op, left, right } => {
+            if matches!(op, BinaryOp::Eq | BinaryOp::Ne)
+                && let ExprKind::Identifier(left_name) = &left.kind
+                && let Some(left_type) = scope.vars.get(left_name)
+                && is_struct_array(left_type, structs)
+            {
+                if let ExprKind::Identifier(right_name) = &right.kind
+                    && scope.vars.get(right_name).is_some_and(|right_type| right_type != left_type)
+                {
+                    return Err(CompilerError::Unsupported("struct array comparison requires matching types".to_string()));
+                }
+                let empty_constants = HashMap::new();
+                let left_leaves = lower_struct_array_value_expr(left, left_type, scope, structs, &[], &empty_constants, 0)?;
+                let right_leaves = lower_struct_array_value_expr(right, left_type, scope, structs, &[], &empty_constants, 0)?;
+                let comparison_op = *op;
+                let combination_op = if *op == BinaryOp::Eq { BinaryOp::And } else { BinaryOp::Or };
+                let comparisons = left_leaves.into_iter().zip(right_leaves).map(|(left, right)| {
+                    Expr::new(ExprKind::Binary { op: comparison_op, left: Box::new(left), right: Box::new(right) }, span)
+                });
+                return comparisons
+                    .reduce(|left, right| {
+                        Expr::new(ExprKind::Binary { op: combination_op, left: Box::new(left), right: Box::new(right) }, span)
+                    })
+                    .ok_or_else(|| CompilerError::Unsupported("cannot compare empty struct arrays".to_string()));
+            }
+
+            Ok(Expr::new(
+                ExprKind::Binary {
+                    op: *op,
+                    left: Box::new(lower_expr(left, scope, structs)?),
+                    right: Box::new(lower_expr(right, scope, structs)?),
+                },
+                span,
+            ))
+        }
         ExprKind::Append { source, args, span: append_span } => Ok(Expr::new(
             ExprKind::Append {
                 source: Box::new(lower_expr(source, scope, structs)?),
@@ -762,6 +789,54 @@ fn lower_struct_array_value_expr<'i>(
                     Expr::new(
                         ExprKind::Binary { op: BinaryOp::Add, left: Box::new(left), right: Box::new(right) },
                         span::Span::default(),
+                    )
+                })
+                .collect())
+        }
+        ExprKind::Split { source, index, part, span } => {
+            let sources = lower_struct_array_value_expr(
+                source,
+                expected_type,
+                scope,
+                structs,
+                contract_fields,
+                contract_constants,
+                contract_fields_end_offset,
+            )?;
+            let index = lower_expr(index, scope, structs)?;
+            Ok(sources
+                .into_iter()
+                .map(|source| {
+                    Expr::new(
+                        ExprKind::Split { source: Box::new(source), index: Box::new(index.clone()), part: *part, span: *span },
+                        expr.span,
+                    )
+                })
+                .collect())
+        }
+        ExprKind::Slice { source, start, end, span } => {
+            let sources = lower_struct_array_value_expr(
+                source,
+                expected_type,
+                scope,
+                structs,
+                contract_fields,
+                contract_constants,
+                contract_fields_end_offset,
+            )?;
+            let start = lower_expr(start, scope, structs)?;
+            let end = lower_expr(end, scope, structs)?;
+            Ok(sources
+                .into_iter()
+                .map(|source| {
+                    Expr::new(
+                        ExprKind::Slice {
+                            source: Box::new(source),
+                            start: Box::new(start.clone()),
+                            end: Box::new(end.clone()),
+                            span: *span,
+                        },
+                        expr.span,
                     )
                 })
                 .collect())

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -422,7 +422,7 @@ fn dynamic_array_of(type_ref: &TypeRef) -> Result<TypeRef, CompilerError> {
 }
 
 fn sequence_part_type(type_ref: &TypeRef, operation: &str) -> Result<TypeRef, CompilerError> {
-    if type_ref.array_element_type().is_some_and(|element_type| element_type.is_byte()) {
+    if type_ref.is_array() {
         return dynamic_array_of(type_ref);
     }
     if type_ref.is_string() {
@@ -431,7 +431,7 @@ fn sequence_part_type(type_ref: &TypeRef, operation: &str) -> Result<TypeRef, Co
     if !type_ref.is_array() && type_ref.base.fixed_byte_sequence_len().is_some() {
         return Ok(TypeRef { base: TypeBase::Byte, array_dims: vec![ArrayDim::Dynamic] });
     }
-    Err(CompilerError::Unsupported(format!("{operation} source must be a byte array, string, or fixed-byte type")))
+    Err(CompilerError::Unsupported(format!("{operation} source must be an array, string, or fixed-byte type")))
 }
 
 fn check_constructor<'i>(name: &str, args: &[Expr<'i>], ctx: &TypeCheckContext<'_, 'i>) -> Result<TypeRef, CompilerError> {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -11500,31 +11500,138 @@ fn runs_standalone_block_tuple_binding_shadowing() {
 }
 
 #[test]
-fn rejects_split_on_non_byte_array() {
+fn runs_split_on_non_byte_array() {
     let source = r#"
         contract SplitNonByteArray() {
-            entry main(int[] values) {
+            entry main() {
+                int[] values = [10, 20, 30, 40];
                 (int[] left, int[] right) = values.split(1);
+                require(left == [10]);
+                require(right == [20, 30, 40]);
             }
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("split on int[] should fail");
-    assert!(err.to_string().contains("split source must be a byte array, string, or fixed-byte type"), "unexpected error: {err}");
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("split on int[] should compile");
+    let selector = selector_for(&compiled, "main");
+    let result = run_script_with_selector(compiled.script, selector);
+    assert!(result.is_ok(), "split on int[] should execute successfully: {}", result.unwrap_err());
 }
 
 #[test]
-fn rejects_slice_on_non_byte_array() {
+fn runs_slice_on_non_byte_array() {
     let source = r#"
         contract SliceNonByteArray() {
-            entry main(int[] values) {
-                int[] part = values.slice(0, 1);
+            entry main() {
+                int[] values = [10, 20, 30, 40];
+                int[] part = values.slice(1, 3);
+                require(part == [20, 30]);
             }
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("slice on int[] should fail");
-    assert!(err.to_string().contains("slice source must be a byte array, string, or fixed-byte type"), "unexpected error: {err}");
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("slice on int[] should compile");
+    let selector = selector_for(&compiled, "main");
+    let result = run_script_with_selector(compiled.script, selector);
+    assert!(result.is_ok(), "slice on int[] should execute successfully: {}", result.unwrap_err());
+}
+
+#[test]
+fn runs_split_and_slice_on_struct_array() {
+    let source = r#"
+        contract StructArraySequenceOperations() {
+            struct S {
+                int number;
+                byte[2] tag;
+            }
+
+            entry main() {
+                S[] values = [
+                    {number: 10, tag: 0x0102},
+                    {number: 20, tag: 0x0304},
+                    {number: 30, tag: 0x0506}
+                ];
+                S[] left = values.split(1).0;
+                S[] right = values.split(1).1;
+                S[] part = values.slice(1, 3);
+
+                require(left == [{number: 10, tag: 0x0102}]);
+                require(right == [
+                    {number: 20, tag: 0x0304},
+                    {number: 30, tag: 0x0506}
+                ]);
+                require(part == [
+                    {number: 20, tag: 0x0304},
+                    {number: 30, tag: 0x0506}
+                ]);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("struct array sequence operations should compile");
+    let selector = selector_for(&compiled, "main");
+    let result = run_script_with_selector(compiled.script, selector);
+    assert!(result.is_ok(), "struct array sequence operations should execute successfully: {}", result.unwrap_err());
+}
+
+#[test]
+fn runs_struct_array_equality_and_inequality_comparisons() {
+    let source = r#"
+        contract StructArrayComparisons() {
+            struct Details {
+                bool active;
+                int score;
+            }
+
+            struct Item {
+                int id;
+                byte[2] tag;
+                Details details;
+            }
+
+            entry main() {
+                Item[] values = [
+                    {id: 1, tag: 0x0102, details: {active: true, score: 10}},
+                    {id: 2, tag: 0x0304, details: {active: false, score: 20}}
+                ];
+                Item[] same = [
+                    {id: 1, tag: 0x0102, details: {active: true, score: 10}},
+                    {id: 2, tag: 0x0304, details: {active: false, score: 20}}
+                ];
+                Item[] differentId = [
+                    {id: 1, tag: 0x0102, details: {active: true, score: 10}},
+                    {id: 3, tag: 0x0304, details: {active: false, score: 20}}
+                ];
+                Item[] differentTag = [
+                    {id: 1, tag: 0x0102, details: {active: true, score: 10}},
+                    {id: 2, tag: 0x0506, details: {active: false, score: 20}}
+                ];
+                Item[] differentNestedField = [
+                    {id: 1, tag: 0x0102, details: {active: true, score: 10}},
+                    {id: 2, tag: 0x0304, details: {active: true, score: 20}}
+                ];
+                Item[] shorter = [
+                    {id: 1, tag: 0x0102, details: {active: true, score: 10}}
+                ];
+                Item[] empty;
+
+                require(values == same);
+                require(!(values != same));
+                require(values != differentId);
+                require(values != differentTag);
+                require(values != differentNestedField);
+                require(values != shorter);
+                require(!(values == differentId));
+                require(empty == []);
+                require(empty != values);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("struct array comparisons should compile");
+    let selector = selector_for(&compiled, "main");
+    let result = run_script_with_selector(compiled.script, selector);
+    assert!(result.is_ok(), "struct array comparisons should execute successfully: {}", result.unwrap_err());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #156 

  Extend array sequence operations beyond byte arrays. `split` and `slice` now work with any supported array element type, using element-based indices.

  Struct arrays can also be split, sliced, and compared using `==` or `!=`.

  ## Language Behavior Changes

  - `split` and `slice` now support arrays such as `int[]`.

  ```silverscript
  int[] values = [10, 20, 30, 40];

  (int[] left, int[] right) = values.split(1);
  int[] middle = values.slice(1, 3);

  require(left == [10]);
  require(right == [20, 30, 40]);
  require(middle == [20, 30]);
  ```

  - Array indices remain element-based, regardless of the serialized size of each element.

  - Struct arrays support `split` and `slice` while preserving complete struct elements.

  ```silverscript
  struct Item {
      int id;
      byte[2] tag;
  }

  Item[] values = [
      {id: 1, tag: 0x0102},
      {id: 2, tag: 0x0304},
      {id: 3, tag: 0x0506}
  ];

  Item[] left = values.split(1).0;
  Item[] remaining = values.split(1).1;
  Item[] middle = values.slice(1, 3);
  ```

  - Struct arrays can be compared with matching arrays or struct-array literals using `==` and `!=`. Comparisons include every field, nested struct fields, and array length.

  ```silverscript
  require(left == [{id: 1, tag: 0x0102}]);
  require(remaining == [
      {id: 2, tag: 0x0304},
      {id: 3, tag: 0x0506}
  ]);
  require(left != remaining);
  ```
