### PR TITLE
Rename the compilation result from `script` to `bytecode`

### DIFF
--- a/debugger/cli/README.md
+++ b/debugger/cli/README.md
@@ -39,7 +39,7 @@ contract Counter(int threshold) {
 When the session starts, you'll see your source context and the `(sdb)` prompt:
 
 ```text
-Stepping through 42 bytes of script
+Stepping through 42 bytes of bytecode
      1 | pragma silverscript ^0.1.0;
      2 | 
      3 | contract Counter(int threshold) {
@@ -101,7 +101,7 @@ Run `.test.json` suites non-interactively to verify logic in bulk. If you pass a
 }
 ```
 
-The debugger will report `PASS` if the script result matches your `expect` field (either `pass` or `fail`).
+The debugger will report `PASS` if the bytecode result matches your `expect` field (either `pass` or `fail`).
 
 Structured args use the same JSON object and object-array form inside `.test.json`:
 
@@ -192,7 +192,7 @@ Add `--test-file <path>` to either form to use an explicit test file instead of 
 ```text
   PASS  valid_transfer
   FAIL  insufficient_funds
-        FAIL: expected failure but script passed
+        FAIL: expected failure but bytecode passed
 
 10 tests: 9 passed, 1 failed
 ```

--- a/debugger/cli/src/main.rs
+++ b/debugger/cli/src/main.rs
@@ -52,19 +52,19 @@ struct CliArgs {
     raw_args: Vec<String>,
 }
 
-fn compile_script_for_ctor_args(
+fn compile_bytecode_for_ctor_args(
     source: &str,
     parsed_contract: &ContractAst<'_>,
     raw_ctor_args: &[String],
     cache: &mut HashMap<Vec<String>, Vec<u8>>,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    if let Some(script) = cache.get(raw_ctor_args) {
-        return Ok(script.clone());
+    if let Some(bytecode) = cache.get(raw_ctor_args) {
+        return Ok(bytecode.clone());
     }
     let ctor_args = parse_ctor_args(parsed_contract, raw_ctor_args)?;
     let compiled = compile_contract(source, &ctor_args, CompileOptions { record_debug_infos: true, ..Default::default() })?;
-    cache.insert(raw_ctor_args.to_vec(), compiled.script.clone());
-    Ok(compiled.script)
+    cache.insert(raw_ctor_args.to_vec(), compiled.bytecode.clone());
+    Ok(compiled.bytecode)
 }
 
 fn compile_contract_for_raw_ctor_args<'i>(
@@ -253,7 +253,7 @@ fn resolve_state_from_raw(
     Ok(value)
 }
 
-fn materialize_script_for_explicit_state(
+fn materialize_bytecode_for_explicit_state(
     source: &str,
     parsed_contract: &ContractAst<'_>,
     raw_instance_args: &[String],
@@ -271,20 +271,20 @@ fn materialize_script_for_explicit_state(
     let materialized_start = materialized.state_layout.start;
     let materialized_end = materialized_start + materialized.state_layout.len;
     if base_compiled.state_layout.len != materialized.state_layout.len {
-        return Err("explicit state changes encoded script size; provide raw script_hex instead".into());
+        return Err("explicit state changes encoded bytecode size; provide raw script_hex instead".into());
     }
-    if base_compiled.script.len() < base_end || materialized.script.len() < materialized_end {
-        return Err("state layout exceeds compiled script length".into());
+    if base_compiled.bytecode.len() < base_end || materialized.bytecode.len() < materialized_end {
+        return Err("state layout exceeds compiled bytecode length".into());
     }
-    if base_compiled.script[..base_start] != materialized.script[..materialized_start]
-        || base_compiled.script[base_end..] != materialized.script[materialized_end..]
+    if base_compiled.bytecode[..base_start] != materialized.bytecode[..materialized_start]
+        || base_compiled.bytecode[base_end..] != materialized.bytecode[materialized_end..]
     {
         return Err("explicit state changed non-state bytecode; provide raw script_hex instead".into());
     }
 
-    let mut script = base_compiled.script;
-    script[base_start..base_end].copy_from_slice(&materialized.script[materialized_start..materialized_end]);
-    Ok(script)
+    let mut bytecode = base_compiled.bytecode;
+    bytecode[base_start..base_end].copy_from_slice(&materialized.bytecode[materialized_start..materialized_end]);
+    Ok(bytecode)
 }
 
 fn contract_with_explicit_state<'i>(contract: &ContractAst<'i>, state: &Expr<'i>) -> Result<ContractAst<'i>, String> {
@@ -337,10 +337,10 @@ fn build_p2pk_script(pubkey: &[u8]) -> Vec<u8> {
         .drain()
 }
 
-fn sigscript_push_script(script: &[u8]) -> Vec<u8> {
+fn sigscript_push_bytecode(bytecode: &[u8]) -> Vec<u8> {
     ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() })
-        .add_data(script)
-        .expect("push script data")
+        .add_data(bytecode)
+        .expect("push bytecode data")
         .drain()
 }
 
@@ -724,10 +724,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let compile_opts = CompileOptions { record_debug_infos: true, ..Default::default() };
     let compiled = compile_contract(&source, &ctor_args, compile_opts)?;
     let debug_info = compiled.debug_info.clone();
-    let mut ctor_script_cache = HashMap::<Vec<String>, Vec<u8>>::new();
+    let mut ctor_bytecode_cache = HashMap::<Vec<String>, Vec<u8>>::new();
     let mut ctor_state_cache = HashMap::<Vec<String>, DebugValue>::new();
     let mut explicit_state_cache = HashMap::<String, DebugValue>::new();
-    ctor_script_cache.insert(raw_ctor_args.clone(), compiled.script.clone());
+    ctor_bytecode_cache.insert(raw_ctor_args.clone(), compiled.bytecode.clone());
     if !parsed_contract.fields.is_empty() {
         let root_state = resolve_state_for_ctor_args(&parsed_contract, &raw_ctor_args, &mut ctor_state_cache)?;
         ctor_state_cache.insert(raw_ctor_args.clone(), root_state);
@@ -770,9 +770,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
         let redeem_script = if input.utxo_script_hex.is_none() {
             if let Some(raw_state) = input.state.as_deref() {
-                Some(materialize_script_for_explicit_state(&source, &parsed_contract, &input_ctor_raw, raw_state)?)
+                Some(materialize_bytecode_for_explicit_state(&source, &parsed_contract, &input_ctor_raw, raw_state)?)
             } else {
-                Some(compile_script_for_ctor_args(&source, &parsed_contract, &input_ctor_raw, &mut ctor_script_cache)?)
+                Some(compile_bytecode_for_ctor_args(&source, &parsed_contract, &input_ctor_raw, &mut ctor_bytecode_cache)?)
             }
         } else {
             None
@@ -816,12 +816,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let p2pk_script = build_p2pk_script(&pubkey_bytes);
             ScriptPublicKey::new(0, p2pk_script.into())
         } else {
-            let output_script = if let Some(raw_state) = output.state.as_deref() {
-                materialize_script_for_explicit_state(&source, &parsed_contract, &output_ctor_raw, raw_state)?
+            let output_bytecode = if let Some(raw_state) = output.state.as_deref() {
+                materialize_bytecode_for_explicit_state(&source, &parsed_contract, &output_ctor_raw, raw_state)?
             } else {
-                compile_script_for_ctor_args(&source, &parsed_contract, &output_ctor_raw, &mut ctor_script_cache)?
+                compile_bytecode_for_ctor_args(&source, &parsed_contract, &output_ctor_raw, &mut ctor_bytecode_cache)?
             };
-            pay_to_script_hash_script(&output_script)
+            pay_to_script_hash_script(&output_bytecode)
         };
 
         let covenant = if let Some(raw) = output.covenant_id.as_deref() {
@@ -917,7 +917,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             )?;
             combine_action_and_redeem(&auto_action, input_redeem_scripts[input_idx].as_ref().expect("checked is_some above"))?
         } else if let Some(redeem) = input_redeem_scripts[input_idx].as_ref() {
-            sigscript_push_script(redeem)
+            sigscript_push_bytecode(redeem)
         } else {
             vec![]
         };
@@ -949,7 +949,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         populated_tx.utxo(tx.active_input_index).ok_or_else(|| format!("missing utxo entry for input {}", tx.active_input_index))?;
     let active_covenant_input_state = input_covenant_states.get(tx.active_input_index).cloned().flatten();
     let active_lockscript =
-        input_redeem_scripts.get(tx.active_input_index).cloned().flatten().unwrap_or_else(|| compiled.script.clone());
+        input_redeem_scripts.get(tx.active_input_index).cloned().flatten().unwrap_or_else(|| compiled.bytecode.clone());
     let covenant_input_states = active_utxo.covenant_id.and_then(|covenant_id| {
         let mut values = Vec::new();
         for (input_covenant_id, covenant_input_state) in input_covenant_ids.iter().zip(input_covenant_states.iter()) {
@@ -984,7 +984,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         match session.run_to_completion() {
             Ok(()) if expect_fail => {
                 print_console_messages(&session.take_console_output());
-                eprintln!("FAIL: expected failure but script passed");
+                eprintln!("FAIL: expected failure but bytecode passed");
                 Err("FAIL".into())
             }
             Ok(()) => {
@@ -1002,7 +1002,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     } else {
-        println!("Stepping through {} bytes of script", compiled.script.len());
+        println!("Stepping through {} bytes of bytecode", compiled.bytecode.len());
         session.run_to_first_executed_statement()?;
         let mut pending_console_output = session.take_console_output();
         let console_output = Vec::new();

--- a/debugger/session/src/presentation.rs
+++ b/debugger/session/src/presentation.rs
@@ -81,7 +81,7 @@ fn unavailable_reason(reason: &str) -> String {
         || reason.contains("__arg_")
     {
         "<unavailable: depends on inlined function call internals>".to_string()
-    } else if reason.contains("failed to execute shadow script") {
+    } else if reason.contains("failed to execute shadow bytecode") {
         "<unavailable: runtime evaluation failed>".to_string()
     } else {
         format!("<unavailable: {}>", concise_reason(reason))

--- a/debugger/session/src/session.rs
+++ b/debugger/session/src/session.rs
@@ -135,7 +135,7 @@ pub struct DebugSession<'a, 'i> {
     opcodes: Vec<Option<DebugOpcode<'a>>>,
     op_displays: Vec<String>,
     opcode_offsets: Vec<usize>,
-    script_len: usize,
+    bytecode_len: usize,
     pc: usize,
     debug_info: DebugInfo<'i>,
     contract_ast: Option<ContractAst<'i>>,
@@ -197,21 +197,21 @@ impl<'a, 'i> DebugSession<'a, 'i> {
     // --- Session construction + stepping ---
 
     /// Creates a debug session simulating a full transaction spend.
-    /// Executes sigscript first to seed the stack, then debugs lockscript execution.
+    /// Executes sigscript first to seed the stack, then debugs the compiled bytecode.
     pub fn full(
         sigscript: &[u8],
-        lockscript: &[u8],
+        bytecode: &[u8],
         source: &'i str,
         debug_info: Option<DebugInfo<'i>>,
         mut engine: DebugEngine<'a>,
     ) -> Result<Self, kaspa_txscript_errors::TxScriptError> {
         seed_engine_with_sigscript(&mut engine, sigscript)?;
-        Self::from_scripts(lockscript, source, debug_info, engine)
+        Self::from_bytecode(bytecode, source, debug_info, engine)
     }
 
-    /// Internal constructor: parses script, prepares opcodes, extracts statement steps.
-    pub fn from_scripts(
-        script: &[u8],
+    /// Internal constructor: parses bytecode, prepares opcodes, extracts statement steps.
+    pub fn from_bytecode(
+        bytecode: &[u8],
         source: &'i str,
         debug_info: Option<DebugInfo<'i>>,
         engine: DebugEngine<'a>,
@@ -222,11 +222,11 @@ impl<'a, 'i> DebugSession<'a, 'i> {
             .as_ref()
             .map(|contract| contract.functions.iter().map(|function| (function.name.clone(), function.params.len())).collect())
             .unwrap_or_default();
-        let opcodes = parse_script::<DebugTx<'a>, DebugReused>(script).collect::<Result<Vec<_>, _>>()?;
+        let opcodes = parse_script::<DebugTx<'a>, DebugReused>(bytecode).collect::<Result<Vec<_>, _>>()?;
         let op_displays = opcodes.iter().map(|op| format!("{op:?}")).collect();
         let opcodes: Vec<Option<DebugOpcode<'a>>> = opcodes.into_iter().map(Some).collect();
         let source_lines: Vec<String> = source.lines().map(String::from).collect();
-        let (opcode_offsets, script_len) = build_opcode_offsets(&opcodes);
+        let (opcode_offsets, bytecode_len) = build_opcode_offsets(&opcodes);
 
         let mut step_order: Vec<usize> = (0..debug_info.steps.len()).collect();
         // Overlapping inline ranges can share the same bytecode offsets; keep
@@ -242,7 +242,7 @@ impl<'a, 'i> DebugSession<'a, 'i> {
             opcodes,
             op_displays,
             opcode_offsets,
-            script_len,
+            bytecode_len,
             pc: 0,
             debug_info,
             contract_ast,
@@ -559,9 +559,9 @@ impl<'a, 'i> DebugSession<'a, 'i> {
         self.current_timeline_step().cloned().or_else(|| self.step_for_offset(self.current_byte_offset()).cloned())
     }
 
-    /// Returns the current bytecode offset in the script.
+    /// Returns the current offset in the bytecode.
     pub fn current_byte_offset(&self) -> usize {
-        self.opcode_offsets.get(self.pc).copied().unwrap_or(self.script_len)
+        self.opcode_offsets.get(self.pc).copied().unwrap_or(self.bytecode_len)
     }
 
     /// Returns the source span (line/col range) at the current position.
@@ -1559,9 +1559,9 @@ impl<'a, 'i> DebugSession<'a, 'i> {
             .enumerate()
             .map(|(index, display)| OpcodeMeta {
                 index,
-                byte_offset: self.opcode_offsets.get(index).copied().unwrap_or(self.script_len),
+                byte_offset: self.opcode_offsets.get(index).copied().unwrap_or(self.bytecode_len),
                 display: display.clone(),
-                step: self.step_for_offset(self.opcode_offsets.get(index).copied().unwrap_or(self.script_len)).cloned(),
+                step: self.step_for_offset(self.opcode_offsets.get(index).copied().unwrap_or(self.bytecode_len)).cloned(),
             })
             .collect()
     }
@@ -1618,8 +1618,8 @@ impl<'a, 'i> DebugSession<'a, 'i> {
         let prepared_expr = lower_expr_for_eval(expr, scope_state)?;
         let (bytecode, _) = compile_debug_expr(&prepared_expr, &env, &stack_bindings, &eval_types)
             .map_err(|err| format!("failed to compile debug expression: {err}"))?;
-        let script = self.build_shadow_script(&shadow_bindings, &bytecode)?;
-        let bytes = self.execute_shadow_script(&script)?;
+        let shadow_bytecode = self.build_shadow_bytecode(&shadow_bindings, &bytecode)?;
+        let bytes = self.execute_shadow_bytecode(&shadow_bytecode)?;
         decode_value_by_type(type_name, bytes)
     }
 
@@ -1639,8 +1639,8 @@ impl<'a, 'i> DebugSession<'a, 'i> {
         let prepared_expr = lower_expr_for_eval(expr, scope_state)?;
         let (bytecode, type_name) = compile_debug_expr(&prepared_expr, &env, &stack_bindings, &eval_types)
             .map_err(|err| format!("failed to compile debug expression: {err}"))?;
-        let script = self.build_shadow_script(&shadow_bindings, &bytecode)?;
-        let bytes = self.execute_shadow_script(&script)?;
+        let shadow_bytecode = self.build_shadow_bytecode(&shadow_bindings, &bytecode)?;
+        let bytes = self.execute_shadow_bytecode(&shadow_bytecode)?;
         let value = decode_value_by_type(&type_name, bytes)?;
         Ok((type_name, value))
     }
@@ -1680,7 +1680,7 @@ impl<'a, 'i> DebugSession<'a, 'i> {
         Ok((shadow_bindings, env, stack_bindings, eval_types))
     }
 
-    fn build_shadow_script(&self, bindings: &[ShadowBindingValue], expr_bytecode: &[u8]) -> Result<Vec<u8>, String> {
+    fn build_shadow_bytecode(&self, bindings: &[ShadowBindingValue], expr_bytecode: &[u8]) -> Result<Vec<u8>, String> {
         let mut builder = ScriptBuilder::new();
         for binding in bindings {
             builder.add_data(&binding.value).map_err(|err| err.to_string())?;
@@ -1689,7 +1689,7 @@ impl<'a, 'i> DebugSession<'a, 'i> {
         Ok(builder.drain())
     }
 
-    fn execute_shadow_script(&self, script: &[u8]) -> Result<Vec<u8>, String> {
+    fn execute_shadow_bytecode(&self, bytecode: &[u8]) -> Result<Vec<u8>, String> {
         let sig_cache = Cache::new(0);
         let reused_values = SigHashReusedValuesUnsync::new();
         let mut engine: DebugEngine<'_> = if let Some(shadow) = self.shadow_tx_context {
@@ -1708,9 +1708,9 @@ impl<'a, 'i> DebugSession<'a, 'i> {
                 EngineFlags { covenants_enabled: true, ..Default::default() },
             )
         };
-        for opcode in parse_script::<DebugTx<'_>, DebugReused>(script) {
-            let opcode = opcode.map_err(|err| format!("failed to parse shadow script: {err}"))?;
-            engine.execute_opcode(opcode).map_err(|err| format!("failed to execute shadow script: {err}"))?;
+        for opcode in parse_script::<DebugTx<'_>, DebugReused>(bytecode) {
+            let opcode = opcode.map_err(|err| format!("failed to parse shadow bytecode: {err}"))?;
+            engine.execute_opcode(opcode).map_err(|err| format!("failed to execute shadow bytecode: {err}"))?;
         }
         engine.stacks().dstack.last().cloned().map(|item| item.to_vec()).ok_or_else(|| "shadow VM produced an empty stack".to_string())
     }
@@ -2102,7 +2102,7 @@ fn flatten_contract_type_leaves<'i>(contract: &ContractAst<'i>, type_ref: &TypeR
     Ok(leaves)
 }
 
-/// Executes sigscript to seed the stack before debugging lockscript.
+/// Executes sigscript to seed the stack before debugging bytecode.
 fn seed_engine_with_sigscript(engine: &mut DebugEngine<'_>, sigscript: &[u8]) -> Result<(), kaspa_txscript_errors::TxScriptError> {
     for opcode in parse_script::<DebugTx<'_>, DebugReused>(sigscript) {
         engine.execute_opcode(opcode?)?;

--- a/debugger/session/tests/debug_session_tests.rs
+++ b/debugger/session/tests/debug_session_tests.rs
@@ -90,9 +90,9 @@ where
 
     assert_eq!(entry.inputs.len(), function_args.len());
 
-    // Seed stack with sigscript args and then execute the lockscript in debug mode.
+    // Seed the stack with sigscript arguments, then execute the bytecode in debug mode.
     let sigscript = compiled.build_sig_script(function_name, function_args)?;
-    let mut session = DebugSession::full(&sigscript, &compiled.script, source, debug_info, engine)?;
+    let mut session = DebugSession::full(&sigscript, &compiled.bytecode, source, debug_info, engine)?;
 
     f(&mut session)
 }
@@ -1087,7 +1087,7 @@ contract MissingStructuredSource() {
     let ctx = EngineCtx::new(&sig_cache).with_reused(&reused_values);
     let engine = debugger_session::session::DebugEngine::new(ctx, EngineFlags { covenants_enabled: true, ..Default::default() });
     let sigscript = compiled.build_sig_script("inspect", vec![struct_object("State", vec![("amount", Expr::int(7))])])?;
-    let mut session = DebugSession::full(&sigscript, &compiled.script, "", Some(debug_info), engine)?;
+    let mut session = DebugSession::full(&sigscript, &compiled.bytecode, "", Some(debug_info), engine)?;
 
     session.run_to_first_executed_statement()?;
     let (type_name, value) = session.evaluate_expression("next.amount")?;
@@ -1652,7 +1652,7 @@ contract CovLocal() {
 
     let covenant_id = Hash::from_bytes([0x11u8; 32]);
     let utxo_entry =
-        UtxoEntry::new(1000, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), Some(covenant_id));
+        UtxoEntry::new(1000, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), Some(covenant_id));
     let populated_tx = PopulatedTransaction::new(&tx, vec![utxo_entry]);
     let cov_ctx = CovenantsContext::from_tx(&populated_tx)?;
 
@@ -1672,7 +1672,8 @@ contract CovLocal() {
     let shadow_ctx =
         ShadowTxContext { tx: &populated_tx, input: input_ref, input_index: 0, utxo_entry: utxo_ref, covenants_ctx: &cov_ctx };
 
-    let mut session = DebugSession::full(&sigscript, &compiled.script, source, debug_info, engine)?.with_shadow_tx_context(shadow_ctx);
+    let mut session =
+        DebugSession::full(&sigscript, &compiled.bytecode, source, debug_info, engine)?.with_shadow_tx_context(shadow_ctx);
     session.run_to_first_executed_statement()?;
 
     for _ in 0..4 {
@@ -1716,7 +1717,7 @@ contract CovEval() {
 
     let covenant_id = Hash::from_bytes([0x22u8; 32]);
     let utxo_entry =
-        UtxoEntry::new(1000, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), Some(covenant_id));
+        UtxoEntry::new(1000, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), Some(covenant_id));
     let populated_tx = PopulatedTransaction::new(&tx, vec![utxo_entry]);
     let cov_ctx = CovenantsContext::from_tx(&populated_tx)?;
 
@@ -1737,7 +1738,8 @@ contract CovEval() {
     let shadow_ctx =
         ShadowTxContext { tx: &populated_tx, input: input_ref, input_index: 0, utxo_entry: utxo_ref, covenants_ctx: &cov_ctx };
 
-    let mut session = DebugSession::full(&sigscript, &compiled.script, source, debug_info, engine)?.with_shadow_tx_context(shadow_ctx);
+    let mut session =
+        DebugSession::full(&sigscript, &compiled.bytecode, source, debug_info, engine)?.with_shadow_tx_context(shadow_ctx);
     session.run_to_first_executed_statement()?;
 
     let (type_name, value) = session.evaluate_expression("OpInputCovenantId(this.activeInputIndex)")?;
@@ -1750,8 +1752,8 @@ fn covenant_debug_value(value: i64) -> DebugValue {
     DebugValue::Object(vec![("value".to_string(), DebugValue::Int(value))])
 }
 
-fn push_redeem_script(script: &[u8]) -> Vec<u8> {
-    ScriptBuilder::new().add_data(script).expect("push redeem script").drain()
+fn push_redeem_script(bytecode: &[u8]) -> Vec<u8> {
+    ScriptBuilder::new().add_data(bytecode).expect("push redeem script").drain()
 }
 
 fn with_cov_rebalance_session<F>(mut f: F) -> Result<(), Box<dyn Error>>
@@ -1785,10 +1787,10 @@ contract CovDebugDemo(int initial_value) {
         resolve_covenant_call_target(&parsed_contract, &compiled0, "rebalance").ok_or("missing covenant call target")?;
     let leader_sigscript = compiled0.build_sig_script(&leader_target.generated_entrypoint_name, leader_args)?;
     let mut leader_input_sigscript = leader_sigscript.clone();
-    leader_input_sigscript.extend_from_slice(&push_redeem_script(&compiled0.script));
+    leader_input_sigscript.extend_from_slice(&push_redeem_script(&compiled0.bytecode));
     let delegate_sigscript = compiled1.build_sig_script(&leader_target.generated_entrypoint_name_for(false), vec![])?;
     let mut delegate_input_sigscript = delegate_sigscript.clone();
-    delegate_input_sigscript.extend_from_slice(&push_redeem_script(&compiled1.script));
+    delegate_input_sigscript.extend_from_slice(&push_redeem_script(&compiled1.bytecode));
 
     let covenant_id = Hash::from_bytes([0x33u8; 32]);
     let inputs = vec![
@@ -1810,20 +1812,20 @@ contract CovDebugDemo(int initial_value) {
     let outputs = vec![
         TransactionOutput {
             value: 1000,
-            script_public_key: pay_to_script_hash_script(&next0.script),
+            script_public_key: pay_to_script_hash_script(&next0.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id }),
         },
         TransactionOutput {
             value: 1000,
-            script_public_key: pay_to_script_hash_script(&next1.script),
+            script_public_key: pay_to_script_hash_script(&next1.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id }),
         },
     ];
     let tx = Transaction::new(1, inputs, outputs, 0, Default::default(), 0, vec![]);
 
     let utxos = vec![
-        UtxoEntry::new(1000, pay_to_script_hash_script(&compiled0.script), 0, tx.is_coinbase(), Some(covenant_id)),
-        UtxoEntry::new(1000, pay_to_script_hash_script(&compiled1.script), 0, tx.is_coinbase(), Some(covenant_id)),
+        UtxoEntry::new(1000, pay_to_script_hash_script(&compiled0.bytecode), 0, tx.is_coinbase(), Some(covenant_id)),
+        UtxoEntry::new(1000, pay_to_script_hash_script(&compiled1.bytecode), 0, tx.is_coinbase(), Some(covenant_id)),
     ];
     let populated_tx = PopulatedTransaction::new(&tx, utxos);
     let cov_ctx = CovenantsContext::from_tx(&populated_tx)?;
@@ -1845,7 +1847,7 @@ contract CovDebugDemo(int initial_value) {
     let shadow_ctx =
         ShadowTxContext { tx: &populated_tx, input: input_ref, input_index: 0, utxo_entry: utxo_ref, covenants_ctx: &cov_ctx };
 
-    let mut session = DebugSession::full(&leader_sigscript, &compiled0.script, source, compiled0.debug_info.clone(), engine)?
+    let mut session = DebugSession::full(&leader_sigscript, &compiled0.bytecode, source, compiled0.debug_info.clone(), engine)?
         .with_shadow_tx_context(shadow_ctx)
         .with_covenant_mode(Some(DebugValue::Array(vec![covenant_debug_value(10), covenant_debug_value(20)])), Some(leader_target));
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -102,7 +102,7 @@ The `args.json` file should contain an array of constructor argument expressions
 The compiled JSON output includes:
 - `contract_name`: The name of the contract
 - `compiler_version`: The SilverScript compiler version that produced the artifact
-- `script`: The compiled bytecode (as an array of bytes)
+- `bytecode`: The compiled bytecode (as an array of bytes)
 - `ast`: The abstract syntax tree of the parsed contract
 - `abi`: An array of entries with their parameter types
 
@@ -134,7 +134,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     println!("Contract name: {}", compiled.contract_name);
     println!("Compiler version: {}", compiled.compiler_version);
-    println!("Script length: {} bytes", compiled.script.len());
+    println!("Bytecode length: {} bytes", compiled.bytecode.len());
     println!("ABI: {:?}", compiled.abi);
     
     Ok(())

--- a/docs/kcc20-book/src/scenarios.md
+++ b/docs/kcc20-book/src/scenarios.md
@@ -30,7 +30,7 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
 
     let handoff_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&handoff.script),
+        script_public_key: pay_to_script_hash_script(&handoff.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let handoff_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -72,12 +72,12 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
     let split_outputs = vec![
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_a.script),
+            script_public_key: pay_to_script_hash_script(&split_a.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_b.script),
+            script_public_key: pay_to_script_hash_script(&split_b.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -123,12 +123,12 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
     let merged = compile_kcc20_state(&source, merged_owner_bytes.clone(), 1_000, 2, 2);
     let merge_outputs = vec![TransactionOutput {
         value: 2_000,
-        script_public_key: pay_to_script_hash_script(&merged.script),
+        script_public_key: pay_to_script_hash_script(&merged.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let merge_entries = vec![
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_a.script), 0, split_tx.is_coinbase(), Some(COV_A)),
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_b.script), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&split_a.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&split_b.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
     ];
     let merge_unsigned_tx = Transaction::new(
         1,
@@ -222,7 +222,7 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
 
     let handoff_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&handoff.script),
+        script_public_key: pay_to_script_hash_script(&handoff.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let handoff_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -264,12 +264,12 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
     let split_outputs = vec![
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_a.script),
+            script_public_key: pay_to_script_hash_script(&split_a.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_b.script),
+            script_public_key: pay_to_script_hash_script(&split_b.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -314,12 +314,12 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
 
     let merge_outputs = vec![TransactionOutput {
         value: 2_000,
-        script_public_key: pay_to_script_hash_script(&merged.script),
+        script_public_key: pay_to_script_hash_script(&merged.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let merge_entries = vec![
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_a.script), 0, split_tx.is_coinbase(), Some(COV_A)),
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_b.script), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&split_a.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&split_b.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
     ];
     let merge_unsigned_tx = Transaction::new(
         1,
@@ -401,7 +401,7 @@ fn kcc20_rejects_split_when_amounts_do_not_match() {
 
     let handoff_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&handoff.script),
+        script_public_key: pay_to_script_hash_script(&handoff.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let handoff_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -443,12 +443,12 @@ fn kcc20_rejects_split_when_amounts_do_not_match() {
     let split_outputs = vec![
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_a.script),
+            script_public_key: pay_to_script_hash_script(&split_a.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_b.script),
+            script_public_key: pay_to_script_hash_script(&split_b.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -533,12 +533,12 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let split_outputs = vec![
         TransactionOutput {
             value: 1_000,
-            script_public_key: pay_to_script_hash_script(&split_minter.script),
+            script_public_key: pay_to_script_hash_script(&split_minter.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 1_000,
-            script_public_key: pay_to_script_hash_script(&split_other.script),
+            script_public_key: pay_to_script_hash_script(&split_other.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -581,11 +581,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let forged_other = compile_kcc20_state(&source, other_owner_bytes.clone(), 700, 2, 2);
     let forged_other_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&forged_other.script),
+        script_public_key: pay_to_script_hash_script(&forged_other.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let forged_other_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_other.script), 0, split_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_other.bytecode), 0, split_tx.is_coinbase(), Some(COV_A))];
     let forged_other_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: split_tx.id(), index: 1 }, vec![])],
@@ -623,11 +623,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let forged_other_minter = compile_kcc20_state_with_minter(&source, other_owner_bytes.clone(), 600, true, 2, 2);
     let forged_other_minter_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&forged_other_minter.script),
+        script_public_key: pay_to_script_hash_script(&forged_other_minter.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let forged_other_minter_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_other.script), 0, split_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_other.bytecode), 0, split_tx.is_coinbase(), Some(COV_A))];
     let forged_other_minter_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: split_tx.id(), index: 1 }, vec![])],
@@ -667,11 +667,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
 
     let mint_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&minted_minter.script),
+        script_public_key: pay_to_script_hash_script(&minted_minter.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let mint_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_minter.script), 0, split_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_minter.bytecode), 0, split_tx.is_coinbase(), Some(COV_A))];
     let mint_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: split_tx.id(), index: 0 }, vec![])],
@@ -706,11 +706,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
 
     let burn_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&burned_minter.script),
+        script_public_key: pay_to_script_hash_script(&burned_minter.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let burn_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&minted_minter.script), 0, mint_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&minted_minter.bytecode), 0, mint_tx.is_coinbase(), Some(COV_A))];
     let burn_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: mint_tx.id(), index: 0 }, vec![])],
@@ -788,7 +788,7 @@ fn kcc20_minter_can_mint_in_single_transaction() {
 
     let mint_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&minted.script),
+        script_public_key: pay_to_script_hash_script(&minted.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let mint_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -926,7 +926,7 @@ fn kcc20_covenant_minter() {
     let minter_genesis_input = tx_input_from_outpoint_v1(minter_genesis_outpoint, vec![]);
     let minter_genesis_utxo = UtxoEntry::new(1_500, funding_spk.clone(), 0, false, None);
     let minter_genesis_output_without_covenant =
-        TransactionOutput { value: 1_000, script_public_key: pay_to_script_hash_script(&pre_init.script), covenant: None };
+        TransactionOutput { value: 1_000, script_public_key: pay_to_script_hash_script(&pre_init.bytecode), covenant: None };
     let minter_cov_id = hashing::covenant_id::covenant_id(
         minter_genesis_outpoint,
         std::iter::once((0, &minter_genesis_output_without_covenant)),
@@ -1272,7 +1272,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
         .iter()
         .map(|state| TransactionOutput {
             value: 150,
-            script_public_key: pay_to_script_hash_script(&state.script),
+            script_public_key: pay_to_script_hash_script(&state.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         })
         .collect();
@@ -1318,7 +1318,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
     let build_single_output = |state: &CompiledContract<'_>| {
         vec![TransactionOutput {
             value: 150,
-            script_public_key: pay_to_script_hash_script(&state.script),
+            script_public_key: pay_to_script_hash_script(&state.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         }]
     };
@@ -1343,7 +1343,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
     let script_hash_spent = compile_kcc20_state(&source, multisig_spend_destination_owner_bytes.clone(), 400, 2, 2);
     let script_hash_spend_outputs = build_single_output(&script_hash_spent);
     let script_hash_spend_entries = vec![
-        UtxoEntry::new(150, pay_to_script_hash_script(&split_states[0].script), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(150, pay_to_script_hash_script(&split_states[0].bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
         UtxoEntry::new(500, pay_to_script_hash_script(&multisig_redeem_script), 0, false, None),
     ];
     let script_hash_auxiliary_outpoint = TransactionOutpoint { transaction_id: TransactionId::from_bytes([2; 32]), index: 0 };
@@ -1402,7 +1402,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
     let covenant_id_spent = compile_kcc20_state(&source, covenant_spend_destination_owner_bytes.clone(), 600, 2, 2);
     let covenant_id_spend_outputs = build_single_output(&covenant_id_spent);
     let covenant_id_spend_entries = vec![
-        UtxoEntry::new(150, pay_to_script_hash_script(&split_states[1].script), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(150, pay_to_script_hash_script(&split_states[1].bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
         UtxoEntry::new(500, pay_to_script_hash_script(&[0x51]), 0, false, Some(covenant_owner)),
     ];
     let covenant_id_auxiliary_outpoint = TransactionOutpoint { transaction_id: TransactionId::from_bytes([3; 32]), index: 0 };

--- a/silverscript-lang/src/ast/mod.rs
+++ b/silverscript-lang/src/ast/mod.rs
@@ -816,8 +816,8 @@ pub enum BinaryOp {
 pub enum NullaryOp {
     ActiveInputIndex,
     ActiveScriptPubKey,
-    ThisScriptSize,
-    ThisScriptSizeDataPrefix,
+    ThisBytecodeSize,
+    ThisBytecodeSizeDataPrefix,
     TxInputsLength,
     TxOutputsLength,
     TxVersion,
@@ -1300,8 +1300,8 @@ fn nullary_op_str(op: NullaryOp) -> &'static str {
     match op {
         NullaryOp::ActiveInputIndex => "this.activeInputIndex",
         NullaryOp::ActiveScriptPubKey => "this.activeScriptPubKey",
-        NullaryOp::ThisScriptSize => "this.scriptSize",
-        NullaryOp::ThisScriptSizeDataPrefix => "this.scriptSizeDataPrefix",
+        NullaryOp::ThisBytecodeSize => "this.bytecodeSize",
+        NullaryOp::ThisBytecodeSizeDataPrefix => "this.bytecodeSizeDataPrefix",
         NullaryOp::TxInputsLength => "tx.inputs.length",
         NullaryOp::TxOutputsLength => "tx.outputs.length",
         NullaryOp::TxVersion => "tx.version",
@@ -2619,8 +2619,8 @@ fn parse_nullary<'i>(raw: &str, span: Span<'i>) -> Result<Expr<'i>, CompilerErro
     let op = match raw {
         "this.activeInputIndex" => NullaryOp::ActiveInputIndex,
         "this.activeScriptPubKey" => NullaryOp::ActiveScriptPubKey,
-        "this.scriptSize" => NullaryOp::ThisScriptSize,
-        "this.scriptSizeDataPrefix" => NullaryOp::ThisScriptSizeDataPrefix,
+        "this.bytecodeSize" => NullaryOp::ThisBytecodeSize,
+        "this.bytecodeSizeDataPrefix" => NullaryOp::ThisBytecodeSizeDataPrefix,
         "tx.inputs.length" => NullaryOp::TxInputsLength,
         "tx.outputs.length" => NullaryOp::TxOutputsLength,
         "tx.version" => NullaryOp::TxVersion,

--- a/silverscript-lang/src/compiler/builtin_types.rs
+++ b/silverscript-lang/src/compiler/builtin_types.rs
@@ -18,9 +18,9 @@ pub(super) enum BuiltinReturn {
 
 pub(super) fn nullary_type(op: NullaryOp) -> TypeRef {
     match op {
-        NullaryOp::ActiveScriptPubKey | NullaryOp::ThisScriptSizeDataPrefix => byte_array(ArrayDim::Dynamic),
+        NullaryOp::ActiveScriptPubKey | NullaryOp::ThisBytecodeSizeDataPrefix => byte_array(ArrayDim::Dynamic),
         NullaryOp::ActiveInputIndex
-        | NullaryOp::ThisScriptSize
+        | NullaryOp::ThisBytecodeSize
         | NullaryOp::TxInputsLength
         | NullaryOp::TxOutputsLength
         | NullaryOp::TxVersion

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -71,84 +71,85 @@ pub(super) fn compile_contract_impl<'i>(
     let without_selector = entrypoint_functions.len() == 1;
 
     let function_abi_entries = build_function_abi_entries(&covenant_lowered_contract);
-    let uses_script_size = contract_uses_script_size(&lowered_contract);
+    let uses_bytecode_size = contract_uses_bytecode_size(&lowered_contract);
 
-    let mut script_size = if uses_script_size { Some(100i64) } else { None };
+    let mut bytecode_size = if uses_bytecode_size { Some(100i64) } else { None };
 
     for _ in 0..32 {
         debug_recorder.record_contract_scope(&inline_lowered_contract, constructor_args, &structs)?;
 
-        let (script, state_layout) = compile_contract_script_iteration(
+        let (bytecode, state_layout) = compile_contract_bytecode_iteration(
             &lowered_contract,
             &lowered_constants,
-            script_size,
+            bytecode_size,
             without_selector,
             &structs,
             &mut debug_recorder,
         )?;
 
         let debug_info = debug_recorder.take_debug_info(source);
-        if !uses_script_size {
+        if !uses_bytecode_size {
             return Ok(build_compiled_contract(
                 &lowered_contract,
                 &covenant_lowered_contract,
                 function_abi_entries.clone(),
                 without_selector,
-                script,
+                bytecode,
                 state_layout,
                 debug_info,
             ));
         }
 
-        let actual_size = script.len() as i64;
-        if Some(actual_size) == script_size {
+        let actual_size = bytecode.len() as i64;
+        if Some(actual_size) == bytecode_size {
             return Ok(build_compiled_contract(
                 &lowered_contract,
                 &covenant_lowered_contract,
                 function_abi_entries.clone(),
                 without_selector,
-                script,
+                bytecode,
                 state_layout,
                 debug_info,
             ));
         }
-        script_size = Some(actual_size);
+        bytecode_size = Some(actual_size);
     }
 
-    Err(CompilerError::Unsupported("script size did not stabilize".to_string()))
+    Err(CompilerError::Unsupported("bytecode size did not stabilize".to_string()))
 }
 
-fn compile_contract_script_iteration<'i>(
+fn compile_contract_bytecode_iteration<'i>(
     lowered_contract: &ContractAst<'i>,
     lowered_constants: &HashMap<String, Expr<'i>>,
-    script_size: Option<i64>,
+    bytecode_size: Option<i64>,
     without_selector: bool,
     structs: &StructRegistry,
     debug_recorder: &mut DebugRecorder<'i>,
 ) -> Result<(Vec<u8>, CompiledStateLayout), CompilerError> {
-    let (_contract_fields, field_prolog_script) = compile_contract_fields(&lowered_contract.fields, lowered_constants, script_size)?;
+    let (_contract_fields, field_prolog_bytecode) =
+        compile_contract_fields(&lowered_contract.fields, lowered_constants, bytecode_size)?;
 
     let selector_prefix_len = if without_selector { 0 } else { 1 };
-    let contract_fields_end_offset = selector_prefix_len + field_prolog_script.len();
-    let state_layout = CompiledStateLayout { start: selector_prefix_len, len: field_prolog_script.len() };
-    let compiled_entrypoints = compile_entrypoint_scripts(
+    let contract_fields_end_offset = selector_prefix_len + field_prolog_bytecode.len();
+    let state_layout = CompiledStateLayout { start: selector_prefix_len, len: field_prolog_bytecode.len() };
+    let compiled_entrypoints = compile_entrypoint_bytecodes(
         lowered_contract,
         contract_fields_end_offset,
         lowered_constants,
         structs,
-        script_size,
+        bytecode_size,
         debug_recorder,
     )?;
-    let script = build_contract_script(debug_recorder, without_selector, &field_prolog_script, &compiled_entrypoints)?;
-    Ok((script, state_layout))
+    let bytecode = build_contract_bytecode(debug_recorder, without_selector, &field_prolog_bytecode, &compiled_entrypoints)?;
+    Ok((bytecode, state_layout))
 }
 
-fn compile_entrypoint_scripts<'i>(
+fn compile_entrypoint_bytecodes<'i>(
     lowered_contract: &ContractAst<'i>,
     contract_fields_end_offset: usize,
     lowered_constants: &HashMap<String, Expr<'i>>,
     structs: &StructRegistry,
-    script_size: Option<i64>,
+    bytecode_size: Option<i64>,
     debug_recorder: &mut DebugRecorder<'i>,
 ) -> Result<Vec<(String, Vec<u8>)>, CompilerError> {
     let mut compiled_entrypoints = Vec::new();
@@ -162,7 +163,7 @@ fn compile_entrypoint_scripts<'i>(
                 contract_fields_end_offset,
                 lowered_constants,
                 structs,
-                script_size,
+                bytecode_size,
                 debug_recorder,
             )?;
             compiled_entrypoints.push(compiled);
@@ -171,36 +172,36 @@ fn compile_entrypoint_scripts<'i>(
     Ok(compiled_entrypoints)
 }
 
-fn build_contract_script(
+fn build_contract_bytecode(
     debug_recorder: &mut DebugRecorder<'_>,
     without_selector: bool,
-    field_prolog_script: &[u8],
+    field_prolog_bytecode: &[u8],
     compiled_entrypoints: &[(String, Vec<u8>)],
 ) -> Result<Vec<u8>, CompilerError> {
     if without_selector {
-        let (name, entrypoint_script) =
+        let (name, entrypoint_bytecode) =
             compiled_entrypoints.first().ok_or_else(|| CompilerError::Unsupported("contract has no entries".to_string()))?;
-        debug_recorder.set_entrypoint_start(name, field_prolog_script.len());
-        let mut script = field_prolog_script.to_vec();
-        script.extend(entrypoint_script.clone());
-        return Ok(script);
+        debug_recorder.set_entrypoint_start(name, field_prolog_bytecode.len());
+        let mut bytecode = field_prolog_bytecode.to_vec();
+        bytecode.extend(entrypoint_bytecode.clone());
+        return Ok(bytecode);
     }
 
     // Preserve the selector while encoding contract state once so
     // reflection helpers can rewrite a single contiguous state segment.
     let mut builder = script_builder();
     builder.add_op(OpToAltStack)?;
-    builder.add_ops(field_prolog_script)?;
+    builder.add_ops(field_prolog_bytecode)?;
     builder.add_op(OpFromAltStack)?;
     let total = compiled_entrypoints.len();
-    for (entrypoint_index, (name, script)) in compiled_entrypoints.iter().enumerate() {
+    for (entrypoint_index, (name, bytecode)) in compiled_entrypoints.iter().enumerate() {
         builder.add_op(OpDup)?;
         builder.add_i64(entrypoint_index as i64)?;
         builder.add_op(OpNumEqual)?;
         builder.add_op(OpIf)?;
         builder.add_op(OpDrop)?;
         debug_recorder.set_entrypoint_start(name, builder.script().len());
-        builder.add_ops(script)?;
+        builder.add_ops(bytecode)?;
         builder.add_op(OpElse)?;
         if entrypoint_index == total - 1 {
             builder.add_op(OpReturn)?;
@@ -219,14 +220,14 @@ fn build_compiled_contract<'i>(
     covenant_lowered_contract: &ContractAst<'i>,
     function_abi_entries: Vec<FunctionAbiEntry>,
     without_selector: bool,
-    script: Vec<u8>,
+    bytecode: Vec<u8>,
     state_layout: CompiledStateLayout,
     debug_info: Option<DebugInfo<'i>>,
 ) -> CompiledContract<'i> {
     CompiledContract {
         contract_name: lowered_contract.name.clone(),
         compiler_version: COMPILER_VERSION.to_string(),
-        script,
+        bytecode,
         ast: covenant_lowered_contract.clone(),
         abi: function_abi_entries,
         without_selector,
@@ -256,7 +257,7 @@ pub fn compile_debug_expr<'i>(
     let mut builder = script_builder();
     let type_ref = infer_expr_type(expr, constants, types)?;
     let stack_bindings = StackBindings::from_depths(stack_bindings.clone());
-    let env = ExprEnv { constants, stack_bindings: &stack_bindings, types, script_size: None, contract_constants: &empty_constants };
+    let env = ExprEnv { constants, stack_bindings: &stack_bindings, types, bytecode_size: None, contract_constants: &empty_constants };
     let mut emitter = ScriptEmitter::new(&mut builder, 0);
     compile_expr(expr, Some(&type_ref), &env, &mut emitter)?;
     Ok((builder.drain(), type_ref.type_name()))

--- a/silverscript-lang/src/compiler/compile/analysis.rs
+++ b/silverscript-lang/src/compiler/compile/analysis.rs
@@ -1,71 +1,71 @@
 use super::*;
 
-pub(super) fn contract_uses_script_size<'i>(contract: &ContractAst<'i>) -> bool {
-    if contract.constants.iter().any(|constant| expr_uses_script_size(&constant.expr)) {
+pub(super) fn contract_uses_bytecode_size<'i>(contract: &ContractAst<'i>) -> bool {
+    if contract.constants.iter().any(|constant| expr_uses_bytecode_size(&constant.expr)) {
         return true;
     }
-    if contract.fields.iter().any(|field| expr_uses_script_size(&field.expr)) {
+    if contract.fields.iter().any(|field| expr_uses_bytecode_size(&field.expr)) {
         return true;
     }
-    contract.functions.iter().any(|func| func.body.iter().any(statement_uses_script_size))
+    contract.functions.iter().any(|func| func.body.iter().any(statement_uses_bytecode_size))
 }
 
-pub(super) fn statement_uses_script_size(stmt: &Statement<'_>) -> bool {
+pub(super) fn statement_uses_bytecode_size(stmt: &Statement<'_>) -> bool {
     match stmt {
-        Statement::VariableDefinition { expr, .. } => expr.as_ref().is_some_and(expr_uses_script_size),
-        Statement::TupleAssignment { expr, .. } => expr_uses_script_size(expr),
+        Statement::VariableDefinition { expr, .. } => expr.as_ref().is_some_and(expr_uses_bytecode_size),
+        Statement::TupleAssignment { expr, .. } => expr_uses_bytecode_size(expr),
         Statement::FunctionCall { name, args, .. } => {
             name == "validateOutputState"
                 || name == super::validate_output_state::VALIDATE_OUTPUT_STATE_INNER
                 || name == "validateOutputStateWithTemplate"
                 || name == super::validate_output_state::VALIDATE_OUTPUT_STATE_WITH_TEMPLATE_INNER
-                || args.iter().any(expr_uses_script_size)
+                || args.iter().any(expr_uses_bytecode_size)
         }
-        Statement::FunctionCallAssign { args, .. } => args.iter().any(expr_uses_script_size),
-        Statement::StateFunctionCallAssign { name, args, .. } => name == "readInputState" || args.iter().any(expr_uses_script_size),
-        Statement::StructDestructure { expr, .. } => expr_uses_script_size(expr),
-        Statement::Assign { expr, .. } => expr_uses_script_size(expr),
-        Statement::TimeOp { expr, .. } => expr_uses_script_size(expr),
-        Statement::Require { expr, .. } => expr_uses_script_size(expr),
-        Statement::Block { body, .. } => body.iter().any(statement_uses_script_size),
+        Statement::FunctionCallAssign { args, .. } => args.iter().any(expr_uses_bytecode_size),
+        Statement::StateFunctionCallAssign { name, args, .. } => name == "readInputState" || args.iter().any(expr_uses_bytecode_size),
+        Statement::StructDestructure { expr, .. } => expr_uses_bytecode_size(expr),
+        Statement::Assign { expr, .. } => expr_uses_bytecode_size(expr),
+        Statement::TimeOp { expr, .. } => expr_uses_bytecode_size(expr),
+        Statement::Require { expr, .. } => expr_uses_bytecode_size(expr),
+        Statement::Block { body, .. } => body.iter().any(statement_uses_bytecode_size),
         Statement::If { condition, then_branch, else_branch, .. } => {
-            expr_uses_script_size(condition)
-                || then_branch.iter().any(statement_uses_script_size)
-                || else_branch.as_ref().is_some_and(|branch| branch.iter().any(statement_uses_script_size))
+            expr_uses_bytecode_size(condition)
+                || then_branch.iter().any(statement_uses_bytecode_size)
+                || else_branch.as_ref().is_some_and(|branch| branch.iter().any(statement_uses_bytecode_size))
         }
         Statement::For { start, end, max_iterations, body, .. } => {
-            expr_uses_script_size(start)
-                || expr_uses_script_size(end)
-                || expr_uses_script_size(max_iterations)
-                || body.iter().any(statement_uses_script_size)
+            expr_uses_bytecode_size(start)
+                || expr_uses_bytecode_size(end)
+                || expr_uses_bytecode_size(max_iterations)
+                || body.iter().any(statement_uses_bytecode_size)
         }
-        Statement::Return { exprs, .. } => exprs.iter().any(expr_uses_script_size),
-        Statement::Console { args, .. } => args.iter().any(expr_uses_script_size),
+        Statement::Return { exprs, .. } => exprs.iter().any(expr_uses_bytecode_size),
+        Statement::Console { args, .. } => args.iter().any(expr_uses_bytecode_size),
     }
 }
 
-pub(super) fn expr_uses_script_size<'i>(expr: &Expr<'i>) -> bool {
+pub(super) fn expr_uses_bytecode_size<'i>(expr: &Expr<'i>) -> bool {
     match &expr.kind {
-        ExprKind::Nullary(NullaryOp::ThisScriptSize) => true,
-        ExprKind::Nullary(NullaryOp::ThisScriptSizeDataPrefix) => true,
-        ExprKind::Unary { expr, .. } => expr_uses_script_size(expr),
-        ExprKind::Binary { left, right, .. } => expr_uses_script_size(left) || expr_uses_script_size(right),
-        ExprKind::Append { source, args, .. } => expr_uses_script_size(source) || args.iter().any(expr_uses_script_size),
+        ExprKind::Nullary(NullaryOp::ThisBytecodeSize) => true,
+        ExprKind::Nullary(NullaryOp::ThisBytecodeSizeDataPrefix) => true,
+        ExprKind::Unary { expr, .. } => expr_uses_bytecode_size(expr),
+        ExprKind::Binary { left, right, .. } => expr_uses_bytecode_size(left) || expr_uses_bytecode_size(right),
+        ExprKind::Append { source, args, .. } => expr_uses_bytecode_size(source) || args.iter().any(expr_uses_bytecode_size),
         ExprKind::IfElse { condition, then_expr, else_expr } => {
-            expr_uses_script_size(condition) || expr_uses_script_size(then_expr) || expr_uses_script_size(else_expr)
+            expr_uses_bytecode_size(condition) || expr_uses_bytecode_size(then_expr) || expr_uses_bytecode_size(else_expr)
         }
-        ExprKind::Array { values, .. } => values.iter().any(expr_uses_script_size),
-        ExprKind::StructLiteral { fields, .. } => fields.iter().any(|field| expr_uses_script_size(&field.expr)),
-        ExprKind::Call { name, args, .. } => name == "readInputState" || args.iter().any(expr_uses_script_size),
-        ExprKind::New { args, .. } => args.iter().any(expr_uses_script_size),
-        ExprKind::Split { source, index, .. } => expr_uses_script_size(source) || expr_uses_script_size(index),
+        ExprKind::Array { values, .. } => values.iter().any(expr_uses_bytecode_size),
+        ExprKind::StructLiteral { fields, .. } => fields.iter().any(|field| expr_uses_bytecode_size(&field.expr)),
+        ExprKind::Call { name, args, .. } => name == "readInputState" || args.iter().any(expr_uses_bytecode_size),
+        ExprKind::New { args, .. } => args.iter().any(expr_uses_bytecode_size),
+        ExprKind::Split { source, index, .. } => expr_uses_bytecode_size(source) || expr_uses_bytecode_size(index),
         ExprKind::Slice { source, start, end, .. } => {
-            expr_uses_script_size(source) || expr_uses_script_size(start) || expr_uses_script_size(end)
+            expr_uses_bytecode_size(source) || expr_uses_bytecode_size(start) || expr_uses_bytecode_size(end)
         }
-        ExprKind::FieldAccess { source, .. } => expr_uses_script_size(source),
-        ExprKind::UnarySuffix { source, .. } => expr_uses_script_size(source),
-        ExprKind::ArrayIndex { source, index } => expr_uses_script_size(source) || expr_uses_script_size(index),
-        ExprKind::Introspection { index, .. } => expr_uses_script_size(index),
+        ExprKind::FieldAccess { source, .. } => expr_uses_bytecode_size(source),
+        ExprKind::UnarySuffix { source, .. } => expr_uses_bytecode_size(source),
+        ExprKind::ArrayIndex { source, index } => expr_uses_bytecode_size(source) || expr_uses_bytecode_size(index),
+        ExprKind::Introspection { index, .. } => expr_uses_bytecode_size(index),
         ExprKind::Int(_)
         | ExprKind::Bool(_)
         | ExprKind::Byte(_)

--- a/silverscript-lang/src/compiler/compile/emitter.rs
+++ b/silverscript-lang/src/compiler/compile/emitter.rs
@@ -1,10 +1,10 @@
 use super::*;
 
-/// Emits script while tracking the number of temporary stack values.
+/// Emits bytecode while tracking the number of temporary stack values.
 ///
 /// Named values are tracked separately by `StackBindings`; this type only
 /// accounts for values produced and consumed while compiling an expression or
-/// another self-contained script fragment.
+/// another self-contained bytecode fragment.
 pub(super) struct ScriptEmitter<'a> {
     builder: &'a mut ScriptBuilder,
     stack_depth: i64,

--- a/silverscript-lang/src/compiler/compile/expression.rs
+++ b/silverscript-lang/src/compiler/compile/expression.rs
@@ -23,7 +23,7 @@ pub(super) struct ExprEnv<'a, 'i> {
     pub constants: &'a HashMap<String, Expr<'i>>,
     pub stack_bindings: &'a StackBindings,
     pub types: &'a TypeMap,
-    pub script_size: Option<i64>,
+    pub bytecode_size: Option<i64>,
     pub contract_constants: &'a HashMap<String, Expr<'i>>,
 }
 
@@ -532,19 +532,19 @@ fn compile_nullary_expr<'i>(ctx: &mut CompileExprContext<'_, '_, 'i>, op: Nullar
             ctx.emit_op(OpTxInputIndex, 1)?;
             ctx.emit_op(OpTxInputSpk, 0)?;
         }
-        NullaryOp::ThisScriptSize => {
+        NullaryOp::ThisBytecodeSize => {
             let size = ctx
                 .env
-                .script_size
-                .ok_or_else(|| CompilerError::Unsupported("this.scriptSize is only available at compile time".to_string()))?;
+                .bytecode_size
+                .ok_or_else(|| CompilerError::Unsupported("this.bytecodeSize is only available at compile time".to_string()))?;
             ctx.push_int(size)?;
         }
-        NullaryOp::ThisScriptSizeDataPrefix => {
-            let size = ctx.env.script_size.ok_or_else(|| {
-                CompilerError::Unsupported("this.scriptSizeDataPrefix is only available at compile time".to_string())
+        NullaryOp::ThisBytecodeSizeDataPrefix => {
+            let size = ctx.env.bytecode_size.ok_or_else(|| {
+                CompilerError::Unsupported("this.bytecodeSizeDataPrefix is only available at compile time".to_string())
             })?;
             let size: usize = size.try_into().map_err(|_| {
-                CompilerError::Unsupported("this.scriptSizeDataPrefix requires a non-negative script size".to_string())
+                CompilerError::Unsupported("this.bytecodeSizeDataPrefix requires a non-negative bytecode size".to_string())
             })?;
             let prefix = data_prefix(size)?;
             ctx.push_data(&prefix)?;
@@ -714,8 +714,8 @@ pub(super) fn data_prefix(data_len: usize) -> Result<Vec<u8>, CompilerError> {
     let dummy_data = vec![0u8; data_len];
     let mut builder = script_builder();
     builder.add_data_with_push_opcode(&dummy_data)?;
-    let script = builder.drain();
-    Ok(script[..script.len() - data_len].to_vec())
+    let bytecode = builder.drain();
+    Ok(bytecode[..bytecode.len() - data_len].to_vec())
 }
 
 #[cfg(test)]

--- a/silverscript-lang/src/compiler/compile/helpers.rs
+++ b/silverscript-lang/src/compiler/compile/helpers.rs
@@ -3,7 +3,7 @@ use super::*;
 pub(super) fn compile_contract_fields<'i>(
     fields: &[ContractFieldAst<'i>],
     base_constants: &HashMap<String, Expr<'i>>,
-    script_size: Option<i64>,
+    bytecode_size: Option<i64>,
 ) -> Result<(HashMap<String, Expr<'i>>, Vec<u8>), CompilerError> {
     let mut field_values = HashMap::new();
     let mut field_types = HashMap::new();
@@ -22,7 +22,7 @@ pub(super) fn compile_contract_fields<'i>(
                 constants: base_constants,
                 stack_bindings: &stack_bindings,
                 types: &field_types,
-                script_size,
+                bytecode_size,
                 contract_constants: base_constants,
             };
             let mut emitter = ScriptEmitter::new(&mut builder, 0);

--- a/silverscript-lang/src/compiler/compile/state.rs
+++ b/silverscript-lang/src/compiler/compile/state.rs
@@ -9,8 +9,8 @@ fn byte_array_type(dimension: ArrayDim) -> TypeRef {
     TypeRef { base: TypeBase::Byte, array_dims: vec![dimension] }
 }
 
-fn input_sigscript_base_expr<'i>(input_idx: &Expr<'i>, script_size_expr: Expr<'i>) -> Expr<'i> {
-    binary_expr(BinaryOp::Sub, Expr::call("OpTxInputScriptSigLen", vec![input_idx.clone()]), script_size_expr)
+fn input_sigscript_base_expr<'i>(input_idx: &Expr<'i>, bytecode_size_expr: Expr<'i>) -> Expr<'i> {
+    binary_expr(BinaryOp::Sub, Expr::call("OpTxInputScriptSigLen", vec![input_idx.clone()]), bytecode_size_expr)
 }
 
 fn input_sigscript_substr_expr<'i>(input_idx: &Expr<'i>, start: Expr<'i>, end: Expr<'i>) -> Expr<'i> {
@@ -37,13 +37,13 @@ pub(in crate::compiler) fn read_input_state_field_expr_symbolic<'i>(
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<Expr<'i>, CompilerError> {
     let state_start_offset = state_start_offset(contract_fields_end_offset, contract_fields, contract_constants)?;
-    let script_size_expr = Expr::new(ExprKind::Nullary(NullaryOp::ThisScriptSize), span::Span::default());
+    let bytecode_size_expr = Expr::new(ExprKind::Nullary(NullaryOp::ThisBytecodeSize), span::Span::default());
     read_input_state_field_expr(
         input_idx,
         &field.type_ref,
         Expr::int(state_start_offset as i64),
         field_chunk_offset,
-        script_size_expr,
+        bytecode_size_expr,
         contract_constants,
         "readInputState",
     )
@@ -87,7 +87,7 @@ pub(super) fn state_start_offset<'i>(
         .ok_or_else(|| CompilerError::Unsupported("state offset underflow".to_string()))
 }
 
-pub(super) fn templated_input_script_size_expr<'i>(
+pub(super) fn templated_input_bytecode_size_expr<'i>(
     template_prefix_len: &Expr<'i>,
     template_suffix_len: &Expr<'i>,
     layout_field_types: &[TypeRef],
@@ -106,7 +106,7 @@ pub(super) fn read_input_state_field_expr<'i>(
     field_type: &TypeRef,
     state_start_offset_expr: Expr<'i>,
     field_chunk_offset: usize,
-    script_size_expr: Expr<'i>,
+    bytecode_size_expr: Expr<'i>,
     contract_constants: &HashMap<String, Expr<'i>>,
     builtin_name: &str,
 ) -> Result<Expr<'i>, CompilerError> {
@@ -117,7 +117,7 @@ pub(super) fn read_input_state_field_expr<'i>(
         state_start_offset_expr,
         Expr::int((field_chunk_offset + data_prefix(field_payload_len)?.len()) as i64),
     );
-    let start = binary_expr(BinaryOp::Add, input_sigscript_base_expr(input_idx, script_size_expr), field_payload_offset);
+    let start = binary_expr(BinaryOp::Add, input_sigscript_base_expr(input_idx, bytecode_size_expr), field_payload_offset);
     let end = binary_expr(BinaryOp::Add, start.clone(), Expr::int(field_payload_len as i64));
     let substr = input_sigscript_substr_expr(input_idx, start, end);
 
@@ -142,15 +142,15 @@ pub(super) fn cast_read_input_state_expr<'i>(substr: Expr<'i>, type_ref: &TypeRe
 ///   args = (input_idx, template_prefix_len, template_suffix_len, expected_template_hash)
 ///   require target state layout is a non-empty flattened struct
 ///
-///   script_size = template_prefix_len + encoded_state_len(layout_field_types) + template_suffix_len
-///   script_base = input_sigscript_len(input_idx) - script_size
+///   bytecode_size = template_prefix_len + encoded_state_len(layout_field_types) + template_suffix_len
+///   bytecode_base = input_sigscript_len(input_idx) - bytecode_size
 ///
-///   actual_redeem_script = input_sigscript[script_base .. script_base + script_size]
-///   prefix = input_sigscript[script_base .. script_base + template_prefix_len]
+///   actual_redeem_script = input_sigscript[bytecode_base .. bytecode_base + bytecode_size]
+///   prefix = input_sigscript[bytecode_base .. bytecode_base + template_prefix_len]
 ///   suffix = input_sigscript[
-///       script_base + template_prefix_len + encoded_state_len(layout_field_types)
+///       bytecode_base + template_prefix_len + encoded_state_len(layout_field_types)
 ///       ..
-///       script_base + script_size
+///       bytecode_base + bytecode_size
 ///   ]
 ///
 ///   actual_template = i64le(prefix.length) || prefix || i64le(suffix.length) || suffix
@@ -168,7 +168,7 @@ pub(super) fn compile_read_input_state_with_template_validation(
     types: &TypeMap,
     builder: &mut ScriptBuilder,
     layout_field_types: &[TypeRef],
-    current_script_size: Option<i64>,
+    current_bytecode_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'_>>,
 ) -> Result<(), CompilerError> {
     let Ok([input_idx, template_prefix_len, template_suffix_len, expected_template_hash]): Result<&[Expr<'_>; 4], _> = args.try_into()
@@ -182,17 +182,17 @@ pub(super) fn compile_read_input_state_with_template_validation(
         return Err(CompilerError::Unsupported("readInputStateWithTemplate requires a struct type".to_string()));
     }
 
-    let script_size_expr =
-        templated_input_script_size_expr(template_prefix_len, template_suffix_len, layout_field_types, contract_constants)?;
-    let script_base_expr = input_sigscript_base_expr(input_idx, script_size_expr.clone());
-    let prefix_end_expr = binary_expr(BinaryOp::Add, script_base_expr.clone(), template_prefix_len.clone());
-    let script_end_expr = binary_expr(BinaryOp::Add, script_base_expr.clone(), script_size_expr.clone());
+    let bytecode_size_expr =
+        templated_input_bytecode_size_expr(template_prefix_len, template_suffix_len, layout_field_types, contract_constants)?;
+    let bytecode_base_expr = input_sigscript_base_expr(input_idx, bytecode_size_expr.clone());
+    let prefix_end_expr = binary_expr(BinaryOp::Add, bytecode_base_expr.clone(), template_prefix_len.clone());
+    let bytecode_end_expr = binary_expr(BinaryOp::Add, bytecode_base_expr.clone(), bytecode_size_expr.clone());
     let state_len = encoded_state_len_for_layout_field_types(layout_field_types, contract_constants)?;
     let suffix_start_expr = binary_expr(BinaryOp::Add, prefix_end_expr.clone(), Expr::int(state_len as i64));
     let suffix_end_expr = binary_expr(BinaryOp::Add, suffix_start_expr.clone(), template_suffix_len.clone());
 
-    let input_redeem_script_expr = input_sigscript_substr_expr(input_idx, script_base_expr.clone(), script_end_expr);
-    let prefix_expr = input_sigscript_substr_expr(input_idx, script_base_expr, prefix_end_expr);
+    let input_redeem_script_expr = input_sigscript_substr_expr(input_idx, bytecode_base_expr.clone(), bytecode_end_expr);
+    let prefix_expr = input_sigscript_substr_expr(input_idx, bytecode_base_expr, prefix_end_expr);
     let suffix_expr = input_sigscript_substr_expr(input_idx, suffix_start_expr, suffix_end_expr);
     let encoded_prefix_len_expr = int_to_fixed_bytes_expr(template_prefix_len.clone(), 8);
     let encoded_suffix_len_expr = int_to_fixed_bytes_expr(template_suffix_len.clone(), 8);
@@ -211,7 +211,8 @@ pub(super) fn compile_read_input_state_with_template_validation(
     );
     let actual_input_spk_expr = input_script_pubkey_expr(input_idx);
 
-    let env = ExprEnv { constants: contract_constants, stack_bindings, types, script_size: current_script_size, contract_constants };
+    let env =
+        ExprEnv { constants: contract_constants, stack_bindings, types, bytecode_size: current_bytecode_size, contract_constants };
     let mut emitter = ScriptEmitter::new(builder, 0);
     let dynamic_bytes = byte_array_type(ArrayDim::Dynamic);
     let p2sh_script_type = constructor_return_type("ScriptPubKeyP2SHFromRedeemScript").expect("known constructor type");
@@ -238,7 +239,7 @@ pub(super) fn compile_validate_output_state_inner_statement(
     builder: &mut ScriptBuilder,
     contract_fields: &[ContractFieldAst<'_>],
     contract_fields_end_offset: usize,
-    script_size: Option<i64>,
+    bytecode_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'_>>,
 ) -> Result<(), CompilerError> {
     if args.len() != contract_fields.len() + 1 {
@@ -271,7 +272,7 @@ pub(super) fn compile_validate_output_state_inner_statement(
         stack_bindings,
         types,
         builder,
-        script_size,
+        bytecode_size,
         contract_constants,
         "validateOutputState",
     )?;
@@ -281,18 +282,18 @@ pub(super) fn compile_validate_output_state_inner_statement(
         .checked_sub(total_state_len)
         .ok_or_else(|| CompilerError::Unsupported("validateOutputState state offset underflow".to_string()))?;
 
-    let script_size_value =
-        script_size.ok_or_else(|| CompilerError::Unsupported("validateOutputState requires this.scriptSize".to_string()))?;
+    let bytecode_size_value =
+        bytecode_size.ok_or_else(|| CompilerError::Unsupported("validateOutputState requires this.bytecodeSize".to_string()))?;
     let mut emitter = ScriptEmitter::new(builder, stack_depth);
 
     // Rebuild `prefix || encoded_new_state || suffix`. The redeem script starts
-    // at `input_sigscript_len - script_size_value`.
+    // at `input_sigscript_len - bytecode_size_value`.
     if state_start_offset > 0 {
         // Extract the bytes before the old state and prepend them to the new state.
         emitter.emit_op(OpTxInputIndex, 1)?;
         emitter.emit_op(OpDup, 1)?;
         emitter.emit_op(OpTxInputScriptSigLen, 0)?;
-        emitter.push_int(script_size_value)?;
+        emitter.push_int(bytecode_size_value)?;
         emitter.emit_op(OpSub, -1)?;
         emitter.emit_op(OpDup, 1)?;
         emitter.push_int(state_start_offset as i64)?;
@@ -308,8 +309,8 @@ pub(super) fn compile_validate_output_state_inner_statement(
     emitter.emit_op(OpTxInputScriptSigLen, 0)?;
     emitter.emit_op(OpDup, 1)?;
 
-    // Compute `suffix_start = input_sigscript_len + contract_fields_end_offset - script_size_value`.`
-    emitter.push_int(contract_fields_end_offset as i64 - script_size_value)?;
+    // Compute `suffix_start = input_sigscript_len + contract_fields_end_offset - bytecode_size_value`.`
+    emitter.push_int(contract_fields_end_offset as i64 - bytecode_size_value)?;
     emitter.emit_op(OpAdd, -1)?;
     emitter.emit_op(OpSwap, 0)?;
     emitter.emit_op(OpTxInputScriptSigSubstr, -2)?;
@@ -330,7 +331,7 @@ pub(super) fn compile_validate_output_state_inner_statement(
     emitter.emit_op(OpCat, -1)?;
 
     // Require the selected output to use that scriptPubKey.
-    let env = ExprEnv { constants, stack_bindings, types, script_size: Some(script_size_value), contract_constants };
+    let env = ExprEnv { constants, stack_bindings, types, bytecode_size: Some(bytecode_size_value), contract_constants };
     let int_type = scalar_type(TypeBase::Int);
     compile_expr(output_idx, Some(&int_type), &env, &mut emitter)?;
     emitter.emit_op(OpTxOutputSpk, 0)?;
@@ -345,7 +346,7 @@ pub(super) fn compile_validate_output_state_with_template_inner_statement(
     stack_bindings: &StackBindings,
     types: &TypeMap,
     builder: &mut ScriptBuilder,
-    script_size: Option<i64>,
+    bytecode_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'_>>,
 ) -> Result<(), CompilerError> {
     if args.len() < 5 {
@@ -363,7 +364,7 @@ pub(super) fn compile_validate_output_state_with_template_inner_statement(
         return Err(CompilerError::Unsupported("validateOutputStateWithTemplate requires contract fields".to_string()));
     }
 
-    let env = ExprEnv { constants, stack_bindings, types, script_size, contract_constants };
+    let env = ExprEnv { constants, stack_bindings, types, bytecode_size, contract_constants };
     let dynamic_bytes_type = byte_array_type(ArrayDim::Dynamic);
     let hash_type = builtin_return_type("blake2b").expect("known builtin type");
     let int_type = scalar_type(TypeBase::Int);
@@ -388,7 +389,7 @@ pub(super) fn compile_validate_output_state_with_template_inner_statement(
         stack_bindings,
         types,
         builder,
-        script_size,
+        bytecode_size,
         contract_constants,
         "validateOutputStateWithTemplate",
     )?;
@@ -425,7 +426,7 @@ pub(super) fn compile_encoded_state_object(
     stack_bindings: &StackBindings,
     types: &TypeMap,
     builder: &mut ScriptBuilder,
-    script_size: Option<i64>,
+    bytecode_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'_>>,
     builtin_name: &str,
 ) -> Result<i64, CompilerError> {
@@ -435,7 +436,7 @@ pub(super) fn compile_encoded_state_object(
         stack_bindings,
         types,
         builder,
-        script_size,
+        bytecode_size,
         contract_constants,
         builtin_name,
     )
@@ -447,7 +448,7 @@ pub(super) fn compile_encoded_flat_state_fields(
     stack_bindings: &StackBindings,
     types: &TypeMap,
     builder: &mut ScriptBuilder,
-    script_size: Option<i64>,
+    bytecode_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'_>>,
     builtin_name: &str,
 ) -> Result<i64, CompilerError> {
@@ -457,7 +458,7 @@ pub(super) fn compile_encoded_flat_state_fields(
         stack_bindings,
         types,
         builder,
-        script_size,
+        bytecode_size,
         contract_constants,
         builtin_name,
     )
@@ -470,7 +471,7 @@ fn compile_encoded_state_fields<'a, 'i>(
     stack_bindings: &StackBindings,
     types: &TypeMap,
     builder: &mut ScriptBuilder,
-    script_size: Option<i64>,
+    bytecode_size: Option<i64>,
     contract_constants: &HashMap<String, Expr<'i>>,
     builtin_name: &str,
 ) -> Result<i64, CompilerError>
@@ -478,7 +479,7 @@ where
     'i: 'a,
 {
     let field_count = state_fields.len();
-    let env = ExprEnv { constants, stack_bindings, types, script_size, contract_constants };
+    let env = ExprEnv { constants, stack_bindings, types, bytecode_size, contract_constants };
     let mut emitter = ScriptEmitter::new(builder, 0);
     for new_value in state_fields {
         let type_ref = infer_expr_type(new_value, constants, types)?;

--- a/silverscript-lang/src/compiler/compile/statement.rs
+++ b/silverscript-lang/src/compiler/compile/statement.rs
@@ -10,7 +10,7 @@ pub(super) fn compile_entrypoint_function<'i>(
     contract_fields_end_offset: usize,
     constants: &HashMap<String, Expr<'i>>,
     structs: &StructRegistry,
-    script_size: Option<i64>,
+    bytecode_size: Option<i64>,
     debug_recorder: &mut DebugRecorder<'i>,
 ) -> Result<(String, Vec<u8>), CompilerError> {
     debug_recorder.begin_entrypoint(function, contract_fields, structs)?;
@@ -55,7 +55,7 @@ pub(super) fn compile_entrypoint_function<'i>(
         contract_fields_end_offset,
         contract_constants: constants,
         structs,
-        script_size,
+        bytecode_size,
         debug_recorder,
     };
     for (index, stmt) in function.body.iter().enumerate() {
@@ -77,7 +77,7 @@ pub(super) fn compile_entrypoint_function<'i>(
         }
         builder.add_op(OpTrue)?;
     } else {
-        let env = ExprEnv { constants, stack_bindings: &stack_bindings, types: &types, script_size, contract_constants: constants };
+        let env = ExprEnv { constants, stack_bindings: &stack_bindings, types: &types, bytecode_size, contract_constants: constants };
         let mut emitter = ScriptEmitter::new(&mut builder, 0);
         for (expr, expected_type) in return_exprs.iter().zip(&function.return_types) {
             compile_expr(expr, Some(expected_type), &env, &mut emitter)?;
@@ -88,9 +88,9 @@ pub(super) fn compile_entrypoint_function<'i>(
             builder.add_op(OpDrop)?;
         }
     }
-    let script = builder.drain();
-    debug_recorder.finish_entrypoint(script.len());
-    Ok((function.name.clone(), script))
+    let bytecode = builder.drain();
+    debug_recorder.finish_entrypoint(bytecode.len());
+    Ok((function.name.clone(), bytecode))
 }
 
 fn compile_fixed_size_param_validations<'i>(
@@ -168,7 +168,7 @@ struct CompileStatementContext<'a, 'i> {
     contract_fields_end_offset: usize,
     contract_constants: &'a HashMap<String, Expr<'i>>,
     structs: &'a StructRegistry,
-    script_size: Option<i64>,
+    bytecode_size: Option<i64>,
     debug_recorder: &'a mut DebugRecorder<'i>,
 }
 
@@ -178,7 +178,7 @@ impl<'a, 'i> CompileStatementContext<'a, 'i> {
             constants: self.contract_constants,
             stack_bindings: self.stack_bindings,
             types: self.types,
-            script_size: self.script_size,
+            bytecode_size: self.bytecode_size,
             contract_constants: self.contract_constants,
         };
         let mut emitter = ScriptEmitter::new(self.builder, 0);
@@ -190,7 +190,7 @@ impl<'a, 'i> CompileStatementContext<'a, 'i> {
             constants: self.contract_constants,
             stack_bindings: self.stack_bindings,
             types: self.types,
-            script_size: self.script_size,
+            bytecode_size: self.bytecode_size,
             contract_constants: self.contract_constants,
         };
         let mut emitter = ScriptEmitter::new(self.builder, 0);
@@ -213,7 +213,7 @@ impl<'a, 'i> CompileStatementContext<'a, 'i> {
             contract_fields_end_offset: self.contract_fields_end_offset,
             contract_constants: self.contract_constants,
             structs: self.structs,
-            script_size: self.script_size,
+            bytecode_size: self.bytecode_size,
             debug_recorder: self.debug_recorder,
         }
     }
@@ -315,7 +315,7 @@ fn compile_function_call_statement<'i>(
             ctx.builder,
             ctx.contract_fields,
             ctx.contract_fields_end_offset,
-            ctx.script_size,
+            ctx.bytecode_size,
             ctx.contract_constants,
         )
         .map(|_| Vec::new());
@@ -327,7 +327,7 @@ fn compile_function_call_statement<'i>(
             ctx.stack_bindings,
             ctx.types,
             ctx.builder,
-            ctx.script_size,
+            ctx.bytecode_size,
             ctx.contract_constants,
         )
         .map(|_| Vec::new());
@@ -445,8 +445,9 @@ fn compile_read_input_state_statement<'i>(
                 ));
             }
 
-            let script_size_value =
-                ctx.script_size.ok_or_else(|| CompilerError::Unsupported("readInputState requires this.scriptSize".to_string()))?;
+            let bytecode_size_value = ctx
+                .bytecode_size
+                .ok_or_else(|| CompilerError::Unsupported("readInputState requires this.bytecodeSize".to_string()))?;
             let total_state_len = encoded_state_len(contract_fields, ctx.contract_constants)?;
             let state_start_offset = contract_fields_end_offset
                 .checked_sub(total_state_len)
@@ -472,7 +473,7 @@ fn compile_read_input_state_statement<'i>(
                     &field.type_ref,
                     Expr::int(state_start_offset as i64),
                     field_chunk_offset,
-                    Expr::int(script_size_value),
+                    Expr::int(bytecode_size_value),
                     ctx.contract_constants,
                     "readInputState",
                 )?;
@@ -516,13 +517,13 @@ fn compile_read_input_state_statement<'i>(
                 ctx.types,
                 ctx.builder,
                 &layout_field_types,
-                ctx.script_size,
+                ctx.bytecode_size,
                 ctx.contract_constants,
             )?;
 
             let input_idx = input_idx.clone();
             let state_start_offset_expr = template_prefix_len.clone();
-            let script_size_expr = templated_input_script_size_expr(
+            let bytecode_size_expr = templated_input_bytecode_size_expr(
                 template_prefix_len,
                 template_suffix_len,
                 &layout_field_types,
@@ -546,7 +547,7 @@ fn compile_read_input_state_statement<'i>(
                     &field.type_ref,
                     state_start_offset_expr.clone(),
                     field_chunk_offset,
-                    script_size_expr.clone(),
+                    bytecode_size_expr.clone(),
                     ctx.contract_constants,
                     "readInputStateWithTemplate",
                 )?;

--- a/silverscript-lang/src/compiler/debug_recording.rs
+++ b/silverscript-lang/src/compiler/debug_recording.rs
@@ -17,8 +17,8 @@ use super::{
 ///
 /// This intentionally keeps the compiler-facing API small:
 /// - record contract-scoped debug state once from the pre-lowering contract
-/// - stage entrypoints once per compiled entrypoint script
-/// - set final bytecode starts after the full contract script is assembled
+/// - stage entrypoints once per compiled entrypoint bytecode sequence
+/// - set final bytecode starts after the full contract bytecode is assembled
 /// - finalize into `DebugInfo`
 ///
 /// The detailed source-step recorder will be built behind this facade in later
@@ -302,7 +302,7 @@ impl<'i> DebugRecorder<'i> {
         }
         active.entrypoints.push(StagedEntrypointDebug {
             name: function.name.clone(),
-            script_len: 0,
+            bytecode_len: 0,
             bytecode_start: None,
             params: build_param_mappings(
                 function,
@@ -450,7 +450,7 @@ impl<'i> DebugRecorder<'i> {
         active.store_pending_statement_slot(depth, state);
     }
 
-    pub(crate) fn finish_entrypoint(&mut self, script_len: usize) {
+    pub(crate) fn finish_entrypoint(&mut self, bytecode_len: usize) {
         let Some(active) = self.active.as_mut() else {
             return;
         };
@@ -459,8 +459,8 @@ impl<'i> DebugRecorder<'i> {
             return;
         };
         if let Some(entrypoint) = active.entrypoints.get_mut(index) {
-            entrypoint.emit_inline_call_resumes(entrypoint.next_statement_index, script_len);
-            entrypoint.script_len = script_len;
+            entrypoint.emit_inline_call_resumes(entrypoint.next_statement_index, bytecode_len);
+            entrypoint.bytecode_len = bytecode_len;
         }
         active.active_function_name = None;
         active.statement_debug_state_stack.clear();
@@ -488,7 +488,7 @@ impl<'i> DebugRecorder<'i> {
             recorder.record_function(DebugFunctionRange {
                 name: entrypoint.name,
                 bytecode_start,
-                bytecode_end: bytecode_start + entrypoint.script_len,
+                bytecode_end: bytecode_start + entrypoint.bytecode_len,
             });
 
             for param in entrypoint.params {
@@ -956,7 +956,7 @@ struct InlineFramePlan<'i> {
 #[derive(Debug)]
 struct StagedEntrypointDebug<'i> {
     name: String,
-    script_len: usize,
+    bytecode_len: usize,
     bytecode_start: Option<usize>,
     params: Vec<DebugParamMapping>,
     steps: Vec<DebugStep<'i>>,
@@ -1392,7 +1392,7 @@ mod tests {
         let entrypoint = active.entrypoints.first().expect("staged entrypoint");
 
         assert_eq!(entrypoint.name, "spend");
-        assert_eq!(entrypoint.script_len, 0);
+        assert_eq!(entrypoint.bytecode_len, 0);
         assert!(entrypoint.bytecode_start.is_none());
         assert_eq!(entrypoint.params.len(), 1);
     }

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -102,7 +102,7 @@ pub struct CompiledStateLayout {
 pub struct CompiledContract<'i> {
     pub contract_name: String,
     pub compiler_version: String,
-    pub script: Vec<u8>,
+    pub bytecode: Vec<u8>,
     pub ast: ContractAst<'i>,
     pub abi: Vec<FunctionAbiEntry>,
     pub without_selector: bool,
@@ -209,7 +209,7 @@ impl<'i> CompiledContract<'i> {
     /// Calculate the canonical hash of this contract's state template.
     pub fn template_hash(&self) -> [u8; 32] {
         let state_end = self.state_layout.start + self.state_layout.len;
-        crate::template::template_hash(&self.script[..self.state_layout.start], &self.script[state_end..])
+        crate::template::template_hash(&self.bytecode[..self.state_layout.start], &self.bytecode[state_end..])
     }
 
     pub fn build_sig_script(&self, function_name: &str, args: Vec<Expr<'i>>) -> Result<Vec<u8>, CompilerError> {

--- a/silverscript-lang/src/compiler/validate_output_state.rs
+++ b/silverscript-lang/src/compiler/validate_output_state.rs
@@ -312,20 +312,23 @@ fn input_template_parts_exprs<'i>(
     template_suffix_len: &Expr<'i>,
     state_len: usize,
 ) -> (Expr<'i>, Expr<'i>) {
-    let script_size = binary_expr(
+    let bytecode_size = binary_expr(
         BinaryOp::Add,
         binary_expr(BinaryOp::Add, template_prefix_len.clone(), Expr::int(state_len as i64)),
         template_suffix_len.clone(),
     );
-    let script_base = input_sigscript_base_expr(input_idx, script_size.clone());
-    let prefix_end = binary_expr(BinaryOp::Add, script_base.clone(), template_prefix_len.clone());
+    let bytecode_base = input_sigscript_base_expr(input_idx, bytecode_size.clone());
+    let prefix_end = binary_expr(BinaryOp::Add, bytecode_base.clone(), template_prefix_len.clone());
     let suffix_start = binary_expr(BinaryOp::Add, prefix_end.clone(), Expr::int(state_len as i64));
     let suffix_end = binary_expr(BinaryOp::Add, suffix_start.clone(), template_suffix_len.clone());
-    (input_sigscript_substr_expr(input_idx, script_base, prefix_end), input_sigscript_substr_expr(input_idx, suffix_start, suffix_end))
+    (
+        input_sigscript_substr_expr(input_idx, bytecode_base, prefix_end),
+        input_sigscript_substr_expr(input_idx, suffix_start, suffix_end),
+    )
 }
 
-fn input_sigscript_base_expr<'i>(input_idx: &Expr<'i>, script_size_expr: Expr<'i>) -> Expr<'i> {
-    binary_expr(BinaryOp::Sub, Expr::call("OpTxInputScriptSigLen", vec![input_idx.clone()]), script_size_expr)
+fn input_sigscript_base_expr<'i>(input_idx: &Expr<'i>, bytecode_size_expr: Expr<'i>) -> Expr<'i> {
+    binary_expr(BinaryOp::Sub, Expr::call("OpTxInputScriptSigLen", vec![input_idx.clone()]), bytecode_size_expr)
 }
 
 fn input_sigscript_substr_expr<'i>(input_idx: &Expr<'i>, start: Expr<'i>, end: Expr<'i>) -> Expr<'i> {

--- a/silverscript-lang/src/silverscript.pest
+++ b/silverscript-lang/src/silverscript.pest
@@ -176,8 +176,8 @@ TxVar = { "this.age" | "tx.time" }
 NullaryOp = {
     "this.activeInputIndex"
     | "this.activeScriptPubKey"
-    | "this.scriptSizeDataPrefix"
-    | "this.scriptSize"
+    | "this.bytecodeSizeDataPrefix"
+    | "this.bytecodeSize"
     | "tx.inputs.length"
     | "tx.outputs.length"
     | "tx.version"
@@ -192,7 +192,7 @@ keyword = {
     "pragma" | "silverscript" | "contract" | "struct" | "entry" | "function" | "if" | "else" | "require" | "for" | "return"
     | "console.log" | "new" | "as" | "true" | "false" | "constant" | "date"
     | "int" | "bool" | "string" | "pubkey" | "sig" | "datasig" | "byte"
-    | "this.age" | "tx.time" | "this.activeInputIndex" | "this.activeScriptPubKey" | "this.scriptSizeDataPrefix" | "this.scriptSize"
+    | "this.age" | "tx.time" | "this.activeInputIndex" | "this.activeScriptPubKey" | "this.bytecodeSizeDataPrefix" | "this.bytecodeSize"
     | "tx.inputs.length" | "tx.outputs.length" | "tx.version" | "tx.locktime"
 }
 

--- a/silverscript-lang/tests/ast_json_tests.rs
+++ b/silverscript-lang/tests/ast_json_tests.rs
@@ -23,7 +23,7 @@ fn compiles_from_ast_json_require() {
     "#;
     let compiled_from_source = compile_contract(source, &[], CompileOptions::default()).expect("compile from source succeeds");
 
-    assert_eq!(compiled_from_ast.script, compiled_from_source.script);
+    assert_eq!(compiled_from_ast.bytecode, compiled_from_source.bytecode);
 }
 
 #[test]
@@ -42,5 +42,5 @@ fn compiles_from_ast_json_return() {
     "#;
     let compiled_from_source = compile_contract(source, &[], options).expect("compile from source succeeds");
 
-    assert_eq!(compiled_from_ast.script, compiled_from_source.script);
+    assert_eq!(compiled_from_ast.bytecode, compiled_from_source.bytecode);
 }

--- a/silverscript-lang/tests/cashc_valid_examples_tests.rs
+++ b/silverscript-lang/tests/cashc_valid_examples_tests.rs
@@ -139,7 +139,7 @@ fn build_p2pk_script(pubkey: &[u8]) -> Vec<u8> {
 }
 
 fn build_tx_context(
-    script: Vec<u8>,
+    bytecode: Vec<u8>,
     outputs: Vec<(u64, Vec<u8>)>,
     input_value: u64,
     lock_time: u64,
@@ -157,7 +157,7 @@ fn build_tx_context(
         .map(|(value, script)| TransactionOutput { value, script_public_key: ScriptPublicKey::new(0, script.into()), covenant: None })
         .collect::<Vec<_>>();
     let tx = Transaction::new(version, vec![input.clone()], tx_outputs.clone(), lock_time, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
     tx.tx.inputs[0].signature_script = vec![];
     (tx, utxo_entry, reused_values)
@@ -259,8 +259,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -275,8 +275,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Byte(1)], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -289,8 +289,8 @@ fn runs_cashc_valid_examples() {
                 let constructor_args = vec![];
                 let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -310,8 +310,8 @@ fn runs_cashc_valid_examples() {
                 let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
                 let selector = selector_for_compiled(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -329,8 +329,8 @@ fn runs_cashc_valid_examples() {
                 let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
                 let selector = selector_for_compiled(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -350,8 +350,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "spend");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -367,8 +367,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "test");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -383,8 +383,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "spend");
                 let sigscript = build_sigscript(&[ArgValue::Int(1)], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -400,8 +400,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -418,8 +418,8 @@ fn runs_cashc_valid_examples() {
                 let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
                 let selector = selector_for_compiled(&compiled, "transfer");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -437,8 +437,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "spend");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -454,8 +454,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -470,8 +470,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Int(1)], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -486,8 +486,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(20), ArgValue::Int(1_209_600)], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -502,8 +502,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Byte(1)], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -524,8 +524,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, function_name);
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -544,8 +544,8 @@ fn runs_cashc_valid_examples() {
                 let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
                 let selector = selector_for_compiled(&compiled, "transfer");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -562,8 +562,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "transfer");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Int(2)], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -578,8 +578,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "spend");
                 let sigscript = build_sigscript(&[ArgValue::Int(0), ArgValue::String("Nope".to_string())], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -594,8 +594,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -610,8 +610,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "spend");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -627,8 +627,8 @@ fn runs_cashc_valid_examples() {
                 let constructor_args = vec![pkh.into()];
                 let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -647,8 +647,8 @@ fn runs_cashc_valid_examples() {
                 let constructor_args = vec![pkh.into()];
                 let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -666,8 +666,8 @@ fn runs_cashc_valid_examples() {
                 let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
                 let selector = selector_for_compiled(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -686,8 +686,8 @@ fn runs_cashc_valid_examples() {
                 let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
                 let selector = selector_for_compiled(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -717,8 +717,8 @@ fn runs_cashc_valid_examples() {
                     let selector = selector_for_compiled(&compiled, "cds");
                     let sigscript = build_sigscript(&[ArgValue::Bytes(message.clone())], selector);
                     let (mut tx, utxo, reused) = build_tx_context(
-                        compiled.script.clone(),
-                        vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                        compiled.bytecode.clone(),
+                        vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                         2_000,
                         0,
                         1,
@@ -749,8 +749,8 @@ fn runs_cashc_valid_examples() {
                     let selector = selector_for_compiled(&compiled, "cds");
                     let sigscript = build_sigscript(&[ArgValue::Bytes(message.clone())], selector);
                     let (mut tx, utxo, reused) = build_tx_context(
-                        compiled.script.clone(),
-                        vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                        compiled.bytecode.clone(),
+                        vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                         2_000,
                         0,
                         1,
@@ -770,8 +770,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -786,8 +786,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "covenant");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     2,
@@ -802,8 +802,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "world");
                 let sigscript = build_sigscript(&[ArgValue::Int(5)], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -818,8 +818,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(0), ArgValue::String("Hello World".to_string())], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -834,8 +834,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "spend");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -850,8 +850,8 @@ fn runs_cashc_valid_examples() {
                 let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
                 let selector = selector_for_compiled(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -894,7 +894,7 @@ fn runs_cashc_valid_examples() {
                     out.extend_from_slice(&lock_bytes);
                     let mut active_bytecode = Vec::new();
                     active_bytecode.extend_from_slice(&0u16.to_be_bytes());
-                    active_bytecode.extend_from_slice(&compiled.script);
+                    active_bytecode.extend_from_slice(&compiled.bytecode);
                     out.extend_from_slice(&active_bytecode[9..]);
                     out
                 };
@@ -904,7 +904,7 @@ fn runs_cashc_valid_examples() {
 
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
+                    compiled.bytecode.clone(),
                     vec![(output0_value, output0_script), (output1_value, output1_script)],
                     input_value,
                     lock_time,
@@ -921,8 +921,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "spend");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -937,8 +937,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "spend");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -956,8 +956,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "spend");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -972,8 +972,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "spend");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -988,8 +988,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "spend");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -1004,8 +1004,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::String("world".to_string())], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -1021,8 +1021,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "hello");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -1038,8 +1038,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "split");
                 let sigscript = build_sigscript(&[], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -1054,8 +1054,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "split");
                 let sigscript = build_sigscript(&[ArgValue::Bytes(vec![0u8; 32])], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,
@@ -1070,8 +1070,8 @@ fn runs_cashc_valid_examples() {
                 let selector = selector_for_compiled(&compiled, "split");
                 let sigscript = build_sigscript(&[ArgValue::Bytes(vec![0u8; 32])], selector);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.script.clone(),
-                    vec![(1_000, compiled.script.clone()), (1_000, compiled.script.clone())],
+                    compiled.bytecode.clone(),
+                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
                     2_000,
                     0,
                     1,

--- a/silverscript-lang/tests/chess_apps_tests.rs
+++ b/silverscript-lang/tests/chess_apps_tests.rs
@@ -28,7 +28,7 @@ const DEFAULT_MOVE_TIMEOUT: i64 = 600;
 struct SizeSnapshot {
     name: &'static str,
     ctor: fn() -> Vec<Expr<'static>>,
-    expected_script_len: usize,
+    expected_bytecode_len: usize,
     // Total complete P2SH sigscript bytes in the runtime-tested transaction.
     expected_sigscript_len: usize,
     expected_instruction_count: usize,
@@ -318,8 +318,8 @@ fn routes_commitment(route_templates: &[u8]) -> Hash {
 fn template_fixture(source: &'static str, ctor: &[Expr<'static>]) -> TemplateFixture {
     let compiled = compile_cached(source, ctor);
     let layout = compiled.state_layout;
-    let prefix = compiled.script[..layout.start].to_vec();
-    let suffix = compiled.script[layout.start + layout.len..].to_vec();
+    let prefix = compiled.bytecode[..layout.start].to_vec();
+    let suffix = compiled.bytecode[layout.start + layout.len..].to_vec();
     let hash = Hash::from_bytes(compiled.template_hash());
     TemplateFixture { source, prefix, suffix, hash }
 }
@@ -443,7 +443,7 @@ fn player_template_hash(fix: &MuxChessFixture) -> Hash {
 fn entry_sigscript(compiled: &CompiledContract<'_>, function: &str, args: Vec<Expr<'_>>) -> Vec<u8> {
     let sigscript = compiled.build_sig_script(function, args).expect("sigscript builds");
     pay_to_script_hash_signature_script_with_flags(
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         sigscript,
         EngineFlags { covenants_enabled: true, ..Default::default() },
     )
@@ -467,7 +467,7 @@ fn covenant_output_with_value(
 ) -> TransactionOutput {
     TransactionOutput {
         value,
-        script_public_key: pay_to_script_hash_script(&compiled.script),
+        script_public_key: pay_to_script_hash_script(&compiled.bytecode),
         covenant: Some(CovenantBinding { authorizing_input, covenant_id }),
     }
 }
@@ -477,7 +477,7 @@ fn covenant_output(compiled: &CompiledContract<'_>, authorizing_input: u16, cove
 }
 
 fn covenant_utxo_with_value(compiled: &CompiledContract<'_>, covenant_id: Hash, value: u64) -> UtxoEntry {
-    UtxoEntry::new(value, pay_to_script_hash_script(&compiled.script), 0, false, Some(covenant_id))
+    UtxoEntry::new(value, pay_to_script_hash_script(&compiled.bytecode), 0, false, Some(covenant_id))
 }
 
 fn covenant_utxo(compiled: &CompiledContract<'_>, covenant_id: Hash) -> UtxoEntry {
@@ -639,12 +639,12 @@ fn approx_updated_rating(self_rating: i64, opp_rating: i64, actual_score: i64) -
     self_rating + delta
 }
 
-fn script_op_counts(script: &[u8]) -> (usize, usize) {
+fn bytecode_op_counts(script: &[u8]) -> (usize, usize) {
     let mut instruction_count = 0;
     let mut charged_op_count = 0;
 
     for opcode in parse_script::<PopulatedTransaction<'static>, SigHashReusedValuesUnsync>(script) {
-        let opcode = opcode.expect("compiled script should parse");
+        let opcode = opcode.expect("compiled bytecode should parse");
         instruction_count += 1;
         if !opcode.is_push_opcode() {
             charged_op_count += 1;
@@ -664,7 +664,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "league.sil",
             ctor: league_constructor_args,
-            expected_script_len: 469,
+            expected_bytecode_len: 469,
             expected_sigscript_len: 3675,
             expected_instruction_count: 270,
             expected_charged_op_count: 196,
@@ -672,7 +672,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "player.sil",
             ctor: player_constructor_args,
-            expected_script_len: 3351,
+            expected_bytecode_len: 3351,
             expected_sigscript_len: 8369,
             expected_instruction_count: 2442,
             expected_charged_op_count: 1584,
@@ -680,7 +680,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "chess_mux.sil",
             ctor: mux_constructor_args,
-            expected_script_len: 1712,
+            expected_bytecode_len: 1712,
             expected_sigscript_len: 3145,
             expected_instruction_count: 1030,
             expected_charged_op_count: 701,
@@ -688,7 +688,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "chess_settle.sil",
             ctor: settle_constructor_args,
-            expected_script_len: 2720,
+            expected_bytecode_len: 2720,
             expected_sigscript_len: 10081,
             expected_instruction_count: 2049,
             expected_charged_op_count: 1336,
@@ -696,7 +696,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "chess_pawn.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 1827,
+            expected_bytecode_len: 1827,
             expected_sigscript_len: 3006,
             expected_instruction_count: 1185,
             expected_charged_op_count: 786,
@@ -704,7 +704,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "chess_knight.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 1417,
+            expected_bytecode_len: 1417,
             expected_sigscript_len: 2596,
             expected_instruction_count: 810,
             expected_charged_op_count: 542,
@@ -712,7 +712,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "chess_vert.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 2005,
+            expected_bytecode_len: 2005,
             expected_sigscript_len: 3184,
             expected_instruction_count: 1368,
             expected_charged_op_count: 949,
@@ -720,7 +720,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "chess_horiz.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 2005,
+            expected_bytecode_len: 2005,
             expected_sigscript_len: 3184,
             expected_instruction_count: 1368,
             expected_charged_op_count: 949,
@@ -728,7 +728,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "chess_diag.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 1972,
+            expected_bytecode_len: 1972,
             expected_sigscript_len: 3151,
             expected_instruction_count: 1342,
             expected_charged_op_count: 931,
@@ -736,7 +736,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "chess_king.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 1487,
+            expected_bytecode_len: 1487,
             expected_sigscript_len: 2666,
             expected_instruction_count: 861,
             expected_charged_op_count: 577,
@@ -744,7 +744,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "chess_castle.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 1533,
+            expected_bytecode_len: 1533,
             expected_sigscript_len: 2712,
             expected_instruction_count: 920,
             expected_charged_op_count: 609,
@@ -752,7 +752,7 @@ fn size_snapshots() -> Vec<SizeSnapshot> {
         SizeSnapshot {
             name: "chess_castle_challenge.sil",
             ctor: pawn_constructor_args,
-            expected_script_len: 1627,
+            expected_bytecode_len: 1627,
             expected_sigscript_len: 2921,
             expected_instruction_count: 1015,
             expected_charged_op_count: 669,
@@ -850,17 +850,17 @@ fn chess_apps_compile_and_probe_sizes_within_noise() {
         let source = local_contract_source(snapshot.name);
         let ctor = (snapshot.ctor)();
         let compiled = compile_cached(source, &ctor);
-        let (instruction_count, charged_op_count) = script_op_counts(&compiled.script);
+        let (instruction_count, charged_op_count) = bytecode_op_counts(&compiled.bytecode);
 
-        actual_sizes.push((snapshot.name, compiled.script.len(), instruction_count, charged_op_count));
+        actual_sizes.push((snapshot.name, compiled.bytecode.len(), instruction_count, charged_op_count));
     }
 
-    for (name, script_len, instruction_count, charged_op_count) in &actual_sizes {
-        println!("{name} script={script_len} instructions={instruction_count} charged_ops={charged_op_count}");
+    for (name, bytecode_len, instruction_count, charged_op_count) in &actual_sizes {
+        println!("{name} bytecode={bytecode_len} instructions={instruction_count} charged_ops={charged_op_count}");
     }
 
-    for (snapshot, (_, script_len, instruction_count, charged_op_count)) in size_snapshots().into_iter().zip(actual_sizes) {
-        assert_size_within_noise(&format!("{} script_len", snapshot.name), script_len, snapshot.expected_script_len);
+    for (snapshot, (_, bytecode_len, instruction_count, charged_op_count)) in size_snapshots().into_iter().zip(actual_sizes) {
+        assert_size_within_noise(&format!("{} bytecode_len", snapshot.name), bytecode_len, snapshot.expected_bytecode_len);
         assert_size_within_noise(
             &format!("{} instruction_count", snapshot.name),
             instruction_count,
@@ -899,8 +899,8 @@ fn league_register_player_runtime_matches_expected_output_state() {
     ];
     let player_template_contract = compile_cached(player_source(), &player_template_ctor);
     let layout = player_template_contract.state_layout;
-    let player_prefix = player_template_contract.script[..layout.start].to_vec();
-    let player_suffix = player_template_contract.script[layout.start + layout.len..].to_vec();
+    let player_prefix = player_template_contract.bytecode[..layout.start].to_vec();
+    let player_suffix = player_template_contract.bytecode[layout.start + layout.len..].to_vec();
     let player_template = Hash::from_bytes(player_template_contract.template_hash());
 
     let league_ctor = vec![
@@ -1004,7 +1004,7 @@ fn player_start_game_runtime_matches_expected_output_states() {
     let player_layout = player_contract.state_layout;
     let player_template = Hash::from_bytes(player_contract.template_hash());
     let player_prefix_len = player_layout.start as i64;
-    let player_suffix_len = (player_contract.script.len() - (player_layout.start + player_layout.len)) as i64;
+    let player_suffix_len = (player_contract.bytecode.len() - (player_layout.start + player_layout.len)) as i64;
 
     let white_player = compile_player_state(
         player_source(),
@@ -1219,7 +1219,7 @@ fn player_rebalance_requires_a_standalone_covenant_input() {
     );
     let player_layout = player.state_layout;
     let player_prefix_len = player_layout.start as i64;
-    let player_suffix_len = (player.script.len() - player_layout.start - player_layout.len) as i64;
+    let player_suffix_len = (player.bytecode.len() - player_layout.start - player_layout.len) as i64;
 
     let placeholder = entry_sigscript(&player, "rebalance", vec![Expr::bytes(vec![0u8; 65]), Expr::bytes(owner.pubkey_bytes.clone())]);
     let entries = vec![covenant_utxo(&player, covenant_id)];
@@ -1320,7 +1320,7 @@ fn player_retire_requires_a_standalone_covenant_input() {
     );
     let player_layout = player.state_layout;
     let player_prefix_len = player_layout.start as i64;
-    let player_suffix_len = (player.script.len() - player_layout.start - player_layout.len) as i64;
+    let player_suffix_len = (player.bytecode.len() - player_layout.start - player_layout.len) as i64;
 
     let placeholder = entry_sigscript(&player, "retire", vec![Expr::bytes(vec![0u8; 65]), Expr::bytes(owner.pubkey_bytes.clone())]);
     let entries = vec![covenant_utxo(&player, covenant_id)];
@@ -1945,7 +1945,7 @@ fn settle_runtime_matches_expected_output_states() {
         "settle",
         vec![
             Expr::int(player_layout.start as i64),
-            Expr::int((player_contract.script.len() - player_layout.start - player_layout.len) as i64),
+            Expr::int((player_contract.bytecode.len() - player_layout.start - player_layout.len) as i64),
         ],
     );
     let settle_prefix_len = fix.settle.prefix.len() as i64;

--- a/silverscript-lang/tests/common.rs
+++ b/silverscript-lang/tests/common.rs
@@ -18,9 +18,9 @@ use silverscript_lang::compiler::{CompiledContract, CovenantDeclCallOptions};
 pub const COV_A: Hash = Hash::from_bytes(*b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
 pub const COV_B: Hash = Hash::from_bytes(*b"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
 
-pub fn push_redeem_script(script: &[u8]) -> Vec<u8> {
+pub fn push_redeem_script(bytecode: &[u8]) -> Vec<u8> {
     ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() })
-        .add_data(script)
+        .add_data(bytecode)
         .expect("push redeem script")
         .drain()
 }
@@ -29,12 +29,12 @@ pub fn covenant_decl_sigscript(compiled: &CompiledContract<'_>, function_name: &
     let mut sigscript = compiled
         .build_sig_script_for_covenant_decl(function_name, args, CovenantDeclCallOptions { is_leader })
         .expect("build covenant declaration sigscript");
-    sigscript.extend_from_slice(&push_redeem_script(&compiled.script));
+    sigscript.extend_from_slice(&push_redeem_script(&compiled.bytecode));
     sigscript
 }
 
 pub fn covenant_utxo(compiled: &CompiledContract<'_>, covenant_id: Hash) -> UtxoEntry {
-    UtxoEntry::new(1_500, pay_to_script_hash_script(&compiled.script), 0, false, Some(covenant_id))
+    UtxoEntry::new(1_500, pay_to_script_hash_script(&compiled.bytecode), 0, false, Some(covenant_id))
 }
 
 pub fn plain_covenant_output(authorizing_input: u16, covenant_id: Hash) -> TransactionOutput {
@@ -84,15 +84,15 @@ pub fn tx_input(index: u32, signature_script: Vec<u8>) -> TransactionInput {
 pub fn covenant_output(compiled: &CompiledContract<'_>, authorizing_input: u16, covenant_id: Hash) -> TransactionOutput {
     TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&compiled.script),
+        script_public_key: pay_to_script_hash_script(&compiled.bytecode),
         covenant: Some(CovenantBinding { authorizing_input, covenant_id }),
     }
 }
 
 pub fn compiled_template_parts_and_hash(compiled: &CompiledContract) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
     let layout = compiled.state_layout;
-    let prefix = compiled.script[..layout.start].to_vec();
-    let suffix = compiled.script[layout.start + layout.len..].to_vec();
+    let prefix = compiled.bytecode[..layout.start].to_vec();
+    let suffix = compiled.bytecode[layout.start + layout.len..].to_vec();
     let template_hash = compiled.template_hash().to_vec();
     (prefix, suffix, template_hash)
 }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -67,13 +67,13 @@ fn pay_to_script_hash_signature_script(
     )
 }
 
-fn run_script_with_selector(script: Vec<u8>, selector: Option<i64>) -> Result<(), kaspa_txscript_errors::TxScriptError> {
+fn run_bytecode_with_selector(bytecode: Vec<u8>, selector: Option<i64>) -> Result<(), kaspa_txscript_errors::TxScriptError> {
     let sigscript = selector_sigscript(selector);
-    run_script_with_sigscript(script, sigscript)
+    run_bytecode_with_sigscript(bytecode, sigscript)
 }
 
-fn run_script_with_tx(
-    script: Vec<u8>,
+fn run_bytecode_with_tx(
+    bytecode: Vec<u8>,
     selector: Option<i64>,
     lock_time: u64,
     sequence: u64,
@@ -88,7 +88,8 @@ fn run_script_with_tx(
         sequence,
         0,
     );
-    let output = TransactionOutput { value: 1000, script_public_key: ScriptPublicKey::new(0, script.clone().into()), covenant: None };
+    let output =
+        TransactionOutput { value: 1000, script_public_key: ScriptPublicKey::new(0, bytecode.clone().into()), covenant: None };
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], lock_time, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, output.script_public_key.clone(), 0, tx.is_coinbase(), None);
     let populated_tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
@@ -112,13 +113,14 @@ fn selector_sigscript(selector: Option<i64>) -> Vec<u8> {
     builder.drain()
 }
 
-fn run_script_with_sigscript(script: Vec<u8>, sigscript: Vec<u8>) -> Result<(), kaspa_txscript_errors::TxScriptError> {
+fn run_bytecode_with_sigscript(bytecode: Vec<u8>, sigscript: Vec<u8>) -> Result<(), kaspa_txscript_errors::TxScriptError> {
     let reused_values = SigHashReusedValuesUnsync::new();
     let sig_cache = Cache::new(10_000);
 
     let input =
         TransactionInput::new(TransactionOutpoint { transaction_id: TransactionId::from_bytes([1u8; 32]), index: 0 }, sigscript, 0, 0);
-    let output = TransactionOutput { value: 1000, script_public_key: ScriptPublicKey::new(0, script.clone().into()), covenant: None };
+    let output =
+        TransactionOutput { value: 1000, script_public_key: ScriptPublicKey::new(0, bytecode.clone().into()), covenant: None };
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, output.script_public_key.clone(), 0, tx.is_coinbase(), None);
     let populated_tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
@@ -134,12 +136,12 @@ fn run_script_with_sigscript(script: Vec<u8>, sigscript: Vec<u8>) -> Result<(), 
     vm.execute()
 }
 
-fn script_op_counts(script: &[u8]) -> (usize, usize) {
+fn bytecode_op_counts(bytecode: &[u8]) -> (usize, usize) {
     let mut instruction_count = 0;
     let mut charged_op_count = 0;
 
-    for opcode in parse_script::<PopulatedTransaction<'static>, SigHashReusedValuesUnsync>(script) {
-        let opcode = opcode.expect("compiled script should parse");
+    for opcode in parse_script::<PopulatedTransaction<'static>, SigHashReusedValuesUnsync>(bytecode) {
+        let opcode = opcode.expect("compiled bytecode should parse");
         instruction_count += 1;
         if !opcode.is_push_opcode() {
             charged_op_count += 1;
@@ -149,8 +151,8 @@ fn script_op_counts(script: &[u8]) -> (usize, usize) {
     (instruction_count, charged_op_count)
 }
 
-fn sigscript_push_script(script: &[u8]) -> Vec<u8> {
-    script_builder().add_data_with_push_opcode(script).unwrap().drain()
+fn sigscript_push_bytecode(bytecode: &[u8]) -> Vec<u8> {
+    script_builder().add_data_with_push_opcode(bytecode).unwrap().drain()
 }
 
 fn test_input(index: u32, signature_script: Vec<u8>) -> TransactionInput {
@@ -333,7 +335,7 @@ fn supports_struct_contract_params_fields_and_constants() {
     let args = vec![struct_object("Pair", vec![("amount", Expr::int(11)), ("code", Expr::bytes(vec![0xab, 0xcd]))])];
     let compiled = compile_contract(source, &args, CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "top-level struct param/field/constant contract should run: {result:?}");
 }
 
@@ -785,22 +787,22 @@ fn branch_heavy_if_else_logic_matches_rust_model_across_cases() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("branch-heavy contract should compile");
-    let script_len = compiled.script.len();
-    let (instruction_count, charged_op_count) = script_op_counts(&compiled.script);
-    println!("branch_maze {script_len} / {instruction_count} / {charged_op_count}");
+    let bytecode_len = compiled.bytecode.len();
+    let (instruction_count, charged_op_count) = bytecode_op_counts(&compiled.bytecode);
+    println!("branch_maze {bytecode_len} / {instruction_count} / {charged_op_count}");
     // Snapshot these metrics exactly so compiler codegen changes must consciously
     // acknowledge their size impact on a branch-heavy stress case.
     assert_eq!(
-        script_len, 318,
-        "branch_maze metrics: script_len={script_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
+        bytecode_len, 318,
+        "branch_maze metrics: bytecode_len={bytecode_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
     );
     assert_eq!(
         instruction_count, 318,
-        "branch_maze metrics: script_len={script_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
+        "branch_maze metrics: bytecode_len={bytecode_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
     );
     assert_eq!(
         charged_op_count, 227,
-        "branch_maze metrics: script_len={script_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
+        "branch_maze metrics: bytecode_len={bytecode_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
     );
     let cases = [(7, 2, 5, 4), (7, 2, -3, 4), (2, 7, 5, 4), (2, 7, 5, 3), (4, 4, 9, 2), (-3, 1, 6, -2), (10, -1, -4, 7), (0, 0, 0, 0)];
 
@@ -821,7 +823,7 @@ fn branch_heavy_if_else_logic_matches_rust_model_across_cases() {
                 ],
             )
             .expect("sigscript builds");
-        let result = run_script_with_sigscript(compiled.script.clone(), sigscript);
+        let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
         assert!(
             result.is_ok(),
             "branch-heavy case ({a}, {b}, {c}, {d}) should match Rust model ({expected_x}, {expected_y}, {expected_z}, {expected_score}): {result:?}"
@@ -845,7 +847,7 @@ fn branch_heavy_if_else_logic_matches_rust_model_across_cases() {
             ],
         )
         .expect("sigscript builds");
-    let err = run_script_with_sigscript(compiled.script.clone(), wrong_sigscript)
+    let err = run_bytecode_with_sigscript(compiled.bytecode.clone(), wrong_sigscript)
         .expect_err("branch-heavy case with wrong expected output should fail");
     assert!(format!("{err:?}").contains("Verify"), "wrong expected output should fail with verify error, got: {err:?}");
 }
@@ -927,20 +929,20 @@ fn sorting_network_over_fixed_array_matches_rust_model_across_cases() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("sorting-network contract should compile");
-    let script_len = compiled.script.len();
-    let (instruction_count, charged_op_count) = script_op_counts(&compiled.script);
-    println!("sorting_network {script_len} / {instruction_count} / {charged_op_count}");
+    let bytecode_len = compiled.bytecode.len();
+    let (instruction_count, charged_op_count) = bytecode_op_counts(&compiled.bytecode);
+    println!("sorting_network {bytecode_len} / {instruction_count} / {charged_op_count}");
     assert_eq!(
-        script_len, 763,
-        "sorting_network metrics: script_len={script_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
+        bytecode_len, 763,
+        "sorting_network metrics: bytecode_len={bytecode_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
     );
     assert_eq!(
         instruction_count, 762,
-        "sorting_network metrics: script_len={script_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
+        "sorting_network metrics: bytecode_len={bytecode_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
     );
     assert_eq!(
         charged_op_count, 595,
-        "sorting_network metrics: script_len={script_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
+        "sorting_network metrics: bytecode_len={bytecode_len} instruction_count={instruction_count} charged_op_count={charged_op_count}"
     );
 
     let cases = [
@@ -970,7 +972,7 @@ fn sorting_network_over_fixed_array_matches_rust_model_across_cases() {
                 ],
             )
             .expect("sigscript builds");
-        let result = run_script_with_sigscript(compiled.script.clone(), sigscript);
+        let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
         assert!(result.is_ok(), "sorting-network case {values:?} should match Rust model: {result:?}");
     }
 }
@@ -1091,8 +1093,8 @@ fn byte_variable_from_int_literal_uses_raw_byte_push() {
         .add_op(OpTrue)
         .unwrap()
         .drain();
-    assert_eq!(compiled.script, expected);
-    assert!(run_script_with_selector(compiled.script, None).is_ok(), "byte int literal script should execute");
+    assert_eq!(compiled.bytecode, expected);
+    assert!(run_bytecode_with_selector(compiled.bytecode, None).is_ok(), "byte int literal script should execute");
 }
 
 #[test]
@@ -1122,8 +1124,8 @@ fn byte_equality_uses_op_equal_not_op_numequal() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("byte equality should compile");
-    assert!(compiled.script.iter().copied().any(|op| op == OpEqual), "byte equality should use OP_EQUAL");
-    assert!(!compiled.script.iter().copied().any(|op| op == OpNumEqual), "byte equality should not use OP_NUMEQUAL");
+    assert!(compiled.bytecode.iter().copied().any(|op| op == OpEqual), "byte equality should use OP_EQUAL");
+    assert!(!compiled.bytecode.iter().copied().any(|op| op == OpNumEqual), "byte equality should not use OP_NUMEQUAL");
 }
 
 #[test]
@@ -1150,8 +1152,8 @@ fn byte_equality_with_rhs_int_literal_uses_raw_byte_push() {
         .add_op(OpTrue)
         .unwrap()
         .drain();
-    assert_eq!(compiled.script, expected);
-    assert!(run_script_with_selector(compiled.script, None).is_ok(), "byte equality with rhs literal should execute");
+    assert_eq!(compiled.bytecode, expected);
+    assert!(run_bytecode_with_selector(compiled.bytecode, None).is_ok(), "byte equality with rhs literal should execute");
 }
 
 #[test]
@@ -1743,8 +1745,8 @@ fn byte_array_to_fixed_byte_array_cast_compiles_without_num2bin() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("byte[] to byte[32] cast should compile");
-    assert!(!compiled.script.iter().copied().any(|op| op == OpNum2Bin), "byte[] to byte[32] cast should not emit OpNum2Bin");
-    assert!(run_script_with_selector(compiled.script, None).is_ok(), "byte[] to byte[32] cast should execute");
+    assert!(!compiled.bytecode.iter().copied().any(|op| op == OpNum2Bin), "byte[] to byte[32] cast should not emit OpNum2Bin");
+    assert!(run_bytecode_with_selector(compiled.bytecode, None).is_ok(), "byte[] to byte[32] cast should execute");
 }
 
 #[test]
@@ -1793,7 +1795,7 @@ fn encodes_non_byte_array_literal_cast_in_contract_field() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("non-byte array literal cast should compile");
-    assert!(run_script_with_selector(compiled.script, None).is_ok(), "encoded non-byte array literal cast should execute");
+    assert!(run_bytecode_with_selector(compiled.bytecode, None).is_ok(), "encoded non-byte array literal cast should execute");
 }
 
 #[test]
@@ -2141,7 +2143,7 @@ fn compiles_struct_sugar_for_locals_calls_and_field_access() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "script should execute successfully: {result:?}");
 }
 
@@ -2172,7 +2174,7 @@ fn compiles_struct_return_types_in_inline_calls() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "struct-return inline call should execute successfully: {result:?}");
 }
 
@@ -2973,7 +2975,7 @@ fn runtime_supports_regular_struct_array_entrypoint_arguments_with_struct_signat
     let sigscript = compiled
         .build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
         .expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
 
     assert!(result.is_ok(), "regular struct[] entrypoint arg should execute successfully: {result:?}");
 }
@@ -3013,7 +3015,7 @@ fn runtime_supports_direct_struct_array_entrypoint_signature() {
     let sigscript = compiled
         .build_sig_script("f", vec![struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
         .expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
 
     assert!(result.is_ok(), "direct struct[] entrypoint signature should execute successfully: {result:?}");
 }
@@ -3101,7 +3103,7 @@ fn runtime_supports_struct_array_append_value_expression() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = compiled.build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02])])]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
 
     assert!(result.is_ok(), "struct[] append value expression should execute successfully: {result:?}");
 }
@@ -3236,7 +3238,7 @@ fn runtime_supports_regular_struct_array_non_entrypoint_arguments_with_struct_si
     let sigscript = compiled
         .build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
         .expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
 
     assert!(result.is_ok(), "regular struct[] arg should flow through non-entrypoint calls at runtime: {result:?}");
 }
@@ -3305,7 +3307,7 @@ fn runtime_supports_direct_struct_array_non_entrypoint_signature() {
     let sigscript = compiled
         .build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
         .expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
 
     assert!(result.is_ok(), "direct struct[] non-entrypoint signature should execute successfully: {result:?}");
 }
@@ -3536,7 +3538,7 @@ fn compiles_struct_destructuring_and_runs() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "struct destructuring runtime failed: {}", result.unwrap_err());
 }
 
@@ -3600,7 +3602,7 @@ fn compiles_function_call_assignment_and_verifies() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
 
@@ -3621,8 +3623,8 @@ fn compiles_function_call_statement_elides_unused_return_expression() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    assert!(!compiled.script.contains(&OpAdd), "unused inline return expressions should be elided entirely");
-    assert!(run_script_with_selector(compiled.script, selector).is_ok());
+    assert!(!compiled.bytecode.contains(&OpAdd), "unused inline return expressions should be elided entirely");
+    assert!(run_bytecode_with_selector(compiled.bytecode, selector).is_ok());
 }
 
 #[test]
@@ -3746,7 +3748,7 @@ fn allows_calling_void_function() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
 
@@ -3794,7 +3796,7 @@ fn function_call_in_require_statement() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("expression-position helper call should compile");
     let sigscript = compiled.build_sig_script("main", vec![Expr::int(4)]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "expression-position helper call should execute successfully: {}", result.unwrap_err());
 }
 
@@ -3814,7 +3816,7 @@ fn single_return_helper_call_can_participate_in_expression() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("single-return helper call should compile");
     let sigscript = compiled.build_sig_script("main", vec![Expr::int(4)]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "single-return helper call should execute successfully: {}", result.unwrap_err());
 }
 
@@ -3854,7 +3856,7 @@ fn rejects_calling_later_defined_function() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("forward call should now compile");
     let selector = selector_for(&compiled, "first");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "forward call should execute successfully: {}", result.unwrap_err());
 }
 
@@ -3934,7 +3936,7 @@ fn multi_return_helper_call_assignment_remains_valid() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("tuple call assignment should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "tuple call assignment should execute successfully: {}", result.unwrap_err());
 }
 
@@ -3955,7 +3957,7 @@ fn tuple_return_field_access_can_initialize_variable_and_run() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("tuple field access should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "tuple field access variable initializer should execute successfully: {}", result.unwrap_err());
 }
 
@@ -3975,7 +3977,7 @@ fn tuple_return_field_access_can_be_used_in_require_and_run() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("tuple field access in require should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "tuple field access in require should execute successfully: {}", result.unwrap_err());
 }
 
@@ -3995,7 +3997,7 @@ fn tuple_return_field_access_allows_parenthesized_single_return_type() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("f() : (int) should allow f().0");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "single-element tuple field access should execute successfully: {}", result.unwrap_err());
 }
 
@@ -4082,7 +4084,7 @@ fn allows_call_chain_with_earlier_defined_functions() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
 
@@ -4116,7 +4118,7 @@ fn allows_call_chain_with_later_defined_functions() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
 
@@ -4179,7 +4181,7 @@ fn allows_calling_void_function_fails() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    assert!(run_script_with_selector(compiled.script, selector).is_err());
+    assert!(run_bytecode_with_selector(compiled.bytecode, selector).is_err());
 }
 
 #[test]
@@ -4248,7 +4250,7 @@ fn single_return_signature_without_parentheses_compiles_and_runs() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "single bare return type should execute successfully: {}", result.unwrap_err());
 }
 
@@ -4269,7 +4271,7 @@ fn single_return_signature_without_parentheses_supports_direct_variable_definiti
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "direct variable definition assignment should execute successfully: {}", result.unwrap_err());
 }
 
@@ -4290,7 +4292,7 @@ fn single_return_statement_without_parentheses_compiles_and_runs() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "single bare return statement should execute successfully: {}", result.unwrap_err());
 }
 
@@ -4333,7 +4335,7 @@ fn array_literal_codegen_uses_declared_element_type() {
 
     let compiled = compile_contract(source, &[], CompileOptions { record_debug_infos: true, ..CompileOptions::default() })
         .expect("compile succeeds");
-    let result = run_script_with_sigscript(compiled.script, script_builder().drain());
+    let result = run_bytecode_with_sigscript(compiled.bytecode, script_builder().drain());
     assert!(result.is_ok(), "array literals should use their declared element type: {}", result.unwrap_err());
 }
 
@@ -4377,7 +4379,7 @@ fn compiles_int_array_length_to_expected_script() {
         .unwrap()
         .drain();
 
-    assert_eq!(compiled.script, expected);
+    assert_eq!(compiled.bytecode, expected);
 }
 
 #[test]
@@ -4429,7 +4431,7 @@ fn compiles_int_array_append_to_expected_script() {
         .unwrap()
         .drain();
 
-    assert_eq!(compiled.script, expected);
+    assert_eq!(compiled.bytecode, expected);
 }
 
 #[test]
@@ -4547,7 +4549,7 @@ fn branchy_three_slot_splice_repro_matches_current_codegen_shape() {
         Expr::int(3),
     ];
     let compiled = compile_contract(source, &args, CompileOptions::default()).expect("compile succeeds");
-    let asm = script_to_str(&compiled.script).expect("compiled script should stringify");
+    let asm = script_to_str(&compiled.bytecode).expect("compiled bytecode should stringify");
 
     // This is a reduced repro for the chess pawn blowup on the current branch.
     // This used to explode because branch-mutated splice
@@ -4555,7 +4557,7 @@ fn branchy_three_slot_splice_repro_matches_current_codegen_shape() {
     // into a very large opcode shape. With array locals kept on the stack, the
     // same source should stay close to the old master-size range instead of
     // ballooning into thousands of bytes and OpPick instructions.
-    assert!(compiled.script.len() < 1000, "script should stay compact, got {}", compiled.script.len());
+    assert!(compiled.bytecode.len() < 1000, "script should stay compact, got {}", compiled.bytecode.len());
     assert!(asm.matches("OpPick").count() < 120, "OpPick count should stay bounded, got {}", asm.matches("OpPick").count());
     assert!(asm.matches("OpSubstr").count() <= 24, "OpSubstr count should stay near master, got {}", asm.matches("OpSubstr").count());
     assert!(asm.matches("OpDup").count() < 16, "OpDup count should stay near master, got {}", asm.matches("OpDup").count());
@@ -4614,7 +4616,7 @@ fn compiles_int_array_index_to_expected_script() {
         .unwrap()
         .drain();
 
-    assert_eq!(compiled.script, expected);
+    assert_eq!(compiled.bytecode, expected);
 }
 
 #[test]
@@ -4636,7 +4638,7 @@ fn runs_array_append_runtime_examples() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "array append runtime example failed: {}", result.unwrap_err());
 }
 
@@ -4654,7 +4656,7 @@ fn runs_int_array_append_length_runtime_example() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "int[] append length runtime example failed: {}", result.unwrap_err());
 }
 
@@ -4672,7 +4674,7 @@ fn runs_slice_with_explicit_end_bounds() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "slice runtime should succeed: {}", result.unwrap_err());
 }
 
@@ -4696,7 +4698,7 @@ fn runs_slice_reconstruction_and_compare_runtime_example() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "slice reconstruction runtime should succeed: {}", result.unwrap_err());
 }
 
@@ -4721,7 +4723,7 @@ fn allows_concat_of_int_arrays_with_plus() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "int[] concatenation runtime failed: {}", result.unwrap_err());
 }
 
@@ -4743,7 +4745,7 @@ fn allows_concat_of_byte_arrays_with_plus() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "byte[] concatenation runtime failed: {}", result.unwrap_err());
 }
 
@@ -4759,7 +4761,7 @@ fn concatenated_byte_array_literal_has_element_length() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let result = run_script_with_sigscript(compiled.script, script_builder().drain());
+    let result = run_bytecode_with_sigscript(compiled.bytecode, script_builder().drain());
     assert!(result.is_ok(), "byte[] literal concatenation should have two elements: {}", result.unwrap_err());
 }
 
@@ -4783,7 +4785,7 @@ fn allows_concat_of_fixed_size_byte_array_elements_with_plus() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "byte[N][] concatenation runtime failed: {}", result.unwrap_err());
 }
 
@@ -4802,9 +4804,9 @@ fn composite_array_index_uses_its_result_type_for_bytewise_operations() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    assert!(!compiled.script.contains(&OpNum2Bin), "an indexed byte array element is already byte-encoded");
+    assert!(!compiled.bytecode.contains(&OpNum2Bin), "an indexed byte array element is already byte-encoded");
 
-    let result = run_script_with_sigscript(compiled.script, script_builder().drain());
+    let result = run_bytecode_with_sigscript(compiled.bytecode, script_builder().drain());
     assert!(result.is_ok(), "composite array indexing should use bytewise operations: {}", result.unwrap_err());
 }
 
@@ -4829,7 +4831,7 @@ fn allows_concat_of_bool_arrays_with_plus() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "bool[] concatenation runtime failed: {}", result.unwrap_err());
 }
 
@@ -4855,7 +4857,7 @@ fn allows_concat_of_pubkey_arrays_with_plus() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "pubkey[] concatenation runtime failed: {}", result.unwrap_err());
 }
 
@@ -4910,7 +4912,7 @@ fn compiles_bytes20_array_append_without_num2bin() {
         .unwrap()
         .drain();
 
-    assert_eq!(compiled.script, expected);
+    assert_eq!(compiled.bytecode, expected);
 }
 
 #[test]
@@ -4930,7 +4932,7 @@ fn runs_bytes20_array_runtime_example() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "byte[20] array runtime example failed: {}", result.unwrap_err());
 }
 
@@ -4950,7 +4952,7 @@ fn allows_array_equality_comparison() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "array equality runtime failed: {}", result.unwrap_err());
 }
 
@@ -4970,7 +4972,7 @@ fn fails_array_equality_comparison() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_err());
 }
 
@@ -4991,7 +4993,7 @@ fn allows_array_inequality_with_different_sizes() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "array inequality runtime failed: {}", result.unwrap_err());
 }
 
@@ -5013,7 +5015,7 @@ fn runs_array_for_loop_example() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "array for-loop runtime failed: {}", result.unwrap_err());
 }
 
@@ -5036,7 +5038,7 @@ fn runs_array_for_loop_with_length_guard() {
 
     let sigscript = compiled.build_sig_script("main", vec![vec![1i64, 2i64, 3i64, 4i64].into()]).expect("sigscript builds");
 
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "array for-loop length-guard runtime failed: {}", result.unwrap_err());
 }
 
@@ -5067,7 +5069,7 @@ fn runs_array_loop_and_function_calls_example() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
 
@@ -5180,15 +5182,15 @@ fn runs_runtime_bounded_for_loop_example() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
     let sigscript = compiled.build_sig_script("main", vec![2.into(), 4.into(), 2.into(), 3.into()]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script.clone(), sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
     assert!(result.is_ok(), "runtime-bounded for-loop should honor end-exclusive bounds: {}", result.unwrap_err());
 
     let sigscript = compiled.build_sig_script("main", vec![5.into(), 8.into(), 3.into(), 7.into()]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script.clone(), sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
     assert!(result.is_ok(), "runtime-bounded for-loop should allow ranges up to max iterations: {}", result.unwrap_err());
 
     let sigscript = compiled.build_sig_script("main", vec![4.into(), 2.into(), 0.into(), (-1).into()]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "runtime-bounded for-loop should skip iterations when start >= end: {}", result.unwrap_err());
 }
 
@@ -5206,7 +5208,7 @@ fn rejects_runtime_for_loop_range_above_max_iterations() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = compiled.build_sig_script("main", vec![2.into(), 6.into()]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_err(), "runtime-bounded for-loop should fail when end - start exceeds max iterations");
 }
 
@@ -5225,7 +5227,7 @@ fn allows_array_assignment_with_compatible_types() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = script_builder().drain();
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "array assignment runtime failed: {}", result.unwrap_err());
 }
 
@@ -5254,13 +5256,13 @@ fn inline_pubkey_param_reassignment_compiles_and_runs() {
     let sigscript_take_b = compiled
         .build_sig_script("main", vec![Expr::bytes(a.clone()), Expr::bytes(b.clone()), Expr::bytes(b.clone()), Expr::bool(true)])
         .expect("sigscript builds");
-    let result_take_b = run_script_with_sigscript(compiled.script.clone(), sigscript_take_b);
+    let result_take_b = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_take_b);
     assert!(result_take_b.is_ok(), "inline pubkey reassignment should allow taking the second value: {}", result_take_b.unwrap_err());
 
     let sigscript_keep_a = compiled
         .build_sig_script("main", vec![Expr::bytes(a.clone()), Expr::bytes(b), Expr::bytes(a), Expr::bool(false)])
         .expect("sigscript builds");
-    let result_keep_a = run_script_with_sigscript(compiled.script, sigscript_keep_a);
+    let result_keep_a = run_bytecode_with_sigscript(compiled.bytecode, sigscript_keep_a);
     assert!(
         result_keep_a.is_ok(),
         "inline pubkey reassignment should preserve the first value when branch is skipped: {}",
@@ -5315,7 +5317,7 @@ fn locking_bytecode_p2pk_matches_pay_to_address_script() {
     expected.extend_from_slice(spk.script());
 
     let sigscript = compiled.build_sig_script("main", vec![pubkey.into(), Expr::dynamic_bytes(expected)]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "p2pk locking bytecode mismatch: {}", result.unwrap_err());
 }
 
@@ -5339,7 +5341,7 @@ fn locking_bytecode_p2sh_matches_pay_to_address_script() {
     expected.extend_from_slice(spk.script());
 
     let sigscript = compiled.build_sig_script("main", vec![hash.into(), Expr::dynamic_bytes(expected)]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "p2sh locking bytecode mismatch: {}", result.unwrap_err());
 }
 
@@ -5364,11 +5366,11 @@ fn locking_bytecode_p2sh_from_redeem_script_matches_pay_to_script_hash_script() 
     let sigscript = compiled
         .build_sig_script("main", vec![Expr::dynamic_bytes(redeem_script), Expr::dynamic_bytes(expected)])
         .expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "p2sh-from-redeem-script locking bytecode mismatch: {}", result.unwrap_err());
 }
 
-fn run_script_with_tx_and_covenants(
+fn run_bytecode_with_tx_and_covenants(
     script: Vec<u8>,
     tx: Transaction,
     mut entries: Vec<UtxoEntry>,
@@ -5520,7 +5522,7 @@ fn compiles_without_selector_single_function() {
         .unwrap()
         .drain();
 
-    assert_eq!(compiled.script, expected);
+    assert_eq!(compiled.bytecode, expected);
 }
 
 #[test]
@@ -5573,8 +5575,8 @@ fn compiles_basic_arithmetic_and_verifies() {
 
     let expected = wrap_with_dispatch(body, selector);
 
-    assert_eq!(compiled.script, expected);
-    assert!(run_script_with_selector(compiled.script, selector).is_ok());
+    assert_eq!(compiled.bytecode, expected);
+    assert!(run_bytecode_with_selector(compiled.bytecode, selector).is_ok());
 }
 
 #[test]
@@ -5607,8 +5609,8 @@ fn compiles_contract_constants_and_verifies() {
 
     let expected = wrap_with_dispatch(body, selector);
 
-    assert_eq!(compiled.script, expected);
-    assert!(run_script_with_selector(compiled.script, selector).is_ok());
+    assert_eq!(compiled.bytecode, expected);
+    assert!(run_bytecode_with_selector(compiled.bytecode, selector).is_ok());
 }
 
 #[test]
@@ -5646,7 +5648,7 @@ fn compiles_contract_fields_as_script_prolog() {
         .unwrap()
         .drain();
 
-    assert_eq!(compiled.script, expected);
+    assert_eq!(compiled.bytecode, expected);
 }
 
 #[test]
@@ -5665,7 +5667,7 @@ fn runs_contract_with_fields_prolog() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    assert!(run_script_with_selector(compiled.script, selector).is_ok());
+    assert!(run_bytecode_with_selector(compiled.bytecode, selector).is_ok());
 }
 
 #[test]
@@ -5692,10 +5694,10 @@ fn runs_selector_dispatch_with_contract_fields() {
     let sigscript_a = compiled.build_sig_script("a", vec![]).expect("sigscript a builds");
     let sigscript_b = compiled.build_sig_script("b", vec![]).expect("sigscript b builds");
 
-    let result_a = run_script_with_sigscript(compiled.script.clone(), sigscript_a);
+    let result_a = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_a);
     assert!(result_a.is_ok(), "entrypoint a runtime failed: {}", result_a.unwrap_err());
 
-    let result_b = run_script_with_sigscript(compiled.script, sigscript_b);
+    let result_b = run_bytecode_with_sigscript(compiled.bytecode, sigscript_b);
     assert!(result_b.is_ok(), "entrypoint b runtime failed: {}", result_b.unwrap_err());
 }
 
@@ -5774,9 +5776,9 @@ fn compiles_validate_output_state_to_expected_script() {
         // duplicate sigscript length; one copy becomes substr length
         .add_op(OpDup)
         .unwrap()
-        // Precompute contract_fields_end_offset - script_size, where
+        // Precompute contract_fields_end_offset - bytecode_size, where
         // contract_fields_end_offset = len(<x><y>) = 12.
-        .add_i64(12 - compiled.script.len() as i64)
+        .add_i64(12 - compiled.bytecode.len() as i64)
         .unwrap()
         // start offset of REST_OF_SCRIPT inside sigscript
         .add_op(OpAdd)
@@ -5848,7 +5850,7 @@ fn compiles_validate_output_state_to_expected_script() {
         .unwrap()
         .drain();
 
-    assert_eq!(compiled.script, expected);
+    assert_eq!(compiled.bytecode, expected);
 }
 
 #[test]
@@ -5867,12 +5869,12 @@ fn runs_validate_output_state() {
     let input_compiled =
         compile_contract(source, &[5.into(), vec![1u8, 2u8].into()], CompileOptions::default()).expect("compile succeeds");
 
-    let input = test_input(0, sigscript_push_script(&input_compiled.script));
+    let input = test_input(0, sigscript_push_bytecode(&input_compiled.bytecode));
 
     let output_compiled =
         compile_contract(source, &[6.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -5898,12 +5900,12 @@ fn runs_validate_output_state_with_state_variable() {
     let input_compiled =
         compile_contract(source, &[5.into(), vec![1u8, 2u8].into()], CompileOptions::default()).expect("compile succeeds");
 
-    let input = test_input(0, sigscript_push_script(&input_compiled.script));
+    let input = test_input(0, sigscript_push_bytecode(&input_compiled.bytecode));
 
     let output_compiled =
         compile_contract(source, &[6.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -5921,7 +5923,7 @@ fn run_read_input_state_with_template_case(
         reader_source,
         reader_constructor_args,
         target_input_compiled,
-        pay_to_script_hash_script(&target_input_compiled.script),
+        pay_to_script_hash_script(&target_input_compiled.bytecode),
     )
 }
 
@@ -5935,10 +5937,10 @@ fn run_read_input_state_with_template_case_with_input_spk(
         compile_contract(reader_source, reader_constructor_args, CompileOptions::default()).expect("compile reader succeeds");
 
     let input0 = test_input(0, vec![]);
-    let input1 = test_input(1, sigscript_push_script(&target_input_compiled.script));
+    let input1 = test_input(1, sigscript_push_bytecode(&target_input_compiled.bytecode));
     let output = TransactionOutput {
         value: 1000,
-        script_public_key: ScriptPublicKey::new(0, reader_compiled.script.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, reader_compiled.bytecode.clone().into()),
         covenant: None,
     };
     let tx = Transaction::new(1, vec![input0.clone(), input1], vec![output.clone()], 0, Default::default(), 0, vec![]);
@@ -5987,11 +5989,11 @@ fn run_validate_output_state_with_template_case(
     .expect("compile mux succeeds");
 
     let sigscript = mux_input_compiled.build_sig_script("routeToA", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(mux_input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(mux_input_compiled.bytecode.clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
 
-    let input_spk = pay_to_script_hash_script(&mux_input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&mux_input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6064,11 +6066,11 @@ fn runs_validate_output_state_with_template() {
     .expect("compile mux succeeds");
 
     let sigscript = mux_input_compiled.build_sig_script("routeToA", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(mux_input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(mux_input_compiled.bytecode.clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
 
-    let input_spk = pay_to_script_hash_script(&mux_input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&target_output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&mux_input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&target_output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6092,8 +6094,8 @@ fn template_hash_matches_all_template_builtins() {
     let target_output =
         compile_contract(target_source, &[8.into()], CompileOptions::default()).expect("compile target output succeeds");
     let layout = target_input.state_layout;
-    let prefix = &target_input.script[..layout.start];
-    let suffix = &target_input.script[layout.start + layout.len..];
+    let prefix = &target_input.bytecode[..layout.start];
+    let suffix = &target_input.bytecode[layout.start + layout.len..];
     let prefix_hex = prefix.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
     let suffix_hex = suffix.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 
@@ -6142,15 +6144,15 @@ fn template_hash_matches_all_template_builtins() {
     );
     let verifier = compile_contract(&verifier_source, &[], CompileOptions::default()).expect("compile verifier succeeds");
     let verifier_sigscript = verifier.build_sig_script("main", vec![]).expect("verifier sigscript builds");
-    let verifier_sigscript = pay_to_script_hash_signature_script(verifier.script.clone(), verifier_sigscript).unwrap();
+    let verifier_sigscript = pay_to_script_hash_signature_script(verifier.bytecode.clone(), verifier_sigscript).unwrap();
 
     let verifier_input = test_input(0, verifier_sigscript);
-    let target_input_tx = test_input(1, sigscript_push_script(&target_input.script));
+    let target_input_tx = test_input(1, sigscript_push_bytecode(&target_input.bytecode));
     let output =
-        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&target_output.script), covenant: None };
+        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&target_output.bytecode), covenant: None };
     let tx = Transaction::new(1, vec![verifier_input, target_input_tx], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let verifier_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&verifier.script), 0, tx.is_coinbase(), None);
-    let target_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&target_input.script), 0, tx.is_coinbase(), None);
+    let verifier_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&verifier.bytecode), 0, tx.is_coinbase(), None);
+    let target_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&target_input.bytecode), 0, tx.is_coinbase(), None);
 
     let result = execute_input(tx, vec![verifier_utxo, target_utxo], 0);
     assert!(result.is_ok(), "templateHash should match all state template builtins: {}", result.unwrap_err());
@@ -6181,14 +6183,14 @@ fn template_hash_matches_all_template_builtins() {
     let invalid_verifier =
         compile_contract(&invalid_verifier_source, &[], CompileOptions::default()).expect("compile invalid verifier succeeds");
     let invalid_sigscript = invalid_verifier.build_sig_script("main", vec![]).expect("invalid verifier sigscript builds");
-    let invalid_sigscript = pay_to_script_hash_signature_script(invalid_verifier.script.clone(), invalid_sigscript).unwrap();
+    let invalid_sigscript = pay_to_script_hash_signature_script(invalid_verifier.bytecode.clone(), invalid_sigscript).unwrap();
     let invalid_input = test_input(0, invalid_sigscript);
-    let target_input_tx = test_input(1, sigscript_push_script(&target_input.script));
+    let target_input_tx = test_input(1, sigscript_push_bytecode(&target_input.bytecode));
     let output =
-        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&target_output.script), covenant: None };
+        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&target_output.bytecode), covenant: None };
     let tx = Transaction::new(1, vec![invalid_input, target_input_tx], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let invalid_verifier_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&invalid_verifier.script), 0, tx.is_coinbase(), None);
-    let target_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&target_input.script), 0, tx.is_coinbase(), None);
+    let invalid_verifier_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&invalid_verifier.bytecode), 0, tx.is_coinbase(), None);
+    let target_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&target_input.bytecode), 0, tx.is_coinbase(), None);
 
     assert!(execute_input(tx, vec![invalid_verifier_utxo, target_utxo], 0).is_err(), "incorrect template lengths must fail");
 }
@@ -6285,11 +6287,11 @@ fn runs_validate_output_state_with_template_using_passed_struct_layout() {
         .expect("compile mux succeeds");
 
     let sigscript = mux_input_compiled.build_sig_script("routeToA", vec![target_hash_value.clone().into()]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(mux_input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(mux_input_compiled.bytecode.clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
 
-    let input_spk = pay_to_script_hash_script(&mux_input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&target_output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&mux_input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&target_output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6302,11 +6304,11 @@ fn runs_validate_output_state_with_template_using_passed_struct_layout() {
     );
 
     let a_sigscript = target_output_compiled.build_sig_script("noop", vec![]).expect("A sigscript builds");
-    let a_sigscript = pay_to_script_hash_signature_script(target_output_compiled.script.clone(), a_sigscript).unwrap();
+    let a_sigscript = pay_to_script_hash_signature_script(target_output_compiled.bytecode.clone(), a_sigscript).unwrap();
     let a_input = test_input(0, a_sigscript);
     let a_output = TransactionOutput { value: 1000, script_public_key: ScriptPublicKey::new(0, vec![OpTrue].into()), covenant: None };
     let a_tx = Transaction::new(1, vec![a_input], vec![a_output], 0, Default::default(), 0, vec![]);
-    let a_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&target_output_compiled.script), 0, a_tx.is_coinbase(), None);
+    let a_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&target_output_compiled.bytecode), 0, a_tx.is_coinbase(), None);
     let a_result = execute_input(a_tx, vec![a_utxo], 0);
     assert!(
         a_result.is_ok(),
@@ -6477,7 +6479,7 @@ contract Sweep(int BOUND, byte[64] init_board) {
     for b in bounds {
         let args = [Expr::int(b), Expr::bytes(vec![0u8; 64])];
         let compiled = compile_contract(SOURCE, &args, CompileOptions::default()).expect("compile succeeds");
-        lens.push(compiled.script.len());
+        lens.push(compiled.bytecode.len());
     }
 
     // Monotonic growth, and no doubling behavior in this range.
@@ -6505,11 +6507,11 @@ fn validate_output_state_accepts_state_value_from_array_index() {
 
     let input_compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
     let sigscript = input_compiled.build_sig_script("main", vec![state_array_arg_x(vec![6])]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
     let output_compiled = compile_contract(source, &[6.into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6538,11 +6540,11 @@ fn validate_output_state_accepts_state_value_from_inline_returned_array() {
 
     let input_compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
     let sigscript = input_compiled.build_sig_script("main", vec![state_array_arg_x(vec![6])]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
     let output_compiled = compile_contract(source, &[6.into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6570,11 +6572,11 @@ fn read_input_state_accepts_self_state_under_selector_dispatch() {
 
     let input_compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
     let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
     let output_compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6599,9 +6601,9 @@ fn read_input_state_int_addition_uses_numeric_semantics() {
 
     let compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
     let sigscript = compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(compiled.script.clone(), sigscript).expect("p2sh sigscript wraps");
+    let sigscript = pay_to_script_hash_signature_script(compiled.bytecode.clone(), sigscript).expect("p2sh sigscript wraps");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&compiled.script);
+    let input_spk = pay_to_script_hash_script(&compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: input_spk.clone(), covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6635,13 +6637,13 @@ fn read_input_state_accepts_three_field_state_under_selector_dispatch() {
         compile_contract(source, &[5.into(), vec![0x34u8, 0x12u8].into(), vec![1u8; 32].into()], CompileOptions::default())
             .expect("compile succeeds");
     let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
     let output_compiled =
         compile_contract(source, &[5.into(), vec![0x34u8, 0x12u8].into(), vec![1u8; 32].into()], CompileOptions::default())
             .expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6672,12 +6674,12 @@ fn read_input_state_accepts_pubkey_and_bool_fields_under_selector_dispatch() {
     let input_compiled =
         compile_contract(source, &[true.into(), vec![2u8; 32].into()], CompileOptions::default()).expect("compile succeeds");
     let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
     let output_compiled =
         compile_contract(source, &[true.into(), vec![2u8; 32].into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6691,9 +6693,9 @@ fn read_input_state_runtime_preserves_supported_field_types_across_contract_shap
     let run_case = |source: &str, args: Vec<Expr<'_>>, label: &str| {
         let compiled = compile_contract(source, &args, CompileOptions::default()).unwrap_or_else(|err| panic!("{label}: {err:?}"));
         let sigscript = compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-        let sigscript = pay_to_script_hash_signature_script(compiled.script.clone(), sigscript).expect("p2sh sigscript wraps");
+        let sigscript = pay_to_script_hash_signature_script(compiled.bytecode.clone(), sigscript).expect("p2sh sigscript wraps");
         let input = test_input(0, sigscript);
-        let input_spk = pay_to_script_hash_script(&compiled.script);
+        let input_spk = pay_to_script_hash_script(&compiled.bytecode);
         let output = TransactionOutput { value: 1000, script_public_key: input_spk.clone(), covenant: None };
         let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
         let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6877,9 +6879,9 @@ fn read_input_state_runtime_preserves_supported_field_types_without_selector_dis
     let run_case = |source: &str, args: Vec<Expr<'_>>, label: &str| {
         let compiled = compile_contract(source, &args, CompileOptions::default()).unwrap_or_else(|err| panic!("{label}: {err:?}"));
         let sigscript = compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-        let sigscript = pay_to_script_hash_signature_script(compiled.script.clone(), sigscript).expect("p2sh sigscript wraps");
+        let sigscript = pay_to_script_hash_signature_script(compiled.bytecode.clone(), sigscript).expect("p2sh sigscript wraps");
         let input = test_input(0, sigscript);
-        let input_spk = pay_to_script_hash_script(&compiled.script);
+        let input_spk = pay_to_script_hash_script(&compiled.bytecode);
         let output = TransactionOutput { value: 1000, script_public_key: input_spk.clone(), covenant: None };
         let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
         let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6966,9 +6968,9 @@ fn read_input_state_scalar_byte_round_trips_at_runtime() {
     let compiled =
         compile_contract(source, &[Expr::byte(7), vec![2u8; 32].into()], CompileOptions::default()).expect("compile succeeds");
     let sigscript = compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(compiled.script.clone(), sigscript).expect("p2sh sigscript wraps");
+    let sigscript = pay_to_script_hash_signature_script(compiled.bytecode.clone(), sigscript).expect("p2sh sigscript wraps");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&compiled.script);
+    let input_spk = pay_to_script_hash_script(&compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: input_spk.clone(), covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -6996,11 +6998,11 @@ fn validate_output_state_accepts_state_under_selector_dispatch() {
     let input_compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
     let sigscript =
         input_compiled.build_sig_script("main", vec![struct_object("State", vec![("x", Expr::int(6))])]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
     let output_compiled = compile_contract(source, &[6.into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -7039,13 +7041,13 @@ fn validate_output_state_accepts_three_field_state_under_selector_dispatch() {
             )],
         )
         .expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
     let output_compiled =
         compile_contract(source, &[6.into(), vec![0xabu8, 0xcdu8].into(), vec![2u8; 32].into()], CompileOptions::default())
             .expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -7083,9 +7085,9 @@ fn debug_validate_output_state_accepts_current_byte32_fields() {
     )
     .expect("compile succeeds");
 
-    let input = test_input(0, sigscript_push_script(&input_compiled.script));
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input = test_input(0, sigscript_push_bytecode(&input_compiled.bytecode));
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -7114,11 +7116,11 @@ fn validate_output_state_accepts_pubkey_field_under_selector_dispatch() {
     let sigscript = input_compiled
         .build_sig_script("main", vec![struct_object("State", vec![("owner", Expr::bytes(vec![2u8; 32]))])])
         .expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
     let output_compiled = compile_contract(source, &[vec![2u8; 32].into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -7170,7 +7172,7 @@ fn runs_state_variable_and_internal_function_argument() {
 
     let compiled = compile_contract(source, &[5.into(), vec![1u8, 2u8].into()], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "script should execute successfully: {result:?}");
 }
 
@@ -7211,7 +7213,7 @@ fn byte_hex_literal_is_a_scalar_numeral() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("scalar byte hex literal should compile");
-    assert!(run_script_with_selector(compiled.script, None).is_ok());
+    assert!(run_bytecode_with_selector(compiled.bytecode, None).is_ok());
 }
 
 #[test]
@@ -7230,7 +7232,7 @@ fn hex_literals_are_numerals_for_int_and_byte() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("hex numerals should compile");
-    assert!(run_script_with_selector(compiled.script, None).is_ok());
+    assert!(run_bytecode_with_selector(compiled.bytecode, None).is_ok());
 }
 
 #[test]
@@ -7259,7 +7261,7 @@ fn hex_literal_over_eight_bytes_requires_an_immediate_byte_array_cast() {
     let source = format!("contract C() {{ entry main() {{ byte[_] value = byte[_]({raw}); require(value == byte[9]({raw})); }} }}");
     let compiled =
         compile_contract(&source, &[], CompileOptions::default()).expect("immediately cast nine-byte literal should compile");
-    assert!(run_script_with_selector(compiled.script, None).is_ok());
+    assert!(run_bytecode_with_selector(compiled.bytecode, None).is_ok());
 }
 
 #[test]
@@ -7283,7 +7285,7 @@ fn fixed_byte_sequence_types_accept_immediate_hex_literals() {
     );
 
     let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("direct fixed byte-sequence casts should compile");
-    assert!(run_script_with_selector(compiled.script, None).is_ok());
+    assert!(run_bytecode_with_selector(compiled.bytecode, None).is_ok());
 }
 
 #[test]
@@ -7357,10 +7359,10 @@ fn compiles_read_input_state_to_expected_script() {
         // len(sigScript of input 1)
         .add_op(OpTxInputScriptSigLen)
         .unwrap()
-        // this.scriptSize
-        .add_i64(compiled.script.len() as i64)
+        // this.bytecodeSize
+        .add_i64(compiled.bytecode.len() as i64)
         .unwrap()
-        // base = sig_len - script_size
+        // base = sig_len - bytecode_size
         .add_op(OpSub)
         .unwrap()
         // skip int pushdata prefix byte (0x08)
@@ -7376,10 +7378,10 @@ fn compiles_read_input_state_to_expected_script() {
         // len(sigScript of input 1)
         .add_op(OpTxInputScriptSigLen)
         .unwrap()
-        // this.scriptSize
-        .add_i64(compiled.script.len() as i64)
+        // this.bytecodeSize
+        .add_i64(compiled.bytecode.len() as i64)
         .unwrap()
-        // base = sig_len - script_size
+        // base = sig_len - bytecode_size
         .add_op(OpSub)
         .unwrap()
         // skip int prefix
@@ -7417,10 +7419,10 @@ fn compiles_read_input_state_to_expected_script() {
         // len(sigScript of input 1)
         .add_op(OpTxInputScriptSigLen)
         .unwrap()
-        // this.scriptSize
-        .add_i64(compiled.script.len() as i64)
+        // this.bytecodeSize
+        .add_i64(compiled.bytecode.len() as i64)
         .unwrap()
-        // base = sig_len - script_size
+        // base = sig_len - bytecode_size
         .add_op(OpSub)
         .unwrap()
         // skip x encoded chunk (9 bytes) + y pushdata prefix (1 byte)
@@ -7436,10 +7438,10 @@ fn compiles_read_input_state_to_expected_script() {
         // len(sigScript of input 1)
         .add_op(OpTxInputScriptSigLen)
         .unwrap()
-        // this.scriptSize
-        .add_i64(compiled.script.len() as i64)
+        // this.bytecodeSize
+        .add_i64(compiled.bytecode.len() as i64)
         .unwrap()
-        // base = sig_len - script_size
+        // base = sig_len - bytecode_size
         .add_op(OpSub)
         .unwrap()
         // skip x chunk + y prefix
@@ -7478,11 +7480,11 @@ fn compiles_read_input_state_to_expected_script() {
         .unwrap()
         .drain();
 
-    let asm = script_to_str(&compiled.script).expect("stringifies");
+    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
     assert_eq!(asm.matches("OpTxInputScriptSigSubstr").count(), 2, "should read two state fields");
     assert_eq!(asm.matches("OpGreaterThan").count(), 1, "should compare x numerically");
     assert_eq!(asm.matches("OpEqual").count(), 1, "should compare y bytewise");
-    assert!(compiled.script.ends_with(&[OpDrop, OpDrop, OpTrue]), "expected stack cleanup for active state");
+    assert!(compiled.bytecode.ends_with(&[OpDrop, OpDrop, OpTrue]), "expected stack cleanup for active state");
 }
 
 #[test]
@@ -7506,11 +7508,11 @@ fn runs_read_input_state() {
         compile_contract(source, &[8.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
 
     let input0 = test_input(0, vec![]);
-    let input1 = test_input(1, sigscript_push_script(&input1_compiled.script));
+    let input1 = test_input(1, sigscript_push_bytecode(&input1_compiled.bytecode));
 
     let output = TransactionOutput {
         value: 1000,
-        script_public_key: ScriptPublicKey::new(0, active_compiled.script.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, active_compiled.bytecode.clone().into()),
         covenant: None,
     };
     let tx = Transaction::new(1, vec![input0.clone(), input1], vec![output.clone()], 0, Default::default(), 0, vec![]);
@@ -7541,11 +7543,11 @@ fn runs_read_input_state_into_state_variable() {
         compile_contract(source, &[8.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
 
     let input0 = test_input(0, vec![]);
-    let input1 = test_input(1, sigscript_push_script(&input1_compiled.script));
+    let input1 = test_input(1, sigscript_push_bytecode(&input1_compiled.bytecode));
 
     let output = TransactionOutput {
         value: 1000,
-        script_public_key: ScriptPublicKey::new(0, active_compiled.script.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, active_compiled.bytecode.clone().into()),
         covenant: None,
     };
     let tx = Transaction::new(1, vec![input0.clone(), input1], vec![output.clone()], 0, Default::default(), 0, vec![]);
@@ -7579,10 +7581,10 @@ fn runs_read_input_state_as_internal_function_argument() {
         compile_contract(source, &[8.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
 
     let input0 = test_input(0, vec![]);
-    let input1 = test_input(1, sigscript_push_script(&input1_compiled.script));
+    let input1 = test_input(1, sigscript_push_bytecode(&input1_compiled.bytecode));
     let output = TransactionOutput {
         value: 1000,
-        script_public_key: ScriptPublicKey::new(0, active_compiled.script.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, active_compiled.bytecode.clone().into()),
         covenant: None,
     };
     let tx = Transaction::new(1, vec![input0, input1], vec![output.clone()], 0, Default::default(), 0, vec![]);
@@ -8058,9 +8060,9 @@ fn validate_output_state_lowers_nested_state_literal_in_state_field_order() {
         compile_contract(source, &[5.into(), 3.into(), 4.into()], CompileOptions::default()).expect("compile succeeds");
     let output_compiled =
         compile_contract(source, &[6.into(), 7.into(), 8.into()], CompileOptions::default()).expect("compile succeeds");
-    let input = test_input(0, sigscript_push_script(&input_compiled.script));
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input = test_input(0, sigscript_push_bytecode(&input_compiled.bytecode));
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8092,9 +8094,9 @@ fn validate_output_state_with_state_identifier() {
         compile_contract(source, &[5.into(), 3.into(), 4.into()], CompileOptions::default()).expect("compile succeeds");
     let output_compiled =
         compile_contract(source, &[6.into(), 7.into(), 8.into()], CompileOptions::default()).expect("compile succeeds");
-    let input = test_input(0, sigscript_push_script(&input_compiled.script));
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input = test_input(0, sigscript_push_bytecode(&input_compiled.bytecode));
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8203,11 +8205,11 @@ fn fails_validate_output_state_with_wrong_output_index() {
     let expected_output_state =
         compile_contract(source, &[6.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
 
-    let input = test_input(0, sigscript_push_script(&input_compiled.script));
+    let input = test_input(0, sigscript_push_bytecode(&input_compiled.bytecode));
 
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let matching_spk = pay_to_script_hash_script(&expected_output_state.script);
-    let wrong_spk = pay_to_script_hash_script(&input_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let matching_spk = pay_to_script_hash_script(&expected_output_state.bytecode);
+    let wrong_spk = pay_to_script_hash_script(&input_compiled.bytecode);
 
     let output0 = TransactionOutput { value: 1000, script_public_key: wrong_spk, covenant: None };
     let output1 = TransactionOutput { value: 1000, script_public_key: matching_spk, covenant: None };
@@ -8236,10 +8238,10 @@ fn fails_validate_output_state_with_mismatched_next_state_fields() {
     let wrong_output_state =
         compile_contract(source, &[7.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
 
-    let input = test_input(0, sigscript_push_script(&input_compiled.script));
+    let input = test_input(0, sigscript_push_bytecode(&input_compiled.bytecode));
 
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let wrong_output_spk = pay_to_script_hash_script(&wrong_output_state.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let wrong_output_spk = pay_to_script_hash_script(&wrong_output_state.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: wrong_output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(1000, input_spk, 0, tx.is_coinbase(), None);
@@ -8306,7 +8308,7 @@ fn assert_compiled_body(source: &str, body: Vec<u8>) {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
     let expected = wrap_with_dispatch(body, selector);
-    assert_eq!(compiled.script, expected);
+    assert_eq!(compiled.bytecode, expected);
 }
 
 #[test]
@@ -8355,7 +8357,7 @@ fn checksigfromstack_lowers_to_matching_opcode() {
         .add_op(OpTrue)
         .unwrap()
         .drain();
-    assert_eq!(compiled.script, expected);
+    assert_eq!(compiled.bytecode, expected);
 }
 
 #[test]
@@ -8391,7 +8393,7 @@ fn checksigfromstackecdsa_lowers_to_matching_opcode() {
         .add_op(OpTrue)
         .unwrap()
         .drain();
-    assert_eq!(compiled.script, expected);
+    assert_eq!(compiled.bytecode, expected);
 }
 
 #[test]
@@ -8577,9 +8579,9 @@ fn r0_succinct_verify_lowers_hash_aliases_to_zk_precompile() {
             .add_op(OpTrue)
             .unwrap()
             .drain();
-        let asm = script_to_str(&compiled.script).expect("R0 succinct script should stringify");
+        let asm = script_to_str(&compiled.bytecode).expect("R0 succinct script should stringify");
         assert!(asm.contains("OpZkPrecompile OpDrop"), "void verifier result should be dropped: {asm}");
-        assert_eq!(compiled.script, expected, "{call_name} lowered unexpectedly");
+        assert_eq!(compiled.bytecode, expected, "{call_name} lowered unexpectedly");
     }
 }
 
@@ -8633,9 +8635,9 @@ fn r0_g16_verify_lowers_with_sdk_verifier_fragment() {
     expected_builder.add_op(OpDrop).unwrap();
     expected_builder.add_op(OpTrue).unwrap();
 
-    let asm = script_to_str(&compiled.script).expect("R0 Groth16 script should stringify");
+    let asm = script_to_str(&compiled.bytecode).expect("R0 Groth16 script should stringify");
     assert!(asm.contains("OpZkPrecompile OpDrop"), "void verifier result should be dropped: {asm}");
-    assert_eq!(compiled.script, expected_builder.drain());
+    assert_eq!(compiled.bytecode, expected_builder.drain());
 }
 
 #[test]
@@ -8680,7 +8682,7 @@ fn value_returning_builtin_statement_discards_result() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("value-returning builtin statement should compile");
-    let asm = script_to_str(&compiled.script).expect("builtin statement script should stringify");
+    let asm = script_to_str(&compiled.bytecode).expect("builtin statement script should stringify");
     assert!(asm.ends_with("OpSHA256 OpDrop OpTrue"), "builtin statement result should be discarded: {asm}");
 }
 
@@ -8862,7 +8864,7 @@ fn r0_succinct_verify_runtime_checks_each_hash_with_fixture() {
                 ],
             )
             .expect("sigscript builds");
-        let result = run_script_with_sigscript(compiled.script, sigscript);
+        let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
         assert!(result.is_ok(), "{call_name} should execute successfully: {result:?}");
     }
 }
@@ -8891,7 +8893,7 @@ fn r0_g16_verify_executes_with_fixture() {
         .build_sig_script("main", vec![journal_hash.into(), Expr::dynamic_bytes(proof), image_id.into()])
         .expect("sigscript builds");
 
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "R0 Groth16 verifier should execute successfully: {result:?}");
 }
 
@@ -8989,7 +8991,7 @@ fn checksigfromstack_executes_schnorr_signature_verification() {
         )
         .expect("compile succeeds");
         let selector = selector_for(&compiled, "main");
-        run_script_with_selector(compiled.script, selector)
+        run_bytecode_with_selector(compiled.bytecode, selector)
     };
 
     assert!(run(valid_signature.clone()).is_ok(), "valid Schnorr data signature should pass");
@@ -9018,7 +9020,7 @@ fn checksigfromstack_false_result_can_be_asserted() {
         let sigscript = compiled
             .build_sig_script("main", vec![signature.into(), digest.as_bytes().to_vec().into(), public_key.clone().into()])
             .expect("sigscript builds");
-        run_script_with_sigscript(compiled.script.clone(), sigscript)
+        run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript)
     };
 
     let valid_result = run(valid_signature);
@@ -9050,7 +9052,7 @@ fn checksigfromstackecdsa_executes_ecdsa_signature_verification() {
         )
         .expect("compile succeeds");
         let selector = selector_for(&compiled, "main");
-        run_script_with_selector(compiled.script, selector)
+        run_bytecode_with_selector(compiled.bytecode, selector)
     };
 
     assert!(run(valid_signature.clone()).is_ok(), "valid ECDSA data signature should pass");
@@ -9943,7 +9945,7 @@ fn executes_opcode_builtins_basic() {
         let selector = selector_for(&compiled, "main");
         let sigscript = selector_sigscript(selector);
         let (tx, entries) = build_basic_opcode_tx(sigscript);
-        let result = run_script_with_tx_and_covenants(compiled.script, tx, entries, None);
+        let result = run_bytecode_with_tx_and_covenants(compiled.bytecode, tx, entries, None);
         assert!(result.is_ok(), "opcode builtin {name} failed: {}", result.unwrap_err());
     }
 }
@@ -9983,7 +9985,7 @@ fn template_hash_matches_canonical_rust_and_sil_vectors() {
         );
 
         let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("templateHash should compile");
-        let result = run_script_with_selector(compiled.script, None);
+        let result = run_bytecode_with_selector(compiled.bytecode, None);
         assert!(result.is_ok(), "templateHash should match canonical vector {expected_hex}: {result:?}");
     }
 }
@@ -9999,7 +10001,7 @@ fn template_hash_binds_prefix_suffix_boundary() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("templateHash should compile");
-    let result = run_script_with_selector(compiled.script, None);
+    let result = run_bytecode_with_selector(compiled.bytecode, None);
     assert!(result.is_ok(), "templateHash should commit to the prefix/suffix boundary: {result:?}");
 }
 
@@ -10028,7 +10030,7 @@ fn executes_opcode_builtins_covenants() {
     let covenant_id_b = Hash::from_bytes(*b"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
     let (tx, entries) = build_covenant_opcode_tx(sigscript, covenant_id_a, covenant_id_b);
 
-    let result = run_script_with_tx_and_covenants(compiled.script, tx, entries, None);
+    let result = run_bytecode_with_tx_and_covenants(compiled.bytecode, tx, entries, None);
     assert!(result.is_ok(), "opcode builtins covenants failed: {}", result.unwrap_err());
 }
 
@@ -10065,7 +10067,7 @@ fn executes_opcode_chainblock_seq_commit() {
     let block = Hash::from_bytes(*b"0123456789abcdef0123456789abcdef");
     let commitment = Hash::from_bytes(*b"fedcba9876543210fedcba9876543210");
     let accessor = MockSeqCommitAccessor { block, commitment };
-    let result = run_script_with_tx_and_covenants(compiled.script, tx, entries, Some(&accessor));
+    let result = run_bytecode_with_tx_and_covenants(compiled.bytecode, tx, entries, Some(&accessor));
     assert!(result.is_ok(), "chainblock seq commit failed: {}", result.unwrap_err());
 }
 
@@ -10113,8 +10115,8 @@ fn compiles_if_else_and_verifies() {
 
     let expected = wrap_with_dispatch(body, selector);
 
-    assert_eq!(compiled.script, expected);
-    assert!(run_script_with_selector(compiled.script, selector).is_ok());
+    assert_eq!(compiled.bytecode, expected);
+    assert!(run_bytecode_with_selector(compiled.bytecode, selector).is_ok());
 }
 
 #[test]
@@ -10133,8 +10135,8 @@ fn compiles_time_op_csv_and_verifies() {
     let body = script_builder().add_i64(10).unwrap().add_op(OpCheckSequenceVerify).unwrap().add_op(OpTrue).unwrap().drain();
     let expected = wrap_with_dispatch(body, selector);
 
-    assert_eq!(compiled.script, expected);
-    assert!(run_script_with_tx(compiled.script, selector, 0, 20).is_ok());
+    assert_eq!(compiled.bytecode, expected);
+    assert!(run_bytecode_with_tx(compiled.bytecode, selector, 0, 20).is_ok());
 }
 
 #[test]
@@ -10233,8 +10235,8 @@ fn compiles_reused_variables_and_verifies() {
 
     let expected = wrap_with_dispatch(body, selector);
 
-    assert_eq!(compiled.script, expected);
-    assert!(run_script_with_selector(compiled.script, selector).is_ok());
+    assert_eq!(compiled.bytecode, expected);
+    assert!(run_bytecode_with_selector(compiled.bytecode, selector).is_ok());
 }
 
 #[test]
@@ -10276,7 +10278,7 @@ fn return_reused_local_is_stored_once_and_reused() {
         .unwrap()
         .drain();
 
-    assert_eq!(compiled.script, expected);
+    assert_eq!(compiled.bytecode, expected);
 }
 
 #[test]
@@ -10299,12 +10301,12 @@ fn compiles_sigscript_inputs_and_verifies() {
     }
     let sigscript = builder.drain();
 
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "sigscript test failed: {}", result.unwrap_err());
 }
 
 #[test]
-fn compiles_script_size_and_runs_sum_array() {
+fn compiles_bytecode_size_and_runs_sum_array() {
     let source = r#"
         contract Sum() {
             int constant MAX_ARRAY_SIZE = 5;
@@ -10317,8 +10319,8 @@ fn compiles_script_size_and_runs_sum_array() {
                 return(sum);
             }
 
-            entry main(int expected_script_size) {
-                require(expected_script_size == this.scriptSize);
+            entry main(int expected_bytecode_size) {
+                require(expected_bytecode_size == this.bytecodeSize);
                 int[] x;
                 x = x.append(1);
                 x = x.append(2);
@@ -10330,10 +10332,10 @@ fn compiles_script_size_and_runs_sum_array() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let expected_size = compiled.script.len() as i64;
+    let expected_size = compiled.bytecode.len() as i64;
     let sigscript = compiled.build_sig_script("main", vec![Expr::int(expected_size)]).expect("sigscript builds");
 
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "script size contract failed: {}", result.unwrap_err());
 }
 
@@ -10346,30 +10348,30 @@ fn data_prefix_for_size(data_len: usize) -> Vec<u8> {
 }
 
 #[test]
-fn compiles_script_size_data_prefix_small_script() {
+fn compiles_bytecode_size_data_prefix_small_script() {
     let source = r#"
         contract PrefixSmall() {
             entry main(byte[] expected_data_prefix) {
-                require(expected_data_prefix == this.scriptSizeDataPrefix);
+                require(expected_data_prefix == this.bytecodeSizeDataPrefix);
                 require(true);
             }
         }
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let expected_prefix = data_prefix_for_size(compiled.script.len());
+    let expected_prefix = data_prefix_for_size(compiled.bytecode.len());
     let sigscript = compiled.build_sig_script("main", vec![Expr::dynamic_bytes(expected_prefix)]).expect("sigscript builds");
 
-    let result = run_script_with_sigscript(compiled.script, sigscript);
-    assert!(result.is_ok(), "scriptSizeDataPrefix small failed: {}", result.unwrap_err());
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    assert!(result.is_ok(), "bytecodeSizeDataPrefix small failed: {}", result.unwrap_err());
 }
 
 #[test]
-fn compiles_script_size_data_prefix_medium_script() {
+fn compiles_bytecode_size_data_prefix_medium_script() {
     let source = r#"
         contract PrefixMedium() {
             entry main(byte[] expected_data_prefix) {
-                require(expected_data_prefix == this.scriptSizeDataPrefix);
+                require(expected_data_prefix == this.bytecodeSizeDataPrefix);
                 for (i, 0, 100, 100) {
                     require(true);
                 }
@@ -10378,19 +10380,19 @@ fn compiles_script_size_data_prefix_medium_script() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let expected_prefix = data_prefix_for_size(compiled.script.len());
+    let expected_prefix = data_prefix_for_size(compiled.bytecode.len());
     let sigscript = compiled.build_sig_script("main", vec![Expr::dynamic_bytes(expected_prefix)]).expect("sigscript builds");
 
-    let result = run_script_with_sigscript(compiled.script, sigscript);
-    assert!(result.is_ok(), "scriptSizeDataPrefix medium failed: {}", result.unwrap_err());
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    assert!(result.is_ok(), "bytecodeSizeDataPrefix medium failed: {}", result.unwrap_err());
 }
 
 #[test]
-fn compiles_script_size_data_prefix_large_script() {
+fn compiles_bytecode_size_data_prefix_large_script() {
     let source = r#"
         contract PrefixLarge() {
             entry main(byte[] expected_data_prefix) {
-                require(expected_data_prefix == this.scriptSizeDataPrefix);
+                require(expected_data_prefix == this.bytecodeSizeDataPrefix);
                 for (i, 0, 300, 300) {
                     require(true);
                 }
@@ -10399,11 +10401,11 @@ fn compiles_script_size_data_prefix_large_script() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let expected_prefix = data_prefix_for_size(compiled.script.len());
+    let expected_prefix = data_prefix_for_size(compiled.bytecode.len());
     let sigscript = compiled.build_sig_script("main", vec![Expr::dynamic_bytes(expected_prefix)]).expect("sigscript builds");
 
-    let result = run_script_with_sigscript(compiled.script, sigscript);
-    assert!(result.is_ok(), "scriptSizeDataPrefix large failed: {}", result.unwrap_err());
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    assert!(result.is_ok(), "bytecodeSizeDataPrefix large failed: {}", result.unwrap_err());
 }
 
 #[test]
@@ -10425,7 +10427,7 @@ fn compiles_sigscript_reused_inputs_and_verifies() {
     }
     let sigscript = builder.drain();
 
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "sigscript reuse test failed: {}", result.unwrap_err());
 }
 
@@ -10449,7 +10451,7 @@ fn compiles_sigscript_inputs_and_fails_on_wrong_sum() {
     }
     let sigscript = builder.drain();
 
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_err());
 }
 
@@ -10472,7 +10474,7 @@ fn compiles_sigscript_reused_inputs_and_fails_on_wrong_value() {
     }
     let sigscript = builder.drain();
 
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_err());
 }
 
@@ -10503,13 +10505,13 @@ fn entrypoints_validate_fixed_array_argument_sizes_at_runtime() {
         builder.drain()
     };
 
-    assert!(run_script_with_sigscript(compiled.script.clone(), sigscript("bytes", &[1, 2, 3])).is_ok());
-    assert!(run_script_with_sigscript(compiled.script.clone(), sigscript("bytes", &[1, 2])).is_err());
-    assert!(run_script_with_sigscript(compiled.script.clone(), sigscript("bytes", &[1, 2, 3, 4])).is_err());
-    assert!(run_script_with_sigscript(compiled.script.clone(), sigscript("ints", &[0; 16])).is_ok());
-    assert!(run_script_with_sigscript(compiled.script.clone(), sigscript("ints", &[0; 8])).is_err());
+    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript("bytes", &[1, 2, 3])).is_ok());
+    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript("bytes", &[1, 2])).is_err());
+    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript("bytes", &[1, 2, 3, 4])).is_err());
+    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript("ints", &[0; 16])).is_ok());
+    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript("ints", &[0; 8])).is_err());
 
-    let asm = script_to_str(&compiled.script).expect("stringifies");
+    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
     assert_eq!(asm.matches("OpSize").count(), 2, "each entrypoint should validate its fixed-array argument: {asm}");
 }
 
@@ -10525,7 +10527,7 @@ fn compile_time_length_for_fixed_size_int_array() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
-    let asm = script_to_str(&compiled.script).expect("stringifies");
+    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
     assert!(!asm.contains("OpSize"), "fixed-size array length should be compile-time, got asm: {asm}");
     assert!(asm.contains("Op5 Op5 OpNumEqual OpVerify"), "expected compile-time length comparison, got asm: {asm}");
 }
@@ -10542,7 +10544,7 @@ fn compile_time_length_for_fixed_size_byte_array() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
-    let asm = script_to_str(&compiled.script).expect("stringifies");
+    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
     assert!(!asm.contains("OpSize"), "fixed-size byte-array length should be compile-time, got asm: {asm}");
     assert!(asm.contains("Op3 Op3 OpNumEqual OpVerify"), "expected compile-time length comparison, got asm: {asm}");
 }
@@ -10561,7 +10563,7 @@ fn compile_time_length_for_inferred_array_sizes() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
-    let asm = script_to_str(&compiled.script).expect("stringifies");
+    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
     assert!(!asm.contains("OpSize"), "inferred fixed-array lengths should be compile-time, got asm: {asm}");
     assert!(asm.contains("Op4 Op4 OpNumEqual OpVerify"), "expected byte-array compile-time length, got asm: {asm}");
     assert!(asm.contains("Op3 Op3 OpNumEqual OpVerify"), "expected int-array compile-time length, got asm: {asm}");
@@ -10671,7 +10673,7 @@ fn compile_time_length_with_constant_size() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
-    let asm = script_to_str(&compiled.script).expect("stringifies");
+    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
     assert!(!asm.contains("OpSize"), "constant-sized array length should be compile-time, got asm: {asm}");
     assert!(asm.contains("Op5 Op5 OpNumEqual OpVerify"), "expected compile-time length comparison, got asm: {asm}");
 }
@@ -10772,9 +10774,9 @@ fn int_as_fixed_bytes_has_a_fixed_result_type_and_uses_num2bin() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("fixed-size integer conversions compile");
-    assert_eq!(compiled.script.iter().filter(|&&op| op == OpNum2Bin).count(), 4);
+    assert_eq!(compiled.bytecode.iter().filter(|&&op| op == OpNum2Bin).count(), 4);
     assert!(
-        run_script_with_sigscript(compiled.script, script_builder().add_i64(42).unwrap().drain()).is_ok(),
+        run_bytecode_with_sigscript(compiled.bytecode, script_builder().add_i64(42).unwrap().drain()).is_ok(),
         "fixed-size integer conversions should execute"
     );
 }
@@ -10843,7 +10845,7 @@ fn blake2b_builtins_require_dynamic_byte_array_arguments() {
         }
     "#;
     let compiled = compile_contract(valid_source, &[], CompileOptions::default()).expect("byte[] arguments should compile");
-    let asm = script_to_str(&compiled.script).expect("Blake2b script should stringify");
+    let asm = script_to_str(&compiled.bytecode).expect("Blake2b script should stringify");
     assert!(asm.contains("OpBlake2b"), "expected OpBlake2b in generated script: {asm}");
     assert!(asm.contains("OpBlake2bWithKey"), "expected OpBlake2bWithKey in generated script: {asm}");
 }
@@ -10898,10 +10900,10 @@ fn byte_array_to_int_cast_compiles_without_extra_opcodes_and_executes() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("byte[] to int cast compiles");
-    assert!(!compiled.script.contains(&OpBin2Num), "int(data) must not emit OpBin2Num");
+    assert!(!compiled.bytecode.contains(&OpBin2Num), "int(data) must not emit OpBin2Num");
 
     let sigscript = script_builder().add_data_with_push_opcode(&[42]).unwrap().drain();
-    assert!(run_script_with_sigscript(compiled.script, sigscript).is_ok(), "int(data) should produce a usable integer value");
+    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript).is_ok(), "int(data) should produce a usable integer value");
 }
 
 #[test]
@@ -10929,9 +10931,9 @@ fn empty_array_statement_expr_evaluation_compiles_to_empty_array_data() {
         .unwrap()
         .drain();
 
-    assert_eq!(compiled.script, expected);
-    assert_eq!(compiled.script[0], OpFalse);
-    assert_eq!(compiled.script[1], OpFalse);
+    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(compiled.bytecode[0], OpFalse);
+    assert_eq!(compiled.bytecode[1], OpFalse);
 }
 
 #[test]
@@ -10950,12 +10952,12 @@ fn function_param_shadows_constructor_constant_with_same_name() {
     // Constructor fee=2, param fee=3 => local = 3+1 = 4 => pass
     let compiled = compile_contract(source, &[Expr::int(2)], CompileOptions::default()).expect("compile succeeds");
     let sigscript = compiled.build_sig_script("main", vec![Expr::int(3)]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script.clone(), sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
     assert!(result.is_ok(), "function param should shadow constructor constant: {}", result.unwrap_err());
 
     // Constructor fee=2, param fee=2 => local = 2+1 = 3 != 4 => fail (proves it's not always the constant)
     let sigscript_wrong = compiled.build_sig_script("main", vec![Expr::int(2)]).expect("sigscript builds");
-    let result_wrong = run_script_with_sigscript(compiled.script, sigscript_wrong);
+    let result_wrong = run_bytecode_with_sigscript(compiled.bytecode, sigscript_wrong);
     assert!(result_wrong.is_err(), "require(3==4) should fail, proving the param value matters");
 }
 
@@ -10991,15 +10993,15 @@ fn ternary_expression_executes_selected_branch() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("ternary contract should compile");
 
     let sigscript_then = compiled.build_sig_script("main", vec![Expr::int(1), Expr::int(7)]).expect("sigscript builds");
-    let result_then = run_script_with_sigscript(compiled.script.clone(), sigscript_then);
+    let result_then = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_then);
     assert!(result_then.is_ok(), "then branch should execute successfully: {}", result_then.unwrap_err());
 
     let sigscript_else = compiled.build_sig_script("main", vec![Expr::int(0), Expr::int(11)]).expect("sigscript builds");
-    let result_else = run_script_with_sigscript(compiled.script.clone(), sigscript_else);
+    let result_else = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_else);
     assert!(result_else.is_ok(), "else branch should execute successfully: {}", result_else.unwrap_err());
 
     let sigscript_wrong = compiled.build_sig_script("main", vec![Expr::int(0), Expr::int(7)]).expect("sigscript builds");
-    let result_wrong = run_script_with_sigscript(compiled.script, sigscript_wrong);
+    let result_wrong = run_bytecode_with_sigscript(compiled.bytecode, sigscript_wrong);
     assert!(result_wrong.is_err(), "else branch should not produce the then value");
 }
 
@@ -11022,7 +11024,7 @@ fn ternary_expression_does_not_execute_unselected_branch() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("ternary contract should compile");
-    let asm = script_to_str(&compiled.script).expect("ternary script should stringify");
+    let asm = script_to_str(&compiled.bytecode).expect("ternary script should stringify");
     let if_index = asm.find("OpIf").expect("ternary should emit OpIf");
     let else_index = asm.find("OpElse").expect("ternary should emit OpElse");
     let end_if_index = asm.find("OpEndIf").expect("ternary should emit OpEndIf");
@@ -11036,20 +11038,20 @@ fn ternary_expression_does_not_execute_unselected_branch() {
     let select_then = compiled
         .build_sig_script("main", vec![Expr::bool(true), Expr::int(10), Expr::int(2), Expr::int(20), Expr::int(0), Expr::int(5)])
         .expect("then-branch sigscript builds");
-    let then_result = run_script_with_sigscript(compiled.script.clone(), select_then);
+    let then_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_then);
     assert!(then_result.is_ok(), "zero divisor in the unselected else branch must not execute: {}", then_result.unwrap_err());
 
     let select_else = compiled
         .build_sig_script("main", vec![Expr::bool(false), Expr::int(10), Expr::int(0), Expr::int(20), Expr::int(4), Expr::int(5)])
         .expect("else-branch sigscript builds");
-    let else_result = run_script_with_sigscript(compiled.script.clone(), select_else);
+    let else_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_else);
     assert!(else_result.is_ok(), "zero divisor in the unselected then branch must not execute: {}", else_result.unwrap_err());
 
     let failing_then = compiled
         .build_sig_script("main", vec![Expr::bool(true), Expr::int(10), Expr::int(0), Expr::int(20), Expr::int(4), Expr::int(5)])
         .expect("failing then-branch sigscript builds");
     assert!(
-        run_script_with_sigscript(compiled.script.clone(), failing_then).is_err(),
+        run_bytecode_with_sigscript(compiled.bytecode.clone(), failing_then).is_err(),
         "zero divisor in the selected then branch should execute and fail"
     );
 
@@ -11057,7 +11059,7 @@ fn ternary_expression_does_not_execute_unselected_branch() {
         .build_sig_script("main", vec![Expr::bool(false), Expr::int(10), Expr::int(2), Expr::int(20), Expr::int(0), Expr::int(5)])
         .expect("failing else-branch sigscript builds");
     assert!(
-        run_script_with_sigscript(compiled.script, failing_else).is_err(),
+        run_bytecode_with_sigscript(compiled.bytecode, failing_else).is_err(),
         "zero divisor in the selected else branch should execute and fail"
     );
 }
@@ -11079,7 +11081,7 @@ fn ternary_expression_does_not_execute_function_call_in_unselected_else_branch()
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("ternary contract should compile");
-    let asm = script_to_str(&compiled.script).expect("ternary script should stringify");
+    let asm = script_to_str(&compiled.bytecode).expect("ternary script should stringify");
     let if_index = asm.find("OpIf").expect("ternary should emit OpIf");
     let else_index = asm.find("OpElse").expect("ternary should emit OpElse");
     let fail_index = asm.find("OpFalse OpVerify").expect("else-branch helper should emit require(false)");
@@ -11092,14 +11094,14 @@ fn ternary_expression_does_not_execute_function_call_in_unselected_else_branch()
     let select_then = compiled
         .build_sig_script("main", vec![Expr::bool(true), Expr::int(7), Expr::int(11), Expr::int(7)])
         .expect("then-branch sigscript builds");
-    let then_result = run_script_with_sigscript(compiled.script.clone(), select_then);
+    let then_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_then);
     assert!(then_result.is_ok(), "require(false) in the unselected else-branch call must not execute: {}", then_result.unwrap_err());
 
     let select_else = compiled
         .build_sig_script("main", vec![Expr::bool(false), Expr::int(7), Expr::int(11), Expr::int(11)])
         .expect("else-branch sigscript builds");
     assert!(
-        run_script_with_sigscript(compiled.script, select_else).is_err(),
+        run_bytecode_with_sigscript(compiled.bytecode, select_else).is_err(),
         "require(false) in the selected else-branch call should execute and fail"
     );
 }
@@ -11121,7 +11123,7 @@ fn ternary_expression_does_not_execute_function_call_in_unselected_then_branch()
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("ternary contract should compile");
-    let asm = script_to_str(&compiled.script).expect("ternary script should stringify");
+    let asm = script_to_str(&compiled.bytecode).expect("ternary script should stringify");
     let if_index = asm.find("OpIf").expect("ternary should emit OpIf");
     let fail_index = asm.find("OpFalse OpVerify").expect("then-branch helper should emit require(false)");
     let else_index = asm.find("OpElse").expect("ternary should emit OpElse");
@@ -11134,14 +11136,14 @@ fn ternary_expression_does_not_execute_function_call_in_unselected_then_branch()
     let select_else = compiled
         .build_sig_script("main", vec![Expr::bool(false), Expr::int(7), Expr::int(11), Expr::int(11)])
         .expect("else-branch sigscript builds");
-    let else_result = run_script_with_sigscript(compiled.script.clone(), select_else);
+    let else_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_else);
     assert!(else_result.is_ok(), "require(false) in the unselected then-branch call must not execute: {}", else_result.unwrap_err());
 
     let select_then = compiled
         .build_sig_script("main", vec![Expr::bool(true), Expr::int(7), Expr::int(11), Expr::int(7)])
         .expect("then-branch sigscript builds");
     assert!(
-        run_script_with_sigscript(compiled.script, select_then).is_err(),
+        run_bytecode_with_sigscript(compiled.bytecode, select_then).is_err(),
         "require(false) in the selected then-branch call should execute and fail"
     );
 }
@@ -11167,7 +11169,7 @@ fn nested_ternary_function_call_remains_in_selected_branch() {
     let select_then = compiled
         .build_sig_script("main", vec![Expr::bool(true), Expr::int(7), Expr::int(11), Expr::int(8)])
         .expect("then-branch sigscript builds");
-    let then_result = run_script_with_sigscript(compiled.script.clone(), select_then);
+    let then_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_then);
     assert!(
         then_result.is_ok(),
         "require(false) in a nested unselected else-branch call must not execute: {}",
@@ -11178,7 +11180,7 @@ fn nested_ternary_function_call_remains_in_selected_branch() {
         .build_sig_script("main", vec![Expr::bool(false), Expr::int(7), Expr::int(11), Expr::int(12)])
         .expect("else-branch sigscript builds");
     assert!(
-        run_script_with_sigscript(compiled.script, select_else).is_err(),
+        run_bytecode_with_sigscript(compiled.bytecode, select_else).is_err(),
         "require(false) in a nested selected else-branch call should execute and fail"
     );
 }
@@ -11249,7 +11251,7 @@ fn if_else_does_not_execute_function_call_in_unselected_else_branch() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("if/else contract should compile");
-    let asm = script_to_str(&compiled.script).expect("if/else script should stringify");
+    let asm = script_to_str(&compiled.bytecode).expect("if/else script should stringify");
     let if_index = asm.find("OpIf").expect("if/else should emit OpIf");
     let else_index = asm.find("OpElse").expect("if/else should emit OpElse");
     let fail_index = asm.find("OpFalse OpVerify").expect("else-branch helper should emit require(false)");
@@ -11262,14 +11264,14 @@ fn if_else_does_not_execute_function_call_in_unselected_else_branch() {
     let select_then = compiled
         .build_sig_script("main", vec![Expr::bool(true), Expr::int(7), Expr::int(11), Expr::int(7)])
         .expect("then-branch sigscript builds");
-    let then_result = run_script_with_sigscript(compiled.script.clone(), select_then);
+    let then_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_then);
     assert!(then_result.is_ok(), "require(false) in the unselected else-branch call must not execute: {}", then_result.unwrap_err());
 
     let select_else = compiled
         .build_sig_script("main", vec![Expr::bool(false), Expr::int(7), Expr::int(11), Expr::int(11)])
         .expect("else-branch sigscript builds");
     assert!(
-        run_script_with_sigscript(compiled.script, select_else).is_err(),
+        run_bytecode_with_sigscript(compiled.bytecode, select_else).is_err(),
         "require(false) in the selected else-branch call should execute and fail"
     );
 }
@@ -11353,7 +11355,7 @@ fn nested_inline_calls_with_args_compile_and_execute() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("nested inline calls should compile");
     let sigscript = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "nested inline calls should execute correctly: {}", result.unwrap_err());
 }
 
@@ -11376,17 +11378,17 @@ fn inline_local_binding_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("inline helper should compile");
 
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpAdd).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
         1,
         "x + 1 should be computed once and stored for both require statements"
     );
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored inline local should execute successfully: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "stored inline local should still enforce the second require");
 }
 
@@ -11408,17 +11410,17 @@ fn inline_function_argument_expression_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("inline call should compile");
 
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpAdd).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
         1,
         "x + 1 should be computed once and reused for both require statements in the inline callee"
     );
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored inline argument should execute successfully: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "stored inline argument should still enforce the second require");
 }
 
@@ -11478,18 +11480,18 @@ fn inline_argument_alias_reuses_existing_local_without_extra_snapshot() {
 
     let expected = wrap_with_dispatch(body, selector);
 
-    assert_eq!(compiled.script, expected);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpDup).count(), 3);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpOver).count(), 1);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpPick).count(), 0);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpMul).count(), 1);
+    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpDup).count(), 3);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpOver).count(), 1);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpPick).count(), 0);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(), 1);
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(2)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "reused local should satisfy both inline requires: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(4)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "reused local should still fail the second inline require");
 }
 
@@ -11540,18 +11542,18 @@ fn inline_argument_alias_snapshots_entrypoint_param_once_per_inlined_call() {
 
     let expected = wrap_with_dispatch(body, selector);
 
-    assert_eq!(compiled.script, expected);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpDup).count(), 2);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpOver).count(), 0);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpPick).count(), 0);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpDrop).count(), 1);
+    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpDup).count(), 2);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpOver).count(), 0);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpPick).count(), 0);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpDrop).count(), 1);
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(2)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "entrypoint param alias should satisfy both inline requires: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "entrypoint param alias should still fail the second inline require");
 }
 
@@ -11604,18 +11606,18 @@ fn local_alias_snapshots_existing_stack_value_once() {
 
     let expected = wrap_with_dispatch(body, selector);
 
-    assert_eq!(compiled.script, expected);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpMul).count(), 1);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpDup).count(), 3);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpOver).count(), 1);
-    assert_eq!(compiled.script.iter().copied().filter(|op| *op == OpPick).count(), 0);
+    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(), 1);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpDup).count(), 3);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpOver).count(), 1);
+    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpPick).count(), 0);
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(2)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "local alias should execute successfully: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(1)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "local alias should still enforce the requires");
 }
 
@@ -11636,11 +11638,11 @@ fn local_alias_reassignment_from_alias_passes_for_x_5() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("local alias reassignment should compile");
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "x=5 should pass after z is incremented past y: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(1)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "x=1 should still fail the initial require(y > 1)");
 }
 
@@ -11659,17 +11661,17 @@ fn local_bool_expression_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("bool local should compile");
 
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpAdd).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
         1,
         "x + 1 should be computed once for the stored bool expression"
     );
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored bool local should execute successfully: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(0)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "stored bool local should still enforce the false branch");
 }
 
@@ -11688,22 +11690,22 @@ fn local_nested_expression_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("nested local should compile");
 
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpAdd).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
         2,
         "the nested local expression should compute each addition once before storing the result"
     );
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpMul).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(),
         1,
         "the nested local expression should multiply once before storing the result"
     );
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored nested local should execute successfully: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "stored nested local should still enforce the second require");
 }
 
@@ -11750,7 +11752,7 @@ fn runs_branch_local_shadowing_and_preserves_outer_scope() {
 
     for cond in [true, false] {
         let sigscript = compiled.build_sig_script("main", vec![Expr::bool(cond)]).expect("sigscript builds");
-        let result = run_script_with_sigscript(compiled.script.clone(), sigscript);
+        let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
         assert!(result.is_ok(), "branch-local shadowing should execute successfully for cond={cond}: {}", result.unwrap_err());
     }
 }
@@ -11772,7 +11774,7 @@ fn runs_for_loop_local_shadowing_and_preserves_outer_scope() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("loop-local shadowing should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "loop-local shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -11793,7 +11795,7 @@ fn runs_standalone_block_local_shadowing_and_preserves_outer_scope() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("block-local shadowing should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "block-local shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -11810,7 +11812,7 @@ fn runs_function_parameter_shadowing() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("parameter shadowing should compile");
     let sigscript = compiled.build_sig_script("main", vec![Expr::int(9)]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "parameter shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -11832,7 +11834,7 @@ fn runs_inlined_function_parameter_shadowing() {
     let compiled =
         compile_contract(source, &[], CompileOptions::default()).expect("inlined function parameter shadowing should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "inlined function parameter shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -11855,7 +11857,7 @@ fn runs_standalone_block_tuple_binding_shadowing() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("tuple binding shadowing should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "tuple binding shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -11874,7 +11876,7 @@ fn runs_split_on_non_byte_array() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("split on int[] should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "split on int[] should execute successfully: {}", result.unwrap_err());
 }
 
@@ -11892,7 +11894,7 @@ fn runs_slice_on_non_byte_array() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("slice on int[] should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "slice on int[] should execute successfully: {}", result.unwrap_err());
 }
 
@@ -11930,7 +11932,7 @@ fn runs_split_and_slice_on_struct_array() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("struct array sequence operations should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "struct array sequence operations should execute successfully: {}", result.unwrap_err());
 }
 
@@ -11990,7 +11992,7 @@ fn runs_struct_array_equality_and_inequality_comparisons() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("struct array comparisons should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "struct array comparisons should execute successfully: {}", result.unwrap_err());
 }
 
@@ -12036,7 +12038,7 @@ fn runs_standalone_block_function_result_binding_shadowing() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("function result binding shadowing should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "function result binding shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -12060,9 +12062,9 @@ fn runs_standalone_block_state_binding_shadowing() {
     let input_compiled =
         compile_contract(source, &[Expr::int(7)], CompileOptions::default()).expect("state binding shadowing should compile");
     let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: input_spk.clone(), covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -12094,7 +12096,7 @@ fn runs_standalone_block_struct_destructure_binding_shadowing() {
     let compiled =
         compile_contract(source, &[], CompileOptions::default()).expect("struct destructure binding shadowing should compile");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "struct destructure binding shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -12116,7 +12118,7 @@ fn branch_shadowing_initializer_reads_outer_binding() {
     let compiled =
         compile_contract(source, &[], CompileOptions::default()).expect("branch shadowing initializer should read the outer binding");
     let sigscript = compiled.build_sig_script("main", vec![Expr::bool(true)]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "branch shadowing initializer should execute successfully: {}", result.unwrap_err());
 }
 
@@ -12139,7 +12141,7 @@ fn branch_reference_before_shadowing_declaration_reads_outer_binding() {
     let compiled = compile_contract(source, &[], CompileOptions::default())
         .expect("a branch reference before a shadowing declaration should read the outer binding");
     let sigscript = compiled.build_sig_script("main", vec![Expr::bool(true)]).expect("sigscript builds");
-    let result = run_script_with_sigscript(compiled.script, sigscript);
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "branch reference before shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -12161,7 +12163,7 @@ fn for_loop_shadowing_initializer_reads_outer_binding() {
     let compiled =
         compile_contract(source, &[], CompileOptions::default()).expect("loop shadowing initializer should read the outer binding");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "loop shadowing initializer should execute successfully: {}", result.unwrap_err());
 }
 
@@ -12184,7 +12186,7 @@ fn for_loop_reference_before_shadowing_declaration_reads_outer_binding() {
     let compiled = compile_contract(source, &[], CompileOptions::default())
         .expect("a loop reference before a shadowing declaration should read the outer binding");
     let selector = selector_for(&compiled, "main");
-    let result = run_script_with_selector(compiled.script, selector);
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
     assert!(result.is_ok(), "loop reference before shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -12225,11 +12227,11 @@ fn runs_standalone_block_and_preserves_outer_scope() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "standalone block should execute successfully: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(8)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_ok(), "outer scope should remain valid after the block: {}", result_err.unwrap_err());
 }
 
@@ -12251,22 +12253,22 @@ fn inline_nested_argument_expression_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("inline nested arg should compile");
 
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpAdd).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
         2,
         "the inline nested argument should compute each addition once and reuse the stored result"
     );
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpMul).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(),
         1,
         "the inline nested argument should multiply once and reuse the stored result"
     );
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored inline nested argument should execute successfully: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "stored inline nested argument should still enforce the second require");
 }
 
@@ -12297,22 +12299,22 @@ fn function_call_assignment_result_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("function-call assignment should compile");
 
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpSub).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpSub).count(),
         1,
         "the nested g(x) return calculation should be computed once and the assigned local reused"
     );
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpMul).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(),
         1,
         "the extra arithmetic in f(x) should be computed once and the assigned local reused"
     );
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(19)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored function-call assignment result should execute successfully: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(29)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "stored function-call assignment result should still enforce the second require");
 }
 
@@ -12345,22 +12347,22 @@ fn struct_return_field_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("struct-return local should compile");
 
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpAdd).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
         1,
         "s.a should be computed once and reused across both require statements"
     );
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpMul).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(),
         1,
         "s.b should be computed once and reused across both require statements"
     );
 
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(3)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored struct fields should execute successfully: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "stored struct fields should still enforce the require conditions");
 }
 
@@ -12383,7 +12385,7 @@ fn compile_time_if_branch_stores_local_var_once_and_reuses_it() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
-    let script = &compiled.script;
+    let script = &compiled.bytecode;
     let if_pos = script.iter().position(|op| *op == OpIf).expect("if present");
     let else_pos = script.iter().position(|op| *op == OpElse).expect("else present");
     let endif_pos = script.iter().position(|op| *op == OpEndIf).expect("endif present");
@@ -12422,17 +12424,17 @@ fn compile_time_if_branch_stores_struct_fields_once_and_reuses_them() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpAdd).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
         1,
         "s.a should be computed once and reused across both require statements"
     );
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpMul).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(),
         1,
         "s.b should be computed once and reused across both require statements"
     );
 
-    let script = &compiled.script;
+    let script = &compiled.bytecode;
     let if_pos = script.iter().position(|op| *op == OpIf).expect("if present");
     let else_pos = script.iter().position(|op| *op == OpElse).expect("else present");
     let endif_pos = script.iter().position(|op| *op == OpEndIf).expect("endif present");
@@ -12466,21 +12468,21 @@ fn partially_reassigned_struct_field_does_not_recompute_unchanged_fields() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("partial struct reassignment should compile");
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpMul).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(),
         1,
         "the unchanged field should keep using its original expression instead of being copied into a new stack slot"
     );
     assert_eq!(
-        compiled.script.iter().copied().filter(|op| *op == OpAdd).count(),
+        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
         2,
         "only the initial `s.a = x + 1` and the reassigned `s.a = s.a + 1` should emit additions"
     );
     let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(2)]).expect("sigscript builds");
-    let result_ok = run_script_with_sigscript(compiled.script.clone(), sigscript_ok);
+    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "partial struct reassignment should execute successfully: {}", result_ok.unwrap_err());
 
     let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(0)]).expect("sigscript builds");
-    let result_err = run_script_with_sigscript(compiled.script, sigscript_err);
+    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
     assert!(result_err.is_err(), "partial struct reassignment should still enforce the updated field checks");
 }
 
@@ -12506,12 +12508,12 @@ fn if_branch_reassignment_drops_hidden_shadow_bindings() {
 
     let sigscript_then =
         compiled.build_sig_script("main", vec![Expr::int(1), Expr::int(1), Expr::int(1), Expr::int(3)]).expect("sigscript builds");
-    let result_then = run_script_with_sigscript(compiled.script.clone(), sigscript_then);
+    let result_then = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_then);
     assert!(result_then.is_ok(), "then-branch reassignment should leave a clean stack: {}", result_then.unwrap_err());
 
     let sigscript_else =
         compiled.build_sig_script("main", vec![Expr::int(0), Expr::int(1), Expr::int(1), Expr::int(2)]).expect("sigscript builds");
-    let result_else = run_script_with_sigscript(compiled.script, sigscript_else);
+    let result_else = run_bytecode_with_sigscript(compiled.bytecode, sigscript_else);
     assert!(result_else.is_ok(), "else-branch reassignment should leave a clean stack: {}", result_else.unwrap_err());
 }
 
@@ -12608,13 +12610,13 @@ fn struct_if_branch_reassignment_drops_hidden_shadow_bindings() {
     let sigscript_then = compiled
         .build_sig_script("main", vec![Expr::int(1), Expr::int(2), Expr::int(3), Expr::int(6), Expr::int(7)])
         .expect("sigscript builds");
-    let result_then = run_script_with_sigscript(compiled.script.clone(), sigscript_then);
+    let result_then = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_then);
     assert!(result_then.is_ok(), "then-branch struct cleanup should leave a clean stack: {}", result_then.unwrap_err());
 
     let sigscript_else = compiled
         .build_sig_script("main", vec![Expr::int(0), Expr::int(2), Expr::int(3), Expr::int(5), Expr::int(7)])
         .expect("sigscript builds");
-    let result_else = run_script_with_sigscript(compiled.script, sigscript_else);
+    let result_else = run_bytecode_with_sigscript(compiled.bytecode, sigscript_else);
     assert!(result_else.is_ok(), "else-branch struct cleanup should leave a clean stack: {}", result_else.unwrap_err());
 }
 
@@ -12647,13 +12649,13 @@ fn partial_struct_if_branch_reassignment_drops_hidden_shadow_bindings() {
     let sigscript_then = compiled
         .build_sig_script("main", vec![Expr::int(1), Expr::int(2), Expr::int(3), Expr::int(6), Expr::int(3)])
         .expect("sigscript builds");
-    let result_then = run_script_with_sigscript(compiled.script.clone(), sigscript_then);
+    let result_then = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_then);
     assert!(result_then.is_ok(), "then-branch partial struct cleanup should leave a clean stack: {}", result_then.unwrap_err());
 
     let sigscript_else = compiled
         .build_sig_script("main", vec![Expr::int(0), Expr::int(2), Expr::int(3), Expr::int(2), Expr::int(8)])
         .expect("sigscript builds");
-    let result_else = run_script_with_sigscript(compiled.script, sigscript_else);
+    let result_else = run_bytecode_with_sigscript(compiled.bytecode, sigscript_else);
     assert!(result_else.is_ok(), "else-branch partial struct cleanup should leave a clean stack: {}", result_else.unwrap_err());
 }
 
@@ -12680,7 +12682,7 @@ contract CounterLoop(int BOUND) {
     for b in bounds {
         let args = [Expr::int(b)];
         let compiled = compile_contract(SOURCE, &args, CompileOptions::default()).expect("compile succeeds");
-        lens.push(compiled.script.len());
+        lens.push(compiled.bytecode.len());
     }
 
     assert!(lens[0] < lens[1] && lens[1] < lens[2], "expected monotonic growth, got {lens:?}");
@@ -12720,7 +12722,7 @@ contract StructCounterLoop(int BOUND) {
     for b in bounds {
         let args = [Expr::int(b)];
         let compiled = compile_contract(SOURCE, &args, CompileOptions::default()).expect("compile succeeds");
-        lens.push(compiled.script.len());
+        lens.push(compiled.bytecode.len());
     }
 
     assert!(lens[0] < lens[1] && lens[1] < lens[2], "expected monotonic growth, got {lens:?}");
@@ -12758,9 +12760,9 @@ fn validate_output_state_preserves_nested_struct_field_paths() {
 
     let input_compiled = compile_contract(source, &[1.into(), 2.into()], CompileOptions::default()).expect("compile succeeds");
     let output_compiled = compile_contract(source, &[3.into(), 4.into()], CompileOptions::default()).expect("compile succeeds");
-    let input = test_input(0, sigscript_push_script(&input_compiled.script));
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&output_compiled.script);
+    let input = test_input(0, sigscript_push_bytecode(&input_compiled.bytecode));
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -12856,16 +12858,16 @@ fn validate_output_state_with_template_preserves_nested_struct_field_paths() {
 
     let input_compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile router succeeds");
     let sigscript = input_compiled.build_sig_script("route", vec![target_hash.into()]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.script.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
-    let template_input = test_input(1, sigscript_push_script(&target_template_compiled.script));
-    let input_spk = pay_to_script_hash_script(&input_compiled.script);
-    let output_spk = pay_to_script_hash_script(&target_output_compiled.script);
+    let template_input = test_input(1, sigscript_push_bytecode(&target_template_compiled.bytecode));
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_spk = pay_to_script_hash_script(&target_output_compiled.bytecode);
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input, template_input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
     let template_utxo =
-        UtxoEntry::new(output.value, pay_to_script_hash_script(&target_template_compiled.script), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, pay_to_script_hash_script(&target_template_compiled.bytecode), 0, tx.is_coinbase(), None);
 
     let result = execute_input(tx, vec![utxo_entry, template_utxo], 0);
     assert!(result.is_ok(), "nested struct fields with the same leaf name should remain distinct by path: {result:?}");
@@ -12891,9 +12893,9 @@ fn blake2b_builtins_lower_and_execute_correctly() {
     );
 
     let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("Blake2b builtins compile");
-    assert!(compiled.script.contains(&OpBlake2b));
-    assert!(compiled.script.contains(&OpBlake2bWithKey));
-    let result = run_script_with_selector(compiled.script, None);
+    assert!(compiled.bytecode.contains(&OpBlake2b));
+    assert!(compiled.bytecode.contains(&OpBlake2bWithKey));
+    let result = run_bytecode_with_selector(compiled.bytecode, None);
     assert!(result.is_ok(), "Blake2b builtins should execute correctly: {result:?}");
 }
 
@@ -12918,9 +12920,9 @@ fn blake3_builtins_lower_and_execute_correctly() {
     );
 
     let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("Blake3 builtins compile");
-    assert!(compiled.script.contains(&OpBlake3));
-    assert!(compiled.script.contains(&OpBlake3WithKey));
-    let result = run_script_with_selector(compiled.script, None);
+    assert!(compiled.bytecode.contains(&OpBlake3));
+    assert!(compiled.bytecode.contains(&OpBlake3WithKey));
+    let result = run_bytecode_with_selector(compiled.bytecode, None);
     assert!(result.is_ok(), "Blake3 builtins should call the engine correctly: {result:?}");
 }
 

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -19,7 +19,7 @@ fn lowers_auth_covenant_declaration_to_hidden_entrypoint_name() {
     assert_eq!(compiled.abi[0].name, generated_covenant_auth_entrypoint_name("spend"));
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_spend" && !f.entrypoint));
     assert!(compiled.ast.functions.iter().any(|f| f.name == generated_covenant_auth_entrypoint_name("spend") && f.entrypoint));
-    assert!(compiled.script.contains(&OpAuthOutputCount));
+    assert!(compiled.bytecode.contains(&OpAuthOutputCount));
 }
 
 #[test]
@@ -39,7 +39,7 @@ fn infers_auth_binding_from_from_equal_one_when_binding_omitted() {
     assert_eq!(compiled.abi[0].name, generated_covenant_auth_entrypoint_name("spend"));
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_spend" && !f.entrypoint));
     assert!(compiled.ast.functions.iter().any(|f| f.name == generated_covenant_auth_entrypoint_name("spend") && f.entrypoint));
-    assert!(compiled.script.contains(&OpAuthOutputCount));
+    assert!(compiled.bytecode.contains(&OpAuthOutputCount));
 }
 
 #[test]
@@ -57,9 +57,9 @@ fn lowers_cov_covenant_to_leader_and_delegate_entrypoints() {
     let abi_names: Vec<&str> = compiled.abi.iter().map(|entry| entry.name.as_str()).collect();
     assert_eq!(abi_names, vec!["__leader_transition_ok", "__delegate"]);
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_transition_ok" && !f.entrypoint));
-    assert!(compiled.script.contains(&OpCovInputCount));
-    assert!(compiled.script.contains(&OpCovOutputCount));
-    assert!(compiled.script.contains(&OpCovInputIdx));
+    assert!(compiled.bytecode.contains(&OpCovInputCount));
+    assert!(compiled.bytecode.contains(&OpCovOutputCount));
+    assert!(compiled.bytecode.contains(&OpCovInputIdx));
 }
 
 #[test]
@@ -77,9 +77,9 @@ fn infers_cov_binding_from_from_greater_than_one_when_binding_omitted() {
     let abi_names: Vec<&str> = compiled.abi.iter().map(|entry| entry.name.as_str()).collect();
     assert_eq!(abi_names, vec!["__leader_transition_ok", "__delegate"]);
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_transition_ok" && !f.entrypoint));
-    assert!(compiled.script.contains(&OpCovInputCount));
-    assert!(compiled.script.contains(&OpCovOutputCount));
-    assert!(compiled.script.contains(&OpCovInputIdx));
+    assert!(compiled.bytecode.contains(&OpCovInputCount));
+    assert!(compiled.bytecode.contains(&OpCovOutputCount));
+    assert!(compiled.bytecode.contains(&OpCovInputIdx));
 }
 
 #[test]
@@ -239,7 +239,7 @@ fn lowers_singleton_sugar_to_auth_one_to_one_defaults() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     assert!(compiled.without_selector);
     assert_eq!(compiled.abi[0].name, generated_covenant_auth_entrypoint_name("spend"));
-    assert!(compiled.script.contains(&OpAuthOutputCount));
+    assert!(compiled.bytecode.contains(&OpAuthOutputCount));
 }
 
 #[test]
@@ -256,7 +256,7 @@ fn lowers_fanout_sugar_to_auth_with_to_bound() {
     let compiled = compile_contract(source, &[Expr::int(3)], CompileOptions::default()).expect("compile succeeds");
     assert!(compiled.without_selector);
     assert_eq!(compiled.abi[0].name, generated_covenant_auth_entrypoint_name("split"));
-    assert!(compiled.script.contains(&OpAuthOutputCount));
+    assert!(compiled.bytecode.contains(&OpAuthOutputCount));
 }
 
 #[test]
@@ -575,9 +575,9 @@ fn auth_covenant_groups_single_injects_shared_count_check() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    assert!(compiled.script.contains(&OpInputCovenantId));
-    assert!(compiled.script.contains(&OpCovOutputCount));
-    assert!(compiled.script.contains(&OpAuthOutputCount));
+    assert!(compiled.bytecode.contains(&OpInputCovenantId));
+    assert!(compiled.bytecode.contains(&OpCovOutputCount));
+    assert!(compiled.bytecode.contains(&OpAuthOutputCount));
 }
 
 #[test]

--- a/silverscript-lang/tests/covenant_declaration_security_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_security_tests.rs
@@ -154,7 +154,7 @@ fn cov_decl_nm_leader_sigscript(compiled: &CompiledContract<'_>, next_values: Ve
 }
 
 fn redeem_only_sigscript(compiled: &CompiledContract<'_>) -> Vec<u8> {
-    push_redeem_script(&compiled.script)
+    push_redeem_script(&compiled.bytecode)
 }
 
 #[test]
@@ -393,8 +393,8 @@ fn many_to_many_happy_path_succeeds() {
     let in1 = compile_state(COV_N_TO_M_SOURCE, 7);
     let out0 = compile_state(COV_N_TO_M_SOURCE, 10);
     let out1 = compile_state(COV_N_TO_M_SOURCE, 10);
-    assert_eq!(in0.script, out0.script, "leader input and output[0] script should match");
-    assert_eq!(in0.script, out1.script, "leader input and output[1] script should match");
+    assert_eq!(in0.bytecode, out0.bytecode, "leader input and output[0] script should match");
+    assert_eq!(in0.bytecode, out1.bytecode, "leader input and output[1] script should match");
 
     // Intended valid shape: two covenant inputs in the same id, two covenant outputs in the same id,
     // leader path on input 0 and delegate path on input 1.

--- a/silverscript-lang/tests/examples_tests.rs
+++ b/silverscript-lang/tests/examples_tests.rs
@@ -39,7 +39,7 @@ fn random_keypair() -> Keypair {
 }
 
 fn run_contract_with_tx(
-    script: Vec<u8>,
+    bytecode: Vec<u8>,
     output0_script: Vec<u8>,
     output1_script: Vec<u8>,
     input_value: u64,
@@ -49,7 +49,7 @@ fn run_contract_with_tx(
     lock_time: u64,
 ) -> Result<(), kaspa_txscript_errors::TxScriptError> {
     run_contract_with_tx_sequence(
-        script,
+        bytecode,
         output0_script,
         output1_script,
         input_value,
@@ -62,7 +62,7 @@ fn run_contract_with_tx(
 }
 
 fn run_contract_with_tx_sequence(
-    script: Vec<u8>,
+    bytecode: Vec<u8>,
     output0_script: Vec<u8>,
     output1_script: Vec<u8>,
     input_value: u64,
@@ -88,7 +88,7 @@ fn run_contract_with_tx_sequence(
 
     let tx =
         Transaction::new(1, vec![input.clone()], vec![output0.clone(), output1.clone()], lock_time, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let populated_tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
 
     let mut vm = TxScriptEngine::from_transaction_input(
@@ -103,7 +103,7 @@ fn run_contract_with_tx_sequence(
 }
 
 fn run_contract_with_outputs(
-    script: Vec<u8>,
+    bytecode: Vec<u8>,
     outputs: Vec<(u64, Vec<u8>)>,
     input_value: u64,
     sigscript: Vec<u8>,
@@ -125,7 +125,7 @@ fn run_contract_with_outputs(
         .collect::<Vec<_>>();
 
     let tx = Transaction::new(1, vec![input.clone()], tx_outputs.clone(), lock_time, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let populated_tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
 
     let mut vm = TxScriptEngine::from_transaction_input(
@@ -139,9 +139,9 @@ fn run_contract_with_outputs(
     vm.execute()
 }
 
-fn script_with_return_checks(script: Vec<u8>, expected: &[i64]) -> Vec<u8> {
+fn bytecode_with_return_checks(bytecode: Vec<u8>, expected: &[i64]) -> Vec<u8> {
     let mut builder = ScriptBuilder::new();
-    builder.add_ops(&script).unwrap();
+    builder.add_ops(&bytecode).unwrap();
     for value in expected.iter().rev() {
         builder.add_i64(*value).unwrap();
         builder.add_op(OpEqualVerify).unwrap();
@@ -150,8 +150,8 @@ fn script_with_return_checks(script: Vec<u8>, expected: &[i64]) -> Vec<u8> {
     builder.drain()
 }
 
-fn sigscript_push_script(script: &[u8]) -> Vec<u8> {
-    ScriptBuilder::new().add_data(script).unwrap().drain()
+fn sigscript_push_bytecode(bytecode: &[u8]) -> Vec<u8> {
+    ScriptBuilder::new().add_data(bytecode).unwrap().drain()
 }
 
 fn r0_groth16_fixture() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
@@ -180,9 +180,9 @@ fn compiles_announcement_example_and_verifies() {
     let input_value = 3000u64;
     let output1_value = input_value - 1000;
     let result = run_contract_with_tx(
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         announcement_script.clone(),
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         input_value,
         0,
         output1_value,
@@ -196,9 +196,9 @@ fn compiles_announcement_example_and_verifies() {
     let input_value = 1500u64;
     let output1_value = 1u64;
     let result = run_contract_with_tx(
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         announcement_script,
-        compiled.script,
+        compiled.bytecode,
         input_value,
         0,
         output1_value,
@@ -224,7 +224,7 @@ fn compiles_constant_budget_example_and_verifies() {
     let output0_value = 1500u64;
     let output1_value = 1200u64;
     let result = run_contract_with_tx(
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         output0_script.clone(),
         output1_script.clone(),
         input_value,
@@ -240,8 +240,16 @@ fn compiles_constant_budget_example_and_verifies() {
     let input_value = 3000u64;
     let output0_value = 1300u64;
     let output1_value = 500u64;
-    let result =
-        run_contract_with_tx(compiled.script, output0_script, output1_script, input_value, output0_value, output1_value, sigscript, 0);
+    let result = run_contract_with_tx(
+        compiled.bytecode,
+        output0_script,
+        output1_script,
+        input_value,
+        output0_value,
+        output1_value,
+        sigscript,
+        0,
+    );
     assert!(result.is_ok(), "constant_budget else branch failed: {}", result.unwrap_err());
 }
 
@@ -268,7 +276,7 @@ fn compiles_for_loop_example_and_verifies() {
         (1002u64, output2_script.clone()),
         (1003u64, output3_script.clone()),
     ];
-    let result = run_contract_with_outputs(compiled.script.clone(), outputs, input_value, sigscript, 0);
+    let result = run_contract_with_outputs(compiled.bytecode.clone(), outputs, input_value, sigscript, 0);
     assert!(result.is_ok(), "for_loop example failed: {}", result.unwrap_err());
 
     // Test check() failure when require fails in the loop.
@@ -280,14 +288,14 @@ fn compiles_for_loop_example_and_verifies() {
         (999u64, output2_script.clone()),
         (1003u64, output3_script.clone()),
     ];
-    let result = run_contract_with_outputs(compiled.script.clone(), outputs, input_value, sigscript, 0);
+    let result = run_contract_with_outputs(compiled.bytecode.clone(), outputs, input_value, sigscript, 0);
     assert!(result.is_err(), "for_loop require failure should error");
 
     // Test check() failure when there are fewer than 4 outputs.
     let sigscript = compiled.build_sig_script("check", vec![]).expect("sigscript builds");
     let input_value = 10_000u64;
     let outputs = vec![(1000u64, output0_script), (1001u64, output1_script), (1002u64, output2_script)];
-    let result = run_contract_with_outputs(compiled.script, outputs, input_value, sigscript, 0);
+    let result = run_contract_with_outputs(compiled.bytecode, outputs, input_value, sigscript, 0);
     assert!(result.is_err(), "for_loop with too few outputs should error");
 }
 
@@ -314,7 +322,7 @@ fn compiles_for_loop_ctor_example_with_constructor_bounds() {
         (1002u64, output2_script.clone()),
         (1003u64, output3_script.clone()),
     ];
-    let result = run_contract_with_outputs(compiled.script, outputs, input_value, sigscript, 0);
+    let result = run_contract_with_outputs(compiled.bytecode, outputs, input_value, sigscript, 0);
     assert!(result.is_ok(), "for_loop_ctor example failed: {}", result.unwrap_err());
 }
 
@@ -324,7 +332,7 @@ fn compiles_return_basic_example_file_and_verifies() {
 
     let options = CompileOptions { allow_entrypoint_return: true, ..CompileOptions::default() };
     let compiled = compile_contract(&source, &[], options).expect("compile succeeds");
-    let script = script_with_return_checks(compiled.script.clone(), &[12, 8]);
+    let script = bytecode_with_return_checks(compiled.bytecode.clone(), &[12, 8]);
     let recipient0 = [9u8; 32];
     let recipient1 = [10u8; 32];
     let output0_script = build_p2pk_script(&recipient0);
@@ -342,7 +350,7 @@ fn compiles_return_loop_example_file_and_verifies() {
 
     let options = CompileOptions { allow_entrypoint_return: true, ..CompileOptions::default() };
     let compiled = compile_contract(&source, &[], options).expect("compile succeeds");
-    let script = script_with_return_checks(compiled.script.clone(), &[10]);
+    let script = bytecode_with_return_checks(compiled.bytecode.clone(), &[10]);
     let recipient0 = [11u8; 32];
     let recipient1 = [12u8; 32];
     let output0_script = build_p2pk_script(&recipient0);
@@ -362,8 +370,16 @@ fn compiles_r0_g16_example_and_verifies() {
     let sigscript =
         compiled.build_sig_script("verify", vec![journal_hash.into(), Expr::dynamic_bytes(proof)]).expect("sigscript builds");
 
-    let result =
-        run_contract_with_tx(compiled.script.clone(), compiled.script.clone(), compiled.script.clone(), 2000, 500, 500, sigscript, 0);
+    let result = run_contract_with_tx(
+        compiled.bytecode.clone(),
+        compiled.bytecode.clone(),
+        compiled.bytecode.clone(),
+        2000,
+        500,
+        500,
+        sigscript,
+        0,
+    );
     assert!(result.is_ok(), "R0 Groth16 example failed: {}", result.unwrap_err());
 }
 
@@ -382,8 +398,16 @@ fn compiles_r0_succinct_example_and_verifies() {
         )
         .expect("sigscript builds");
 
-    let result =
-        run_contract_with_tx(compiled.script.clone(), compiled.script.clone(), compiled.script.clone(), 2000, 500, 500, sigscript, 0);
+    let result = run_contract_with_tx(
+        compiled.bytecode.clone(),
+        compiled.bytecode.clone(),
+        compiled.bytecode.clone(),
+        2000,
+        500,
+        500,
+        sigscript,
+        0,
+    );
     assert!(result.is_ok(), "R0 Succinct example failed: {}", result.unwrap_err());
 }
 
@@ -410,7 +434,7 @@ fn compiles_return_basic_example_and_verifies() {
 
     let options = CompileOptions { allow_entrypoint_return: true, ..CompileOptions::default() };
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
-    let script = script_with_return_checks(compiled.script.clone(), &[2, 5]);
+    let script = bytecode_with_return_checks(compiled.bytecode.clone(), &[2, 5]);
     let recipient0 = [13u8; 32];
     let recipient1 = [14u8; 32];
     let output0_script = build_p2pk_script(&recipient0);
@@ -441,11 +465,15 @@ fn runs_everything_example_and_verifies() {
         sequence: 500,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 5_000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 5_000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -486,9 +514,9 @@ fn runs_sum_series_example_with_multiple_inputs() {
         let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
         let sigscript = compiled.build_sig_script("main", vec![n.into()]).expect("sigscript builds");
         let result = run_contract_with_tx(
-            compiled.script.clone(),
-            compiled.script.clone(),
-            compiled.script.clone(),
+            compiled.bytecode.clone(),
+            compiled.bytecode.clone(),
+            compiled.bytecode.clone(),
             2000,
             500,
             500,
@@ -515,9 +543,9 @@ fn runs_complex_assignments_example_and_verifies() {
         let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
         let sigscript = compiled.build_sig_script("main", vec![n.into()]).expect("sigscript builds");
         let result = run_contract_with_tx(
-            compiled.script.clone(),
-            compiled.script.clone(),
-            compiled.script.clone(),
+            compiled.bytecode.clone(),
+            compiled.bytecode.clone(),
+            compiled.bytecode.clone(),
             2000,
             500,
             500,
@@ -555,11 +583,15 @@ fn compiles_hodl_vault_example_and_verifies() {
         sequence: 0,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 5000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 5000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], block_height as u64, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -613,9 +645,9 @@ fn compiles_mecenas_example_and_verifies() {
     let output0_script = build_p2pk_script(&recipient);
 
     let result = run_contract_with_tx(
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         output0_script,
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         input_value,
         output0_value,
         output1_value,
@@ -633,9 +665,9 @@ fn compiles_mecenas_example_and_verifies() {
     let output0_script = build_p2pk_script(&recipient);
 
     let result = run_contract_with_tx(
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         output0_script,
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         input_value,
         output0_value,
         output1_value,
@@ -650,11 +682,15 @@ fn compiles_mecenas_example_and_verifies() {
         sequence: 0,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 5000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 5000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -709,9 +745,9 @@ fn compiles_mecenas_locktime_example_and_verifies() {
     let pledge = passed_blocks as i64 * pledge_per_block;
 
     let output0_script = build_p2pk_script(&recipient);
-    let mut active_bytecode = Vec::with_capacity(2 + compiled.script.len());
+    let mut active_bytecode = Vec::with_capacity(2 + compiled.bytecode.len());
     active_bytecode.extend_from_slice(&0u16.to_be_bytes());
-    active_bytecode.extend_from_slice(&compiled.script);
+    active_bytecode.extend_from_slice(&compiled.bytecode);
     let mut bc_value = Vec::new();
     bc_value.push(8u8);
     bc_value.extend_from_slice(&lock_time.to_le_bytes());
@@ -725,7 +761,7 @@ fn compiles_mecenas_locktime_example_and_verifies() {
     let output1_value = input_value - pledge as u64 - 1000;
 
     let result = run_contract_with_tx(
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         output0_script.clone(),
         output1_script,
         input_value,
@@ -744,9 +780,9 @@ fn compiles_mecenas_locktime_example_and_verifies() {
     let output1_value = 0u64;
 
     let result = run_contract_with_tx(
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         output0_script,
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         input_value,
         output0_value,
         output1_value,
@@ -761,11 +797,15 @@ fn compiles_mecenas_locktime_example_and_verifies() {
         sequence: 0,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 6000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 6000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -813,11 +853,15 @@ fn compiles_p2pkh_example_and_verifies() {
         sequence: 0,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 7000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 7000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -867,11 +911,15 @@ fn compiles_transfer_with_timeout_and_verifies() {
         sequence: 0,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 8_000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 8_000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -907,11 +955,15 @@ fn compiles_transfer_with_timeout_and_verifies() {
         sequence: 0,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 9_000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 9_000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], lock_time, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -969,7 +1021,7 @@ fn compiles_covenant_escrow_example_and_verifies() {
         TransactionOutput { value: output0_value, script_public_key: ScriptPublicKey::new(0, output0_script.into()), covenant: None };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output0.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1025,11 +1077,15 @@ fn compiles_covenant_last_will_and_verifies() {
         sequence: 180,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 5_000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 5_000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1065,11 +1121,15 @@ fn compiles_covenant_last_will_and_verifies() {
         sequence: 0,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 4_000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 4_000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1110,12 +1170,12 @@ fn compiles_covenant_last_will_and_verifies() {
     };
     let output0 = TransactionOutput {
         value: output0_value,
-        script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output0.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1170,9 +1230,9 @@ fn compiles_covenant_mecenas_example_and_verifies() {
     let output0_script = build_p2pk_script(&recipient);
 
     let result = run_contract_with_tx_sequence(
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         output0_script,
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         input_value,
         output0_value,
         output1_value,
@@ -1190,9 +1250,9 @@ fn compiles_covenant_mecenas_example_and_verifies() {
     let output0_script = build_p2pk_script(&recipient);
 
     let result = run_contract_with_tx_sequence(
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         output0_script,
-        compiled.script.clone(),
+        compiled.bytecode.clone(),
         input_value,
         output0_value,
         output1_value,
@@ -1208,11 +1268,15 @@ fn compiles_covenant_mecenas_example_and_verifies() {
         sequence: 0,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 7_000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 7_000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1267,7 +1331,7 @@ fn compiles_covenant_id_example_and_verifies() {
 
         let mut active_sigscript =
             active_compiled.build_sig_script("main", vec![vec![out0_amount, out1_amount].into()]).expect("sigscript builds");
-        active_sigscript.extend_from_slice(&sigscript_push_script(&active_compiled.script));
+        active_sigscript.extend_from_slice(&sigscript_push_bytecode(&active_compiled.bytecode));
 
         let input0 = TransactionInput {
             previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([24u8; 32]), index: 0 },
@@ -1277,7 +1341,7 @@ fn compiles_covenant_id_example_and_verifies() {
         };
         let input1 = TransactionInput {
             previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([25u8; 32]), index: 1 },
-            signature_script: sigscript_push_script(&input1_compiled.script),
+            signature_script: sigscript_push_bytecode(&input1_compiled.bytecode),
             sequence: 0,
             compute_commit: SigopCount(0).into(),
         };
@@ -1290,7 +1354,7 @@ fn compiles_covenant_id_example_and_verifies() {
 
         let output0 = TransactionOutput {
             value: 1,
-            script_public_key: pay_to_script_hash_script(&output0_compiled.script),
+            script_public_key: pay_to_script_hash_script(&output0_compiled.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id }),
         };
 
@@ -1302,7 +1366,7 @@ fn compiles_covenant_id_example_and_verifies() {
 
         let output2 = TransactionOutput {
             value: 1,
-            script_public_key: pay_to_script_hash_script(&output1_compiled.script),
+            script_public_key: pay_to_script_hash_script(&output1_compiled.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id }),
         };
 
@@ -1316,8 +1380,9 @@ fn compiles_covenant_id_example_and_verifies() {
             vec![],
         );
 
-        let utxo0 = UtxoEntry::new(1_600, pay_to_script_hash_script(&active_compiled.script), 0, tx.is_coinbase(), Some(covenant_id));
-        let utxo1 = UtxoEntry::new(700, pay_to_script_hash_script(&input1_compiled.script), 0, tx.is_coinbase(), Some(covenant_id));
+        let utxo0 =
+            UtxoEntry::new(1_600, pay_to_script_hash_script(&active_compiled.bytecode), 0, tx.is_coinbase(), Some(covenant_id));
+        let utxo1 = UtxoEntry::new(700, pay_to_script_hash_script(&input1_compiled.bytecode), 0, tx.is_coinbase(), Some(covenant_id));
         let utxo2 = UtxoEntry::new(300, ScriptPublicKey::new(0, vec![OpTrue].into()), 0, tx.is_coinbase(), Some(other_covenant_id));
 
         let reused_values = SigHashReusedValuesUnsync::new();
@@ -1361,11 +1426,15 @@ fn compiles_bar_example_and_verifies() {
         sequence: 0,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 7_000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 7_000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1412,11 +1481,15 @@ fn compiles_foo_example_and_verifies() {
         sequence: 0,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 7_000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 7_000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1452,13 +1525,29 @@ fn compiles_bounded_bytes_example_and_verifies() {
 
     let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = compiled.build_sig_script("spend", vec![vec![0u8; 4].into(), 0.into()]).expect("sigscript builds");
-    let result =
-        run_contract_with_tx(compiled.script.clone(), compiled.script.clone(), compiled.script.clone(), 2000, 500, 500, sigscript, 0);
+    let result = run_contract_with_tx(
+        compiled.bytecode.clone(),
+        compiled.bytecode.clone(),
+        compiled.bytecode.clone(),
+        2000,
+        500,
+        500,
+        sigscript,
+        0,
+    );
     assert!(result.is_ok(), "bounded_bytes example failed: {}", result.unwrap_err());
 
     let sigscript = compiled.build_sig_script("spend", vec![vec![0u8; 4].into(), 1.into()]).expect("sigscript builds");
-    let result =
-        run_contract_with_tx(compiled.script.clone(), compiled.script.clone(), compiled.script.clone(), 2000, 500, 500, sigscript, 0);
+    let result = run_contract_with_tx(
+        compiled.bytecode.clone(),
+        compiled.bytecode.clone(),
+        compiled.bytecode.clone(),
+        2000,
+        500,
+        500,
+        sigscript,
+        0,
+    );
     assert!(result.is_err(), "bounded_bytes mismatch should fail");
 }
 
@@ -1479,11 +1568,15 @@ fn compiles_p2pkh_invalid_example_and_fails() {
         sequence: 0,
         compute_commit: SigopCount(1).into(),
     };
-    let output =
-        TransactionOutput { value: 7_000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output = TransactionOutput {
+        value: 7_000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1538,8 +1631,11 @@ fn compiles_sibling_introspection_example_and_verifies() {
         compute_commit: SigopCount(0).into(),
     };
 
-    let output0 =
-        TransactionOutput { value: 1_000, script_public_key: ScriptPublicKey::new(0, compiled.script.clone().into()), covenant: None };
+    let output0 = TransactionOutput {
+        value: 1_000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
     let output1 = TransactionOutput {
         value: 1_000,
         script_public_key: ScriptPublicKey::new(0, expected_locking_bytecode[2..].to_vec().into()),
@@ -1555,7 +1651,7 @@ fn compiles_sibling_introspection_example_and_verifies() {
         0,
         vec![],
     );
-    let utxo0 = UtxoEntry::new(output0.value, ScriptPublicKey::new(0, compiled.script.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo0 = UtxoEntry::new(output0.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
     let utxo1 = UtxoEntry::new(
         output1.value,
         ScriptPublicKey::new(0, expected_locking_bytecode[2..].to_vec().into()),
@@ -1590,5 +1686,5 @@ fn compiles_many_assignments_example_under_500_bytes() {
     // We check the final bytecode stays small to prove the compiler is not
     // re-expanding earlier expressions exponentially. Instead, each interim
     // variable should be stored on the stack once and reused by later steps.
-    assert!(compiled.script.len() < 500, "long.sil should compile to less than 500 bytes, got {}", compiled.script.len());
+    assert!(compiled.bytecode.len() < 500, "long.sil should compile to less than 500 bytes, got {}", compiled.bytecode.len());
 }

--- a/silverscript-lang/tests/kcc20_tests.rs
+++ b/silverscript-lang/tests/kcc20_tests.rs
@@ -179,7 +179,7 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
 
     let handoff_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&handoff.script),
+        script_public_key: pay_to_script_hash_script(&handoff.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let handoff_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -221,12 +221,12 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
     let split_outputs = vec![
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_a.script),
+            script_public_key: pay_to_script_hash_script(&split_a.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_b.script),
+            script_public_key: pay_to_script_hash_script(&split_b.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -272,12 +272,12 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
     let merged = compile_kcc20_state(&source, merged_owner_bytes.clone(), 1_000, 2, 2);
     let merge_outputs = vec![TransactionOutput {
         value: 2_000,
-        script_public_key: pay_to_script_hash_script(&merged.script),
+        script_public_key: pay_to_script_hash_script(&merged.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let merge_entries = vec![
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_a.script), 0, split_tx.is_coinbase(), Some(COV_A)),
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_b.script), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&split_a.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&split_b.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
     ];
     let merge_unsigned_tx = Transaction::new(
         1,
@@ -346,7 +346,7 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
 
     let handoff_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&handoff.script),
+        script_public_key: pay_to_script_hash_script(&handoff.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let handoff_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -388,12 +388,12 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
     let split_outputs = vec![
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_a.script),
+            script_public_key: pay_to_script_hash_script(&split_a.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_b.script),
+            script_public_key: pay_to_script_hash_script(&split_b.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -438,12 +438,12 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
 
     let merge_outputs = vec![TransactionOutput {
         value: 2_000,
-        script_public_key: pay_to_script_hash_script(&merged.script),
+        script_public_key: pay_to_script_hash_script(&merged.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let merge_entries = vec![
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_a.script), 0, split_tx.is_coinbase(), Some(COV_A)),
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_b.script), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&split_a.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&split_b.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
     ];
     let merge_unsigned_tx = Transaction::new(
         1,
@@ -509,7 +509,7 @@ fn kcc20_rejects_split_when_amounts_do_not_match() {
 
     let handoff_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&handoff.script),
+        script_public_key: pay_to_script_hash_script(&handoff.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let handoff_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -551,12 +551,12 @@ fn kcc20_rejects_split_when_amounts_do_not_match() {
     let split_outputs = vec![
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_a.script),
+            script_public_key: pay_to_script_hash_script(&split_a.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_b.script),
+            script_public_key: pay_to_script_hash_script(&split_b.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -623,12 +623,12 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let split_outputs = vec![
         TransactionOutput {
             value: 1_000,
-            script_public_key: pay_to_script_hash_script(&split_minter.script),
+            script_public_key: pay_to_script_hash_script(&split_minter.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 1_000,
-            script_public_key: pay_to_script_hash_script(&split_other.script),
+            script_public_key: pay_to_script_hash_script(&split_other.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -671,11 +671,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let forged_other = compile_kcc20_state(&source, other_owner_bytes.clone(), 700, 2, 2);
     let forged_other_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&forged_other.script),
+        script_public_key: pay_to_script_hash_script(&forged_other.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let forged_other_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_other.script), 0, split_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_other.bytecode), 0, split_tx.is_coinbase(), Some(COV_A))];
     let forged_other_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: split_tx.id(), index: 1 }, vec![])],
@@ -713,11 +713,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let forged_other_minter = compile_kcc20_state_with_minter(&source, other_owner_bytes.clone(), 600, true, 2, 2);
     let forged_other_minter_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&forged_other_minter.script),
+        script_public_key: pay_to_script_hash_script(&forged_other_minter.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let forged_other_minter_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_other.script), 0, split_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_other.bytecode), 0, split_tx.is_coinbase(), Some(COV_A))];
     let forged_other_minter_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: split_tx.id(), index: 1 }, vec![])],
@@ -757,11 +757,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
 
     let mint_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&minted_minter.script),
+        script_public_key: pay_to_script_hash_script(&minted_minter.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let mint_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_minter.script), 0, split_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_minter.bytecode), 0, split_tx.is_coinbase(), Some(COV_A))];
     let mint_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: split_tx.id(), index: 0 }, vec![])],
@@ -796,11 +796,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
 
     let burn_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&burned_minter.script),
+        script_public_key: pay_to_script_hash_script(&burned_minter.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let burn_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&minted_minter.script), 0, mint_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&minted_minter.bytecode), 0, mint_tx.is_coinbase(), Some(COV_A))];
     let burn_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: mint_tx.id(), index: 0 }, vec![])],
@@ -846,7 +846,7 @@ fn kcc20_minter_can_mint_in_single_transaction() {
 
     let mint_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&minted.script),
+        script_public_key: pay_to_script_hash_script(&minted.bytecode),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let mint_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -967,7 +967,7 @@ fn kcc20_covenant_minter() {
     let minter_genesis_input = tx_input_from_outpoint_v1(minter_genesis_outpoint, vec![]);
     let minter_genesis_utxo = UtxoEntry::new(1_500, funding_spk.clone(), 0, false, None);
     let minter_genesis_output_without_covenant =
-        TransactionOutput { value: 1_000, script_public_key: pay_to_script_hash_script(&pre_init.script), covenant: None };
+        TransactionOutput { value: 1_000, script_public_key: pay_to_script_hash_script(&pre_init.bytecode), covenant: None };
     let minter_cov_id =
         hashing::covenant_id::covenant_id(minter_genesis_outpoint, std::iter::once((0, &minter_genesis_output_without_covenant)));
     let minter_genesis_outputs = vec![TransactionOutput {
@@ -1268,7 +1268,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
         .iter()
         .map(|state| TransactionOutput {
             value: 150,
-            script_public_key: pay_to_script_hash_script(&state.script),
+            script_public_key: pay_to_script_hash_script(&state.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         })
         .collect();
@@ -1314,7 +1314,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
     let build_single_output = |state: &CompiledContract<'_>| {
         vec![TransactionOutput {
             value: 150,
-            script_public_key: pay_to_script_hash_script(&state.script),
+            script_public_key: pay_to_script_hash_script(&state.bytecode),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         }]
     };
@@ -1339,7 +1339,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
     let script_hash_spent = compile_kcc20_state(&source, multisig_spend_destination_owner_bytes.clone(), 400, 2, 2);
     let script_hash_spend_outputs = build_single_output(&script_hash_spent);
     let script_hash_spend_entries = vec![
-        UtxoEntry::new(150, pay_to_script_hash_script(&split_states[0].script), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(150, pay_to_script_hash_script(&split_states[0].bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
         UtxoEntry::new(500, pay_to_script_hash_script(&multisig_redeem_script), 0, false, None),
     ];
     let script_hash_auxiliary_outpoint = TransactionOutpoint { transaction_id: TransactionId::from_bytes([2; 32]), index: 0 };
@@ -1402,7 +1402,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
     let covenant_id_spent = compile_kcc20_state(&source, covenant_spend_destination_owner_bytes.clone(), 600, 2, 2);
     let covenant_id_spend_outputs = build_single_output(&covenant_id_spent);
     let covenant_id_spend_entries = vec![
-        UtxoEntry::new(150, pay_to_script_hash_script(&split_states[1].script), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(150, pay_to_script_hash_script(&split_states[1].bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
         UtxoEntry::new(500, pay_to_script_hash_script(&[0x51]), 0, false, Some(covenant_owner)),
     ];
     let covenant_id_auxiliary_outpoint = TransactionOutpoint { transaction_id: TransactionId::from_bytes([3; 32]), index: 0 };

--- a/silverscript-lang/tests/silverc_tests.rs
+++ b/silverscript-lang/tests/silverc_tests.rs
@@ -39,7 +39,7 @@ fn temp_dir(name: &str) -> PathBuf {
     dir
 }
 
-fn run_script_with_selector(script: Vec<u8>, selector: Option<i64>) -> Result<(), kaspa_txscript_errors::TxScriptError> {
+fn run_bytecode_with_selector(bytecode: Vec<u8>, selector: Option<i64>) -> Result<(), kaspa_txscript_errors::TxScriptError> {
     let mut builder = ScriptBuilder::new();
     if let Some(selector) = selector {
         builder.add_i64(selector).unwrap();
@@ -54,7 +54,8 @@ fn run_script_with_selector(script: Vec<u8>, selector: Option<i64>) -> Result<()
         sequence: 0,
         compute_commit: SigopCount(0).into(),
     };
-    let output = TransactionOutput { value: 1000, script_public_key: ScriptPublicKey::new(0, script.clone().into()), covenant: None };
+    let output =
+        TransactionOutput { value: 1000, script_public_key: ScriptPublicKey::new(0, bytecode.clone().into()), covenant: None };
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, output.script_public_key.clone(), 0, tx.is_coinbase(), None);
     let populated_tx = PopulatedTransaction::new(&tx, vec![utxo_entry.clone()]);
@@ -126,7 +127,7 @@ fn silverc_accepts_constructor_args_and_output_flag() {
     assert_eq!(compiled.compiler_version, COMPILER_VERSION);
     let selector =
         if compiled.without_selector { None } else { Some(function_branch_index(&compiled.ast, "main").expect("selector resolved")) };
-    assert!(run_script_with_selector(compiled.script, selector).is_ok());
+    assert!(run_bytecode_with_selector(compiled.bytecode, selector).is_ok());
 }
 
 #[test]

--- a/silverscript-lang/tests/tutorial_rust_examples_tests.rs
+++ b/silverscript-lang/tests/tutorial_rust_examples_tests.rs
@@ -18,7 +18,7 @@ fn tutorial_rust_programmatic_compilation_example() {
         .expect("programmatic compilation example should compile");
 
     assert_eq!(compiled.contract_name, "MyContract");
-    assert!(!compiled.script.is_empty());
+    assert!(!compiled.bytecode.is_empty());
     assert_eq!(compiled.abi.len(), 1);
     assert_eq!(compiled.abi[0].name, "spend");
 }

--- a/tree-sitter/grammar.js
+++ b/tree-sitter/grammar.js
@@ -466,8 +466,8 @@ export default grammar({
       choice(
         "this.activeInputIndex",
         "this.activeScriptPubKey",
-        "this.scriptSizeDataPrefix",
-        "this.scriptSize",
+        "this.bytecodeSizeDataPrefix",
+        "this.bytecodeSize",
         "tx.inputs.length",
         "tx.outputs.length",
         "tx.version",

--- a/tree-sitter/src/grammar.json
+++ b/tree-sitter/src/grammar.json
@@ -2685,11 +2685,11 @@
         },
         {
           "type": "STRING",
-          "value": "this.scriptSizeDataPrefix"
+          "value": "this.bytecodeSizeDataPrefix"
         },
         {
           "type": "STRING",
-          "value": "this.scriptSize"
+          "value": "this.bytecodeSize"
         },
         {
           "type": "STRING",

--- a/tree-sitter/src/node-types.json
+++ b/tree-sitter/src/node-types.json
@@ -1889,11 +1889,11 @@
     "named": false
   },
   {
-    "type": "this.scriptSize",
+    "type": "this.bytecodeSize",
     "named": false
   },
   {
-    "type": "this.scriptSizeDataPrefix",
+    "type": "this.bytecodeSizeDataPrefix",
     "named": false
   },
   {

--- a/tree-sitter/src/parser.c
+++ b/tree-sitter/src/parser.c
@@ -106,8 +106,8 @@ enum ts_symbol_identifiers {
   anon_sym_tx_DOTtime = 84,
   anon_sym_this_DOTactiveInputIndex = 85,
   anon_sym_this_DOTactiveScriptPubKey = 86,
-  anon_sym_this_DOTscriptSizeDataPrefix = 87,
-  anon_sym_this_DOTscriptSize = 88,
+  anon_sym_this_DOTbytecodeSizeDataPrefix = 87,
+  anon_sym_this_DOTbytecodeSize = 88,
   anon_sym_tx_DOTinputs_DOTlength = 89,
   anon_sym_tx_DOToutputs_DOTlength = 90,
   anon_sym_tx_DOTversion = 91,
@@ -309,8 +309,8 @@ static const char * const ts_symbol_names[] = {
   [anon_sym_tx_DOTtime] = "tx.time",
   [anon_sym_this_DOTactiveInputIndex] = "this.activeInputIndex",
   [anon_sym_this_DOTactiveScriptPubKey] = "this.activeScriptPubKey",
-  [anon_sym_this_DOTscriptSizeDataPrefix] = "this.scriptSizeDataPrefix",
-  [anon_sym_this_DOTscriptSize] = "this.scriptSize",
+  [anon_sym_this_DOTbytecodeSizeDataPrefix] = "this.bytecodeSizeDataPrefix",
+  [anon_sym_this_DOTbytecodeSize] = "this.bytecodeSize",
   [anon_sym_tx_DOTinputs_DOTlength] = "tx.inputs.length",
   [anon_sym_tx_DOToutputs_DOTlength] = "tx.outputs.length",
   [anon_sym_tx_DOTversion] = "tx.version",
@@ -512,8 +512,8 @@ static const TSSymbol ts_symbol_map[] = {
   [anon_sym_tx_DOTtime] = anon_sym_tx_DOTtime,
   [anon_sym_this_DOTactiveInputIndex] = anon_sym_this_DOTactiveInputIndex,
   [anon_sym_this_DOTactiveScriptPubKey] = anon_sym_this_DOTactiveScriptPubKey,
-  [anon_sym_this_DOTscriptSizeDataPrefix] = anon_sym_this_DOTscriptSizeDataPrefix,
-  [anon_sym_this_DOTscriptSize] = anon_sym_this_DOTscriptSize,
+  [anon_sym_this_DOTbytecodeSizeDataPrefix] = anon_sym_this_DOTbytecodeSizeDataPrefix,
+  [anon_sym_this_DOTbytecodeSize] = anon_sym_this_DOTbytecodeSize,
   [anon_sym_tx_DOTinputs_DOTlength] = anon_sym_tx_DOTinputs_DOTlength,
   [anon_sym_tx_DOToutputs_DOTlength] = anon_sym_tx_DOToutputs_DOTlength,
   [anon_sym_tx_DOTversion] = anon_sym_tx_DOTversion,
@@ -976,11 +976,11 @@ static const TSSymbolMetadata ts_symbol_metadata[] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_this_DOTscriptSizeDataPrefix] = {
+  [anon_sym_this_DOTbytecodeSizeDataPrefix] = {
     .visible = true,
     .named = false,
   },
-  [anon_sym_this_DOTscriptSize] = {
+  [anon_sym_this_DOTbytecodeSize] = {
     .visible = true,
     .named = false,
   },
@@ -1918,166 +1918,166 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
   eof = lexer->eof(lexer);
   switch (state) {
     case 0:
-      if (eof) ADVANCE(136);
+      if (eof) ADVANCE(138);
       ADVANCE_MAP(
-        '!', 171,
+        '!', 173,
         '"', 5,
         '#', 20,
-        '%', 169,
-        '&', 158,
+        '%', 171,
+        '&', 160,
         '\'', 6,
-        '(', 148,
-        ')', 150,
-        '*', 167,
-        '+', 164,
-        ',', 149,
-        '-', 166,
-        '.', 175,
-        '/', 168,
-        '0', 186,
-        ':', 151,
-        ';', 137,
-        '<', 162,
-        '=', 147,
-        '>', 163,
-        '[', 172,
-        ']', 173,
-        '^', 157,
-        '_', 185,
-        'c', 216,
-        't', 210,
-        '{', 144,
-        '|', 156,
-        '}', 145,
+        '(', 150,
+        ')', 152,
+        '*', 169,
+        '+', 166,
+        ',', 151,
+        '-', 168,
+        '.', 177,
+        '/', 170,
+        '0', 188,
+        ':', 153,
+        ';', 139,
+        '<', 164,
+        '=', 149,
+        '>', 165,
+        '[', 174,
+        ']', 175,
+        '^', 159,
+        '_', 187,
+        'c', 218,
+        't', 212,
+        '{', 146,
+        '|', 158,
+        '}', 147,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(0);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(189);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 1:
       ADVANCE_MAP(
         '!', 12,
         '#', 20,
-        '%', 169,
-        '&', 158,
-        '(', 148,
-        ')', 150,
-        '*', 167,
-        '+', 164,
-        ',', 149,
-        '-', 165,
-        '.', 175,
-        '/', 168,
-        ';', 137,
-        '<', 162,
+        '%', 171,
+        '&', 160,
+        '(', 150,
+        ')', 152,
+        '*', 169,
+        '+', 166,
+        ',', 151,
+        '-', 167,
+        '.', 177,
+        '/', 170,
+        ';', 139,
+        '<', 164,
         '=', 13,
-        '>', 163,
-        '[', 172,
-        ']', 173,
-        '^', 157,
-        '_', 185,
-        '{', 144,
-        '|', 156,
-        '}', 145,
+        '>', 165,
+        '[', 174,
+        ']', 175,
+        '^', 159,
+        '_', 187,
+        '{', 146,
+        '|', 158,
+        '}', 147,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(1);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(188);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(190);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 2:
       ADVANCE_MAP(
-        '!', 170,
+        '!', 172,
         '"', 5,
         '\'', 6,
-        '(', 148,
-        ')', 150,
-        '-', 166,
+        '(', 150,
+        ')', 152,
+        '-', 168,
         '/', 8,
-        '0', 189,
-        't', 211,
-        '}', 145,
+        '0', 191,
+        't', 213,
+        '}', 147,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(2);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(190);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(192);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 3:
       ADVANCE_MAP(
-        '!', 170,
+        '!', 172,
         '"', 5,
         '\'', 6,
-        '(', 148,
-        ',', 149,
-        '-', 166,
-        '.', 174,
+        '(', 150,
+        ',', 151,
+        '-', 168,
+        '.', 176,
         '/', 8,
-        '0', 189,
-        ';', 137,
-        '=', 146,
-        't', 210,
+        '0', 191,
+        ';', 139,
+        '=', 148,
+        't', 212,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(3);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(190);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(192);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 4:
       ADVANCE_MAP(
         '"', 5,
         '\'', 6,
-        '(', 148,
-        ')', 150,
-        '-', 131,
-        '.', 174,
+        '(', 150,
+        ')', 152,
+        '-', 133,
+        '.', 176,
         '/', 8,
-        '0', 189,
-        '=', 146,
-        '[', 172,
-        '{', 144,
+        '0', 191,
+        '=', 148,
+        '[', 174,
+        '{', 146,
       );
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(4);
-      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(190);
+      if (('1' <= lookahead && lookahead <= '9')) ADVANCE(192);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 5:
-      if (lookahead == '"') ADVANCE(192);
-      if (lookahead == '\\') ADVANCE(134);
+      if (lookahead == '"') ADVANCE(194);
+      if (lookahead == '\\') ADVANCE(136);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(5);
       END_STATE();
     case 6:
-      if (lookahead == '\'') ADVANCE(192);
-      if (lookahead == '\\') ADVANCE(135);
+      if (lookahead == '\'') ADVANCE(194);
+      if (lookahead == '\\') ADVANCE(137);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(6);
       END_STATE();
     case 7:
-      if (lookahead == '(') ADVANCE(148);
+      if (lookahead == '(') ADVANCE(150);
       if (lookahead == '/') ADVANCE(8);
-      if (lookahead == 'c') ADVANCE(216);
-      if (lookahead == '{') ADVANCE(144);
-      if (lookahead == '}') ADVANCE(145);
+      if (lookahead == 'c') ADVANCE(218);
+      if (lookahead == '{') ADVANCE(146);
+      if (lookahead == '}') ADVANCE(147);
       if (('\t' <= lookahead && lookahead <= '\r') ||
           lookahead == ' ') SKIP(7);
       if (('A' <= lookahead && lookahead <= 'Z') ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 8:
       if (lookahead == '*') ADVANCE(10);
-      if (lookahead == '/') ADVANCE(223);
+      if (lookahead == '/') ADVANCE(225);
       END_STATE();
     case 9:
       if (lookahead == '*') ADVANCE(9);
-      if (lookahead == '/') ADVANCE(222);
+      if (lookahead == '/') ADVANCE(224);
       if (lookahead != 0) ADVANCE(10);
       END_STATE();
     case 10:
@@ -2085,55 +2085,55 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead != 0) ADVANCE(10);
       END_STATE();
     case 11:
-      if (lookahead == '/') ADVANCE(139);
+      if (lookahead == '/') ADVANCE(141);
       if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(142);
+          lookahead == ' ') ADVANCE(144);
       if (lookahead != 0 &&
-          lookahead != ';') ADVANCE(143);
+          lookahead != ';') ADVANCE(145);
       END_STATE();
     case 12:
-      if (lookahead == '=') ADVANCE(160);
+      if (lookahead == '=') ADVANCE(162);
       END_STATE();
     case 13:
-      if (lookahead == '=') ADVANCE(159);
+      if (lookahead == '=') ADVANCE(161);
       END_STATE();
     case 14:
-      if (lookahead == 'I') ADVANCE(83);
+      if (lookahead == 'I') ADVANCE(86);
       END_STATE();
     case 15:
-      if (lookahead == 'I') ADVANCE(87);
-      if (lookahead == 'S') ADVANCE(32);
+      if (lookahead == 'I') ADVANCE(89);
+      if (lookahead == 'S') ADVANCE(28);
       END_STATE();
     case 16:
-      if (lookahead == 'K') ADVANCE(46);
+      if (lookahead == 'K') ADVANCE(49);
       END_STATE();
     case 17:
-      if (lookahead == 'P') ADVANCE(120);
+      if (lookahead == 'P') ADVANCE(121);
       END_STATE();
     case 18:
-      if (lookahead == 'P') ADVANCE(101);
+      if (lookahead == 'P') ADVANCE(103);
       END_STATE();
     case 19:
-      if (lookahead == 'S') ADVANCE(62);
+      if (lookahead == 'S') ADVANCE(65);
       END_STATE();
     case 20:
-      if (lookahead == '[') ADVANCE(133);
+      if (lookahead == '[') ADVANCE(135);
       END_STATE();
     case 21:
-      if (lookahead == ']') ADVANCE(184);
+      if (lookahead == ']') ADVANCE(186);
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(21);
       END_STATE();
     case 22:
-      if (lookahead == 'a') ADVANCE(31);
-      if (lookahead == 's') ADVANCE(28);
+      if (lookahead == 'a') ADVANCE(32);
+      if (lookahead == 'b') ADVANCE(131);
       END_STATE();
     case 23:
       if (lookahead == 'a') ADVANCE(18);
       END_STATE();
     case 24:
-      if (lookahead == 'a') ADVANCE(30);
-      if (lookahead == 's') ADVANCE(28);
+      if (lookahead == 'a') ADVANCE(31);
+      if (lookahead == 'b') ADVANCE(131);
       END_STATE();
     case 25:
       if (lookahead == 'a') ADVANCE(113);
@@ -2142,262 +2142,262 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 'b') ADVANCE(16);
       END_STATE();
     case 27:
-      if (lookahead == 'c') ADVANCE(72);
+      if (lookahead == 'c') ADVANCE(74);
       END_STATE();
     case 28:
-      if (lookahead == 'c') ADVANCE(100);
+      if (lookahead == 'c') ADVANCE(102);
       END_STATE();
     case 29:
-      if (lookahead == 'c') ADVANCE(38);
+      if (lookahead == 'c') ADVANCE(39);
       END_STATE();
     case 30:
-      if (lookahead == 'c') ADVANCE(117);
+      if (lookahead == 'c') ADVANCE(92);
       END_STATE();
     case 31:
       if (lookahead == 'c') ADVANCE(117);
-      if (lookahead == 'g') ADVANCE(41);
       END_STATE();
     case 32:
-      if (lookahead == 'c') ADVANCE(102);
+      if (lookahead == 'c') ADVANCE(117);
+      if (lookahead == 'g') ADVANCE(42);
       END_STATE();
     case 33:
-      if (lookahead == 'd') ADVANCE(180);
+      if (lookahead == 'd') ADVANCE(182);
       END_STATE();
     case 34:
       if (lookahead == 'd') ADVANCE(45);
       END_STATE();
     case 35:
-      if (lookahead == 'e') ADVANCE(80);
+      if (lookahead == 'd') ADVANCE(47);
       END_STATE();
     case 36:
-      if (lookahead == 'e') ADVANCE(125);
+      if (lookahead == 'e') ADVANCE(82);
       END_STATE();
     case 37:
-      if (lookahead == 'e') ADVANCE(98);
+      if (lookahead == 'e') ADVANCE(126);
       END_STATE();
     case 38:
-      if (lookahead == 'e') ADVANCE(179);
+      if (lookahead == 'e') ADVANCE(100);
       END_STATE();
     case 39:
-      if (lookahead == 'e') ADVANCE(195);
-      END_STATE();
-    case 40:
       if (lookahead == 'e') ADVANCE(181);
       END_STATE();
+    case 40:
+      if (lookahead == 'e') ADVANCE(197);
+      END_STATE();
     case 41:
-      if (lookahead == 'e') ADVANCE(194);
+      if (lookahead == 'e') ADVANCE(183);
       END_STATE();
     case 42:
-      if (lookahead == 'e') ADVANCE(15);
+      if (lookahead == 'e') ADVANCE(196);
       END_STATE();
     case 43:
-      if (lookahead == 'e') ADVANCE(203);
+      if (lookahead == 'e') ADVANCE(15);
       END_STATE();
     case 44:
-      if (lookahead == 'e') ADVANCE(199);
+      if (lookahead == 'e') ADVANCE(205);
       END_STATE();
     case 45:
-      if (lookahead == 'e') ADVANCE(127);
+      if (lookahead == 'e') ADVANCE(19);
       END_STATE();
     case 46:
-      if (lookahead == 'e') ADVANCE(129);
+      if (lookahead == 'e') ADVANCE(201);
       END_STATE();
     case 47:
-      if (lookahead == 'e') ADVANCE(52);
+      if (lookahead == 'e') ADVANCE(128);
       END_STATE();
     case 48:
-      if (lookahead == 'e') ADVANCE(81);
+      if (lookahead == 'e') ADVANCE(55);
       END_STATE();
     case 49:
-      if (lookahead == 'e') ADVANCE(99);
+      if (lookahead == 'e') ADVANCE(130);
       END_STATE();
     case 50:
-      if (lookahead == 'e') ADVANCE(85);
+      if (lookahead == 'e') ADVANCE(83);
       END_STATE();
     case 51:
-      if (lookahead == 'e') ADVANCE(86);
+      if (lookahead == 'e') ADVANCE(30);
       END_STATE();
     case 52:
-      if (lookahead == 'f') ADVANCE(67);
+      if (lookahead == 'e') ADVANCE(101);
       END_STATE();
     case 53:
-      if (lookahead == 'g') ADVANCE(107);
+      if (lookahead == 'e') ADVANCE(87);
       END_STATE();
     case 54:
-      if (lookahead == 'g') ADVANCE(153);
+      if (lookahead == 'e') ADVANCE(88);
       END_STATE();
     case 55:
-      if (lookahead == 'g') ADVANCE(112);
+      if (lookahead == 'f') ADVANCE(70);
       END_STATE();
     case 56:
-      if (lookahead == 'g') ADVANCE(114);
+      if (lookahead == 'g') ADVANCE(108);
       END_STATE();
     case 57:
-      if (lookahead == 'h') ADVANCE(177);
+      if (lookahead == 'g') ADVANCE(155);
       END_STATE();
     case 58:
-      if (lookahead == 'h') ADVANCE(200);
+      if (lookahead == 'g') ADVANCE(112);
       END_STATE();
     case 59:
-      if (lookahead == 'h') ADVANCE(201);
+      if (lookahead == 'g') ADVANCE(114);
       END_STATE();
     case 60:
-      if (lookahead == 'i') ADVANCE(29);
+      if (lookahead == 'h') ADVANCE(179);
       END_STATE();
     case 61:
-      if (lookahead == 'i') ADVANCE(78);
+      if (lookahead == 'h') ADVANCE(202);
       END_STATE();
     case 62:
-      if (lookahead == 'i') ADVANCE(130);
+      if (lookahead == 'h') ADVANCE(203);
       END_STATE();
     case 63:
-      if (lookahead == 'i') ADVANCE(84);
-      if (lookahead == 'l') ADVANCE(89);
-      if (lookahead == 'o') ADVANCE(121);
-      if (lookahead == 't') ADVANCE(61);
-      if (lookahead == 'v') ADVANCE(49);
+      if (lookahead == 'i') ADVANCE(29);
       END_STATE();
     case 64:
-      if (lookahead == 'i') ADVANCE(84);
-      if (lookahead == 'l') ADVANCE(89);
-      if (lookahead == 'o') ADVANCE(121);
-      if (lookahead == 'v') ADVANCE(49);
+      if (lookahead == 'i') ADVANCE(80);
       END_STATE();
     case 65:
-      if (lookahead == 'i') ADVANCE(90);
+      if (lookahead == 'i') ADVANCE(132);
       END_STATE();
     case 66:
-      if (lookahead == 'i') ADVANCE(108);
+      if (lookahead == 'i') ADVANCE(85);
+      if (lookahead == 'l') ADVANCE(91);
+      if (lookahead == 'o') ADVANCE(122);
+      if (lookahead == 't') ADVANCE(64);
+      if (lookahead == 'v') ADVANCE(52);
       END_STATE();
     case 67:
-      if (lookahead == 'i') ADVANCE(128);
+      if (lookahead == 'i') ADVANCE(85);
+      if (lookahead == 'l') ADVANCE(91);
+      if (lookahead == 'o') ADVANCE(122);
+      if (lookahead == 'v') ADVANCE(52);
       END_STATE();
     case 68:
-      if (lookahead == 'i') ADVANCE(92);
-      END_STATE();
-    case 69:
-      if (lookahead == 'i') ADVANCE(126);
-      END_STATE();
-    case 70:
-      if (lookahead == 'i') ADVANCE(79);
-      END_STATE();
-    case 71:
       if (lookahead == 'i') ADVANCE(93);
       END_STATE();
+    case 69:
+      if (lookahead == 'i') ADVANCE(109);
+      END_STATE();
+    case 70:
+      if (lookahead == 'i') ADVANCE(129);
+      END_STATE();
+    case 71:
+      if (lookahead == 'i') ADVANCE(95);
+      END_STATE();
     case 72:
-      if (lookahead == 'k') ADVANCE(118);
+      if (lookahead == 'i') ADVANCE(127);
       END_STATE();
     case 73:
-      if (lookahead == 'l') ADVANCE(60);
-      if (lookahead == 'p') ADVANCE(74);
+      if (lookahead == 'i') ADVANCE(81);
       END_STATE();
     case 74:
-      if (lookahead == 'l') ADVANCE(66);
+      if (lookahead == 'k') ADVANCE(119);
       END_STATE();
     case 75:
-      if (lookahead == 'l') ADVANCE(88);
+      if (lookahead == 'l') ADVANCE(63);
+      if (lookahead == 'p') ADVANCE(76);
       END_STATE();
     case 76:
-      if (lookahead == 'l') ADVANCE(50);
+      if (lookahead == 'l') ADVANCE(69);
       END_STATE();
     case 77:
-      if (lookahead == 'l') ADVANCE(51);
+      if (lookahead == 'l') ADVANCE(90);
       END_STATE();
     case 78:
-      if (lookahead == 'm') ADVANCE(39);
+      if (lookahead == 'l') ADVANCE(53);
       END_STATE();
     case 79:
-      if (lookahead == 'm') ADVANCE(43);
+      if (lookahead == 'l') ADVANCE(54);
       END_STATE();
     case 80:
-      if (lookahead == 'n') ADVANCE(53);
+      if (lookahead == 'm') ADVANCE(40);
       END_STATE();
     case 81:
-      if (lookahead == 'n') ADVANCE(33);
+      if (lookahead == 'm') ADVANCE(44);
       END_STATE();
     case 82:
-      if (lookahead == 'n') ADVANCE(202);
-      END_STATE();
-    case 83:
-      if (lookahead == 'n') ADVANCE(34);
-      END_STATE();
-    case 84:
-      if (lookahead == 'n') ADVANCE(95);
-      END_STATE();
-    case 85:
-      if (lookahead == 'n') ADVANCE(55);
-      END_STATE();
-    case 86:
       if (lookahead == 'n') ADVANCE(56);
       END_STATE();
-    case 87:
+    case 83:
+      if (lookahead == 'n') ADVANCE(33);
+      END_STATE();
+    case 84:
+      if (lookahead == 'n') ADVANCE(204);
+      END_STATE();
+    case 85:
       if (lookahead == 'n') ADVANCE(97);
       END_STATE();
+    case 86:
+      if (lookahead == 'n') ADVANCE(35);
+      END_STATE();
+    case 87:
+      if (lookahead == 'n') ADVANCE(58);
+      END_STATE();
     case 88:
-      if (lookahead == 'o') ADVANCE(54);
+      if (lookahead == 'n') ADVANCE(59);
       END_STATE();
     case 89:
-      if (lookahead == 'o') ADVANCE(27);
+      if (lookahead == 'n') ADVANCE(99);
       END_STATE();
     case 90:
-      if (lookahead == 'o') ADVANCE(82);
+      if (lookahead == 'o') ADVANCE(57);
       END_STATE();
     case 91:
-      if (lookahead == 'p') ADVANCE(94);
+      if (lookahead == 'o') ADVANCE(27);
       END_STATE();
     case 92:
-      if (lookahead == 'p') ADVANCE(109);
+      if (lookahead == 'o') ADVANCE(34);
       END_STATE();
     case 93:
-      if (lookahead == 'p') ADVANCE(111);
+      if (lookahead == 'o') ADVANCE(84);
       END_STATE();
     case 94:
-      if (lookahead == 'p') ADVANCE(48);
+      if (lookahead == 'p') ADVANCE(96);
       END_STATE();
     case 95:
-      if (lookahead == 'p') ADVANCE(122);
+      if (lookahead == 'p') ADVANCE(111);
       END_STATE();
     case 96:
-      if (lookahead == 'p') ADVANCE(123);
+      if (lookahead == 'p') ADVANCE(50);
       END_STATE();
     case 97:
-      if (lookahead == 'p') ADVANCE(124);
+      if (lookahead == 'p') ADVANCE(123);
       END_STATE();
     case 98:
-      if (lookahead == 'r') ADVANCE(106);
+      if (lookahead == 'p') ADVANCE(124);
       END_STATE();
     case 99:
-      if (lookahead == 'r') ADVANCE(105);
+      if (lookahead == 'p') ADVANCE(125);
       END_STATE();
     case 100:
-      if (lookahead == 'r') ADVANCE(68);
+      if (lookahead == 'r') ADVANCE(107);
       END_STATE();
     case 101:
-      if (lookahead == 'r') ADVANCE(47);
+      if (lookahead == 'r') ADVANCE(106);
       END_STATE();
     case 102:
       if (lookahead == 'r') ADVANCE(71);
       END_STATE();
     case 103:
-      if (lookahead == 's') ADVANCE(183);
+      if (lookahead == 'r') ADVANCE(48);
       END_STATE();
     case 104:
-      if (lookahead == 's') ADVANCE(182);
+      if (lookahead == 's') ADVANCE(185);
       END_STATE();
     case 105:
-      if (lookahead == 's') ADVANCE(65);
+      if (lookahead == 's') ADVANCE(184);
       END_STATE();
     case 106:
-      if (lookahead == 's') ADVANCE(40);
+      if (lookahead == 's') ADVANCE(68);
       END_STATE();
     case 107:
-      if (lookahead == 't') ADVANCE(57);
+      if (lookahead == 's') ADVANCE(41);
       END_STATE();
     case 108:
-      if (lookahead == 't') ADVANCE(178);
+      if (lookahead == 't') ADVANCE(60);
       END_STATE();
     case 109:
-      if (lookahead == 't') ADVANCE(19);
+      if (lookahead == 't') ADVANCE(180);
       END_STATE();
     case 110:
       if (lookahead == 't') ADVANCE(14);
@@ -2406,502 +2406,508 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       if (lookahead == 't') ADVANCE(17);
       END_STATE();
     case 112:
-      if (lookahead == 't') ADVANCE(58);
+      if (lookahead == 't') ADVANCE(61);
       END_STATE();
     case 113:
       if (lookahead == 't') ADVANCE(23);
       END_STATE();
     case 114:
-      if (lookahead == 't') ADVANCE(59);
+      if (lookahead == 't') ADVANCE(62);
       END_STATE();
     case 115:
-      if (lookahead == 't') ADVANCE(103);
-      END_STATE();
-    case 116:
       if (lookahead == 't') ADVANCE(104);
       END_STATE();
+    case 116:
+      if (lookahead == 't') ADVANCE(105);
+      END_STATE();
     case 117:
-      if (lookahead == 't') ADVANCE(69);
+      if (lookahead == 't') ADVANCE(72);
       END_STATE();
     case 118:
-      if (lookahead == 't') ADVANCE(70);
+      if (lookahead == 't') ADVANCE(51);
       END_STATE();
     case 119:
-      if (lookahead == 't') ADVANCE(96);
+      if (lookahead == 't') ADVANCE(73);
       END_STATE();
     case 120:
-      if (lookahead == 'u') ADVANCE(26);
+      if (lookahead == 't') ADVANCE(98);
       END_STATE();
     case 121:
-      if (lookahead == 'u') ADVANCE(119);
+      if (lookahead == 'u') ADVANCE(26);
       END_STATE();
     case 122:
-      if (lookahead == 'u') ADVANCE(115);
+      if (lookahead == 'u') ADVANCE(120);
       END_STATE();
     case 123:
-      if (lookahead == 'u') ADVANCE(116);
+      if (lookahead == 'u') ADVANCE(115);
       END_STATE();
     case 124:
-      if (lookahead == 'u') ADVANCE(110);
+      if (lookahead == 'u') ADVANCE(116);
       END_STATE();
     case 125:
-      if (lookahead == 'v') ADVANCE(37);
+      if (lookahead == 'u') ADVANCE(110);
       END_STATE();
     case 126:
-      if (lookahead == 'v') ADVANCE(42);
+      if (lookahead == 'v') ADVANCE(38);
       END_STATE();
     case 127:
-      if (lookahead == 'x') ADVANCE(196);
+      if (lookahead == 'v') ADVANCE(43);
       END_STATE();
     case 128:
       if (lookahead == 'x') ADVANCE(198);
       END_STATE();
     case 129:
-      if (lookahead == 'y') ADVANCE(197);
+      if (lookahead == 'x') ADVANCE(200);
       END_STATE();
     case 130:
-      if (lookahead == 'z') ADVANCE(44);
+      if (lookahead == 'y') ADVANCE(199);
       END_STATE();
     case 131:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(190);
+      if (lookahead == 'y') ADVANCE(118);
       END_STATE();
     case 132:
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(191);
+      if (lookahead == 'z') ADVANCE(46);
       END_STATE();
     case 133:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(192);
+      END_STATE();
+    case 134:
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(193);
+      END_STATE();
+    case 135:
       if (lookahead != 0 &&
           lookahead != '\n' &&
           lookahead != ']') ADVANCE(21);
       END_STATE();
-    case 134:
+    case 136:
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(5);
       END_STATE();
-    case 135:
+    case 137:
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(6);
       END_STATE();
-    case 136:
+    case 138:
       ACCEPT_TOKEN(ts_builtin_sym_end);
       END_STATE();
-    case 137:
-      ACCEPT_TOKEN(anon_sym_SEMI);
-      END_STATE();
-    case 138:
-      ACCEPT_TOKEN(sym_pragma_value);
-      if (lookahead == '\n') ADVANCE(143);
-      if (lookahead == ';') ADVANCE(223);
-      if (lookahead != 0) ADVANCE(138);
-      END_STATE();
     case 139:
-      ACCEPT_TOKEN(sym_pragma_value);
-      if (lookahead == '*') ADVANCE(141);
-      if (lookahead == '/') ADVANCE(138);
-      if (lookahead != 0 &&
-          lookahead != ';') ADVANCE(143);
+      ACCEPT_TOKEN(anon_sym_SEMI);
       END_STATE();
     case 140:
       ACCEPT_TOKEN(sym_pragma_value);
-      if (lookahead == '*') ADVANCE(140);
-      if (lookahead == '/') ADVANCE(143);
-      if (lookahead == ';') ADVANCE(10);
-      if (lookahead != 0) ADVANCE(141);
+      if (lookahead == '\n') ADVANCE(145);
+      if (lookahead == ';') ADVANCE(225);
+      if (lookahead != 0) ADVANCE(140);
       END_STATE();
     case 141:
       ACCEPT_TOKEN(sym_pragma_value);
-      if (lookahead == '*') ADVANCE(140);
-      if (lookahead == ';') ADVANCE(10);
-      if (lookahead != 0) ADVANCE(141);
+      if (lookahead == '*') ADVANCE(143);
+      if (lookahead == '/') ADVANCE(140);
+      if (lookahead != 0 &&
+          lookahead != ';') ADVANCE(145);
       END_STATE();
     case 142:
       ACCEPT_TOKEN(sym_pragma_value);
-      if (lookahead == '/') ADVANCE(139);
-      if (('\t' <= lookahead && lookahead <= '\r') ||
-          lookahead == ' ') ADVANCE(142);
-      if (lookahead != 0 &&
-          lookahead != ';') ADVANCE(143);
+      if (lookahead == '*') ADVANCE(142);
+      if (lookahead == '/') ADVANCE(145);
+      if (lookahead == ';') ADVANCE(10);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
     case 143:
       ACCEPT_TOKEN(sym_pragma_value);
-      if (lookahead != 0 &&
-          lookahead != ';') ADVANCE(143);
+      if (lookahead == '*') ADVANCE(142);
+      if (lookahead == ';') ADVANCE(10);
+      if (lookahead != 0) ADVANCE(143);
       END_STATE();
     case 144:
-      ACCEPT_TOKEN(anon_sym_LBRACE);
+      ACCEPT_TOKEN(sym_pragma_value);
+      if (lookahead == '/') ADVANCE(141);
+      if (('\t' <= lookahead && lookahead <= '\r') ||
+          lookahead == ' ') ADVANCE(144);
+      if (lookahead != 0 &&
+          lookahead != ';') ADVANCE(145);
       END_STATE();
     case 145:
-      ACCEPT_TOKEN(anon_sym_RBRACE);
+      ACCEPT_TOKEN(sym_pragma_value);
+      if (lookahead != 0 &&
+          lookahead != ';') ADVANCE(145);
       END_STATE();
     case 146:
-      ACCEPT_TOKEN(anon_sym_EQ);
+      ACCEPT_TOKEN(anon_sym_LBRACE);
       END_STATE();
     case 147:
-      ACCEPT_TOKEN(anon_sym_EQ);
-      if (lookahead == '=') ADVANCE(159);
+      ACCEPT_TOKEN(anon_sym_RBRACE);
       END_STATE();
     case 148:
-      ACCEPT_TOKEN(anon_sym_LPAREN);
+      ACCEPT_TOKEN(anon_sym_EQ);
       END_STATE();
     case 149:
-      ACCEPT_TOKEN(anon_sym_COMMA);
-      END_STATE();
-    case 150:
-      ACCEPT_TOKEN(anon_sym_RPAREN);
-      END_STATE();
-    case 151:
-      ACCEPT_TOKEN(anon_sym_COLON);
-      END_STATE();
-    case 152:
-      ACCEPT_TOKEN(anon_sym_GT_EQ);
-      END_STATE();
-    case 153:
-      ACCEPT_TOKEN(anon_sym_console_DOTlog);
-      END_STATE();
-    case 154:
-      ACCEPT_TOKEN(anon_sym_PIPE_PIPE);
-      END_STATE();
-    case 155:
-      ACCEPT_TOKEN(anon_sym_AMP_AMP);
-      END_STATE();
-    case 156:
-      ACCEPT_TOKEN(anon_sym_PIPE);
-      if (lookahead == '|') ADVANCE(154);
-      END_STATE();
-    case 157:
-      ACCEPT_TOKEN(anon_sym_CARET);
-      END_STATE();
-    case 158:
-      ACCEPT_TOKEN(anon_sym_AMP);
-      if (lookahead == '&') ADVANCE(155);
-      END_STATE();
-    case 159:
-      ACCEPT_TOKEN(anon_sym_EQ_EQ);
-      END_STATE();
-    case 160:
-      ACCEPT_TOKEN(anon_sym_BANG_EQ);
-      END_STATE();
-    case 161:
-      ACCEPT_TOKEN(anon_sym_LT_EQ);
-      END_STATE();
-    case 162:
-      ACCEPT_TOKEN(anon_sym_LT);
+      ACCEPT_TOKEN(anon_sym_EQ);
       if (lookahead == '=') ADVANCE(161);
       END_STATE();
+    case 150:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      END_STATE();
+    case 151:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      END_STATE();
+    case 152:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      END_STATE();
+    case 153:
+      ACCEPT_TOKEN(anon_sym_COLON);
+      END_STATE();
+    case 154:
+      ACCEPT_TOKEN(anon_sym_GT_EQ);
+      END_STATE();
+    case 155:
+      ACCEPT_TOKEN(anon_sym_console_DOTlog);
+      END_STATE();
+    case 156:
+      ACCEPT_TOKEN(anon_sym_PIPE_PIPE);
+      END_STATE();
+    case 157:
+      ACCEPT_TOKEN(anon_sym_AMP_AMP);
+      END_STATE();
+    case 158:
+      ACCEPT_TOKEN(anon_sym_PIPE);
+      if (lookahead == '|') ADVANCE(156);
+      END_STATE();
+    case 159:
+      ACCEPT_TOKEN(anon_sym_CARET);
+      END_STATE();
+    case 160:
+      ACCEPT_TOKEN(anon_sym_AMP);
+      if (lookahead == '&') ADVANCE(157);
+      END_STATE();
+    case 161:
+      ACCEPT_TOKEN(anon_sym_EQ_EQ);
+      END_STATE();
+    case 162:
+      ACCEPT_TOKEN(anon_sym_BANG_EQ);
+      END_STATE();
     case 163:
-      ACCEPT_TOKEN(anon_sym_GT);
-      if (lookahead == '=') ADVANCE(152);
+      ACCEPT_TOKEN(anon_sym_LT_EQ);
       END_STATE();
     case 164:
-      ACCEPT_TOKEN(anon_sym_PLUS);
+      ACCEPT_TOKEN(anon_sym_LT);
+      if (lookahead == '=') ADVANCE(163);
       END_STATE();
     case 165:
-      ACCEPT_TOKEN(anon_sym_DASH);
+      ACCEPT_TOKEN(anon_sym_GT);
+      if (lookahead == '=') ADVANCE(154);
       END_STATE();
     case 166:
-      ACCEPT_TOKEN(anon_sym_DASH);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(190);
+      ACCEPT_TOKEN(anon_sym_PLUS);
       END_STATE();
     case 167:
-      ACCEPT_TOKEN(anon_sym_STAR);
+      ACCEPT_TOKEN(anon_sym_DASH);
       END_STATE();
     case 168:
-      ACCEPT_TOKEN(anon_sym_SLASH);
-      if (lookahead == '*') ADVANCE(10);
-      if (lookahead == '/') ADVANCE(223);
+      ACCEPT_TOKEN(anon_sym_DASH);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(192);
       END_STATE();
     case 169:
-      ACCEPT_TOKEN(anon_sym_PERCENT);
+      ACCEPT_TOKEN(anon_sym_STAR);
       END_STATE();
     case 170:
-      ACCEPT_TOKEN(anon_sym_BANG);
+      ACCEPT_TOKEN(anon_sym_SLASH);
+      if (lookahead == '*') ADVANCE(10);
+      if (lookahead == '/') ADVANCE(225);
       END_STATE();
     case 171:
-      ACCEPT_TOKEN(anon_sym_BANG);
-      if (lookahead == '=') ADVANCE(160);
+      ACCEPT_TOKEN(anon_sym_PERCENT);
       END_STATE();
     case 172:
-      ACCEPT_TOKEN(anon_sym_LBRACK);
+      ACCEPT_TOKEN(anon_sym_BANG);
       END_STATE();
     case 173:
-      ACCEPT_TOKEN(anon_sym_RBRACK);
+      ACCEPT_TOKEN(anon_sym_BANG);
+      if (lookahead == '=') ADVANCE(162);
       END_STATE();
     case 174:
-      ACCEPT_TOKEN(anon_sym_DOT);
+      ACCEPT_TOKEN(anon_sym_LBRACK);
       END_STATE();
     case 175:
-      ACCEPT_TOKEN(anon_sym_DOT);
-      if (lookahead == 'a') ADVANCE(91);
-      if (lookahead == 'l') ADVANCE(35);
-      if (lookahead == 'r') ADVANCE(36);
-      if (lookahead == 's') ADVANCE(73);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(176);
+      ACCEPT_TOKEN(anon_sym_RBRACK);
       END_STATE();
     case 176:
-      ACCEPT_TOKEN(sym_tuple_field_access);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(176);
+      ACCEPT_TOKEN(anon_sym_DOT);
       END_STATE();
     case 177:
-      ACCEPT_TOKEN(sym_unary_suffix);
+      ACCEPT_TOKEN(anon_sym_DOT);
+      if (lookahead == 'a') ADVANCE(94);
+      if (lookahead == 'l') ADVANCE(36);
+      if (lookahead == 'r') ADVANCE(37);
+      if (lookahead == 's') ADVANCE(75);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(178);
       END_STATE();
     case 178:
-      ACCEPT_TOKEN(anon_sym_DOTsplit);
+      ACCEPT_TOKEN(sym_tuple_field_access);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(178);
       END_STATE();
     case 179:
-      ACCEPT_TOKEN(anon_sym_DOTslice);
+      ACCEPT_TOKEN(sym_unary_suffix);
       END_STATE();
     case 180:
-      ACCEPT_TOKEN(anon_sym_DOTappend);
+      ACCEPT_TOKEN(anon_sym_DOTsplit);
       END_STATE();
     case 181:
-      ACCEPT_TOKEN(anon_sym_DOTreverse);
+      ACCEPT_TOKEN(anon_sym_DOTslice);
       END_STATE();
     case 182:
-      ACCEPT_TOKEN(sym_output_root);
-      if (lookahead == '.') ADVANCE(77);
+      ACCEPT_TOKEN(anon_sym_DOTappend);
       END_STATE();
     case 183:
-      ACCEPT_TOKEN(sym_input_root);
-      if (lookahead == '.') ADVANCE(76);
+      ACCEPT_TOKEN(anon_sym_DOTreverse);
       END_STATE();
     case 184:
-      ACCEPT_TOKEN(sym_attribute);
+      ACCEPT_TOKEN(sym_output_root);
+      if (lookahead == '.') ADVANCE(79);
       END_STATE();
     case 185:
-      ACCEPT_TOKEN(anon_sym__);
+      ACCEPT_TOKEN(sym_input_root);
+      if (lookahead == '.') ADVANCE(78);
       END_STATE();
     case 186:
-      ACCEPT_TOKEN(sym_array_bound);
-      if (lookahead == '_') ADVANCE(131);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(132);
-      if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(193);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      ACCEPT_TOKEN(sym_attribute);
       END_STATE();
     case 187:
-      ACCEPT_TOKEN(sym_array_bound);
-      if (lookahead == '_') ADVANCE(131);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(132);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(187);
+      ACCEPT_TOKEN(anon_sym__);
       END_STATE();
     case 188:
       ACCEPT_TOKEN(sym_array_bound);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(188);
+      if (lookahead == '_') ADVANCE(133);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(134);
+      if (lookahead == 'X' ||
+          lookahead == 'x') ADVANCE(195);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(189);
       END_STATE();
     case 189:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == '_') ADVANCE(131);
+      ACCEPT_TOKEN(sym_array_bound);
+      if (lookahead == '_') ADVANCE(133);
       if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(132);
-      if (lookahead == 'X' ||
-          lookahead == 'x') ADVANCE(193);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(190);
+          lookahead == 'e') ADVANCE(134);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(189);
       END_STATE();
     case 190:
-      ACCEPT_TOKEN(sym_number);
-      if (lookahead == '_') ADVANCE(131);
-      if (lookahead == 'E' ||
-          lookahead == 'e') ADVANCE(132);
+      ACCEPT_TOKEN(sym_array_bound);
       if (('0' <= lookahead && lookahead <= '9')) ADVANCE(190);
       END_STATE();
     case 191:
       ACCEPT_TOKEN(sym_number);
-      if (lookahead == '_') ADVANCE(132);
-      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(191);
+      if (lookahead == '_') ADVANCE(133);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(134);
+      if (lookahead == 'X' ||
+          lookahead == 'x') ADVANCE(195);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(192);
       END_STATE();
     case 192:
-      ACCEPT_TOKEN(sym_string_literal);
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '_') ADVANCE(133);
+      if (lookahead == 'E' ||
+          lookahead == 'e') ADVANCE(134);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(192);
       END_STATE();
     case 193:
+      ACCEPT_TOKEN(sym_number);
+      if (lookahead == '_') ADVANCE(134);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(193);
+      END_STATE();
+    case 194:
+      ACCEPT_TOKEN(sym_string_literal);
+      END_STATE();
+    case 195:
       ACCEPT_TOKEN(sym_hex_literal);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'F') ||
-          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(193);
-      END_STATE();
-    case 194:
-      ACCEPT_TOKEN(anon_sym_this_DOTage);
-      END_STATE();
-    case 195:
-      ACCEPT_TOKEN(anon_sym_tx_DOTtime);
+          ('a' <= lookahead && lookahead <= 'f')) ADVANCE(195);
       END_STATE();
     case 196:
-      ACCEPT_TOKEN(anon_sym_this_DOTactiveInputIndex);
+      ACCEPT_TOKEN(anon_sym_this_DOTage);
       END_STATE();
     case 197:
-      ACCEPT_TOKEN(anon_sym_this_DOTactiveScriptPubKey);
+      ACCEPT_TOKEN(anon_sym_tx_DOTtime);
       END_STATE();
     case 198:
-      ACCEPT_TOKEN(anon_sym_this_DOTscriptSizeDataPrefix);
+      ACCEPT_TOKEN(anon_sym_this_DOTactiveInputIndex);
       END_STATE();
     case 199:
-      ACCEPT_TOKEN(anon_sym_this_DOTscriptSize);
-      if (lookahead == 'D') ADVANCE(25);
+      ACCEPT_TOKEN(anon_sym_this_DOTactiveScriptPubKey);
       END_STATE();
     case 200:
-      ACCEPT_TOKEN(anon_sym_tx_DOTinputs_DOTlength);
+      ACCEPT_TOKEN(anon_sym_this_DOTbytecodeSizeDataPrefix);
       END_STATE();
     case 201:
-      ACCEPT_TOKEN(anon_sym_tx_DOToutputs_DOTlength);
+      ACCEPT_TOKEN(anon_sym_this_DOTbytecodeSize);
+      if (lookahead == 'D') ADVANCE(25);
       END_STATE();
     case 202:
-      ACCEPT_TOKEN(anon_sym_tx_DOTversion);
+      ACCEPT_TOKEN(anon_sym_tx_DOTinputs_DOTlength);
       END_STATE();
     case 203:
-      ACCEPT_TOKEN(anon_sym_tx_DOTlocktime);
+      ACCEPT_TOKEN(anon_sym_tx_DOToutputs_DOTlength);
       END_STATE();
     case 204:
+      ACCEPT_TOKEN(anon_sym_tx_DOTversion);
+      END_STATE();
+    case 205:
+      ACCEPT_TOKEN(anon_sym_tx_DOTlocktime);
+      END_STATE();
+    case 206:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '.') ADVANCE(63);
+      if (lookahead == '.') ADVANCE(66);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
-    case 205:
+    case 207:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == '.') ADVANCE(22);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
-      END_STATE();
-    case 206:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '.') ADVANCE(64);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
-      END_STATE();
-    case 207:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == '.') ADVANCE(75);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 208:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '.') ADVANCE(67);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
+      END_STATE();
+    case 209:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == '.') ADVANCE(77);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
+      END_STATE();
+    case 210:
       ACCEPT_TOKEN(sym_identifier);
       if (lookahead == '.') ADVANCE(24);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
-      END_STATE();
-    case 209:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'e') ADVANCE(207);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
-      END_STATE();
-    case 210:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'h') ADVANCE(212);
-      if (lookahead == 'x') ADVANCE(204);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 211:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'h') ADVANCE(213);
+      if (lookahead == 'e') ADVANCE(209);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
+      END_STATE();
+    case 212:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 'h') ADVANCE(214);
       if (lookahead == 'x') ADVANCE(206);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
-      END_STATE();
-    case 212:
-      ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(219);
-      if (('0' <= lookahead && lookahead <= '9') ||
-          ('A' <= lookahead && lookahead <= 'Z') ||
-          lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 213:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'i') ADVANCE(220);
+      if (lookahead == 'h') ADVANCE(215);
+      if (lookahead == 'x') ADVANCE(208);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 214:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'l') ADVANCE(209);
+      if (lookahead == 'i') ADVANCE(221);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 215:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'n') ADVANCE(218);
+      if (lookahead == 'i') ADVANCE(222);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 216:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(215);
+      if (lookahead == 'l') ADVANCE(211);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 217:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 'o') ADVANCE(214);
+      if (lookahead == 'n') ADVANCE(220);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 218:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(217);
+      if (lookahead == 'o') ADVANCE(217);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 219:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(205);
+      if (lookahead == 'o') ADVANCE(216);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 220:
       ACCEPT_TOKEN(sym_identifier);
-      if (lookahead == 's') ADVANCE(208);
+      if (lookahead == 's') ADVANCE(219);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
     case 221:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(207);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
+      END_STATE();
+    case 222:
+      ACCEPT_TOKEN(sym_identifier);
+      if (lookahead == 's') ADVANCE(210);
+      if (('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
+      END_STATE();
+    case 223:
       ACCEPT_TOKEN(sym_identifier);
       if (('0' <= lookahead && lookahead <= '9') ||
           ('A' <= lookahead && lookahead <= 'Z') ||
           lookahead == '_' ||
-          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(221);
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(223);
       END_STATE();
-    case 222:
+    case 224:
       ACCEPT_TOKEN(sym_comment);
       END_STATE();
-    case 223:
+    case 225:
       ACCEPT_TOKEN(sym_comment);
       if (lookahead != 0 &&
-          lookahead != '\n') ADVANCE(223);
+          lookahead != '\n') ADVANCE(225);
       END_STATE();
     default:
       return false;
@@ -4065,8 +4071,8 @@ static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
     [anon_sym_tx_DOTtime] = ACTIONS(1),
     [anon_sym_this_DOTactiveInputIndex] = ACTIONS(1),
     [anon_sym_this_DOTactiveScriptPubKey] = ACTIONS(1),
-    [anon_sym_this_DOTscriptSizeDataPrefix] = ACTIONS(1),
-    [anon_sym_this_DOTscriptSize] = ACTIONS(1),
+    [anon_sym_this_DOTbytecodeSizeDataPrefix] = ACTIONS(1),
+    [anon_sym_this_DOTbytecodeSize] = ACTIONS(1),
     [anon_sym_tx_DOTinputs_DOTlength] = ACTIONS(1),
     [anon_sym_tx_DOToutputs_DOTlength] = ACTIONS(1),
     [anon_sym_tx_DOTversion] = ACTIONS(1),
@@ -4106,7 +4112,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -4168,7 +4174,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -4205,7 +4211,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     ACTIONS(39), 1,
       anon_sym_RPAREN,
     STATE(47), 1,
@@ -4264,7 +4270,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -4299,7 +4305,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     ACTIONS(41), 1,
       anon_sym_LPAREN,
     STATE(47), 1,
@@ -4359,7 +4365,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -4396,7 +4402,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     ACTIONS(43), 1,
       anon_sym_RBRACE,
     STATE(47), 1,
@@ -4455,7 +4461,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -4492,7 +4498,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     ACTIONS(39), 1,
       anon_sym_RPAREN,
     STATE(47), 1,
@@ -4551,7 +4557,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -4588,7 +4594,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     ACTIONS(45), 1,
       anon_sym_RPAREN,
     STATE(47), 1,
@@ -4647,7 +4653,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -4684,7 +4690,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     ACTIONS(47), 1,
       anon_sym_RPAREN,
     STATE(47), 1,
@@ -4743,7 +4749,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -4780,7 +4786,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     ACTIONS(49), 1,
       anon_sym_RBRACE,
     STATE(47), 1,
@@ -4839,7 +4845,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -4876,7 +4882,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     ACTIONS(51), 1,
       anon_sym_RPAREN,
     STATE(47), 1,
@@ -4935,7 +4941,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -4972,7 +4978,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     ACTIONS(53), 1,
       anon_sym_RBRACE,
     STATE(47), 1,
@@ -5031,7 +5037,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -5068,7 +5074,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -5125,7 +5131,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -5162,7 +5168,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -5219,7 +5225,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -5256,7 +5262,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -5313,7 +5319,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -5350,7 +5356,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -5407,7 +5413,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -5444,7 +5450,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -5501,7 +5507,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -5538,7 +5544,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -5595,7 +5601,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -5632,7 +5638,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -5689,7 +5695,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -5726,7 +5732,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -5783,7 +5789,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -5820,7 +5826,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -5877,7 +5883,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -5914,7 +5920,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -5971,7 +5977,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -6008,7 +6014,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -6065,7 +6071,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -6102,7 +6108,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -6159,7 +6165,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -6196,7 +6202,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -6253,7 +6259,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -6290,7 +6296,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -6347,7 +6353,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -6384,7 +6390,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(114), 1,
@@ -6443,7 +6449,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -6479,7 +6485,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -6536,7 +6542,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -6573,7 +6579,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -6630,7 +6636,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -6667,7 +6673,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -6724,7 +6730,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -6761,7 +6767,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(116), 1,
@@ -6820,7 +6826,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -6856,7 +6862,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -6913,7 +6919,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -6950,7 +6956,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(117), 1,
@@ -7009,7 +7015,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -7045,7 +7051,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -7102,7 +7108,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -7139,7 +7145,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -7196,7 +7202,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -7233,7 +7239,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -7290,7 +7296,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -7327,7 +7333,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -7384,7 +7390,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -7421,7 +7427,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -7474,7 +7480,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -7511,7 +7517,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -7562,7 +7568,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -7599,7 +7605,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -7648,7 +7654,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -7685,7 +7691,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -7732,7 +7738,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -7769,7 +7775,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -7814,7 +7820,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -7851,7 +7857,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -7894,7 +7900,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -7931,7 +7937,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -7972,7 +7978,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -8009,7 +8015,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(123), 1,
@@ -8048,7 +8054,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -8085,7 +8091,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(124), 1,
@@ -8122,7 +8128,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -8159,7 +8165,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(31), 1,
       anon_sym_date,
     ACTIONS(37), 1,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
     STATE(47), 1,
       sym_primary,
     STATE(126), 1,
@@ -8194,7 +8200,7 @@ static const uint16_t ts_small_parse_table[] = {
     ACTIONS(35), 7,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -10878,7 +10884,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_output_root,
       sym_input_root,
       sym_number,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
       sym_identifier,
     ACTIONS(376), 21,
       anon_sym_LPAREN,
@@ -10897,7 +10903,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_hex_literal,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,
@@ -10910,7 +10916,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_output_root,
       sym_input_root,
       sym_number,
-      anon_sym_this_DOTscriptSize,
+      anon_sym_this_DOTbytecodeSize,
       sym_identifier,
     ACTIONS(386), 22,
       anon_sym_LPAREN,
@@ -10930,7 +10936,7 @@ static const uint16_t ts_small_parse_table[] = {
       sym_hex_literal,
       anon_sym_this_DOTactiveInputIndex,
       anon_sym_this_DOTactiveScriptPubKey,
-      anon_sym_this_DOTscriptSizeDataPrefix,
+      anon_sym_this_DOTbytecodeSizeDataPrefix,
       anon_sym_tx_DOTinputs_DOTlength,
       anon_sym_tx_DOToutputs_DOTlength,
       anon_sym_tx_DOTversion,


### PR DESCRIPTION
Closes #165 

 Use `bytecode` consistently for SilverScript compiler output, while retaining established transaction terms such as signature scripts, redeem scripts, and script public keys.

  This is a breaking terminology change for SilverScript source, serialized compiler artifacts, and the Rust API.

  ## Language Behavior Changes

  - Rename the compile-time expressions `this.scriptSize` and `this.scriptSizeDataPrefix`:

  ```silverscript
  entry main(int expectedSize, byte[] expectedPrefix) {
      require(expectedSize == this.bytecodeSize);
      require(expectedPrefix == this.bytecodeSizeDataPrefix);
  }
  ```

  - Rename the compiled artifact’s JSON field from `script` to `bytecode`:

  ```json
  {
    "contract_name": "Example",
    "bytecode": [81]
  }
  ```

  - Rename `CompiledContract::script` to `CompiledContract::bytecode` for programmatic compiler consumers:

  ```rust
  let compiled = compile_contract(source, &args, options)?;
  println!("Bytecode length: {}", compiled.bytecode.len());
  ```

  - Update debugger output and APIs to describe execution in terms of compiled bytecode.
