### PR TITLE
Restrict bitwise operators to bytes and equal-sized byte arrays

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -421,15 +421,15 @@ bool not = !t;      // false (logical NOT)
 
 ### Bitwise Operators
 
-**Note:** Bitwise operators require covenant features to be enabled.
+**Note:** Bitwise operators operate on two bytes or two equal-sized byte arrays. Two dynamic byte arrays may be used, but their sizes must match at runtime.
 
 ```javascript
-int x = 0x0F;  // 00001111
-int y = 0xF0;  // 11110000
+byte[1] x = byte[_](0x0F);  // 00001111
+byte[1] y = byte[_](0xF0);  // 11110000
 
-int bitAnd = x & y;  // 0x00 (bitwise AND)
-int bitOr = x | y;   // 0xFF (bitwise OR)
-int bitXor = x ^ y;  // 0xFF (bitwise XOR)
+byte[1] bitAnd = x & y;  // 0x00 (bitwise AND)
+byte[1] bitOr = x | y;   // 0xFF (bitwise OR)
+byte[1] bitXor = x ^ y;  // 0xFF (bitwise XOR)
 ```
 
 ### Ternary Operator

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -371,21 +371,29 @@ fn check_binary<'i>(
             Err(CompilerError::Unsupported("byte values do not support '+'".to_string()))
         }
         BinaryOp::Add if left_type.is_string() && right_type.is_string() => Ok(scalar_type(TypeBase::String)),
-        BinaryOp::BitOr | BinaryOp::BitXor | BinaryOp::BitAnd
-            if matches!(left_type.base, TypeBase::Byte)
-                && left_type.is_array()
-                && type_refs_equal(&left_type, &right_type, ctx.constants) =>
-        {
+        BinaryOp::BitOr | BinaryOp::BitXor | BinaryOp::BitAnd => {
+            if left_type.is_byte() && right_type.is_byte() {
+                return Ok(left_type);
+            }
+            let left_is_byte_array = matches!(left_type.base, TypeBase::Byte) && left_type.is_array();
+            let right_is_byte_array = matches!(right_type.base, TypeBase::Byte) && right_type.is_array();
+            if !left_is_byte_array || !right_is_byte_array {
+                return Err(CompilerError::Unsupported(format!(
+                    "bitwise operations require bytes or byte arrays, got {} and {}",
+                    left_type.type_name(),
+                    right_type.type_name()
+                )));
+            }
+            if !type_refs_equal(&left_type, &right_type, ctx.constants) {
+                return Err(CompilerError::Unsupported(format!(
+                    "bitwise operations require byte arrays of equal size, got {} and {}",
+                    left_type.type_name(),
+                    right_type.type_name()
+                )));
+            }
             Ok(left_type)
         }
-        BinaryOp::Add
-        | BinaryOp::Sub
-        | BinaryOp::Mul
-        | BinaryOp::Div
-        | BinaryOp::Mod
-        | BinaryOp::BitOr
-        | BinaryOp::BitXor
-        | BinaryOp::BitAnd => {
+        BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod => {
             let int_type = scalar_type(TypeBase::Int);
             ensure_expected(&left_type, Some(&int_type), ctx.constants)?;
             ensure_expected(&right_type, Some(&int_type), ctx.constants)?;

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -1219,6 +1219,136 @@ fn rejects_assigning_sum_of_byte_values_to_byte() {
 }
 
 #[test]
+fn rejects_bitwise_operations_on_integers() {
+    for operator in ["&", "|", "^"] {
+        let source = format!(
+            r#"
+                contract Bitwise() {{
+                    entry main() {{
+                        require((128 {operator} 1) == 0);
+                    }}
+                }}
+            "#
+        );
+
+        let err = compile_contract(&source, &[], CompileOptions::default())
+            .expect_err(&format!("integer operands for {operator} should be rejected"));
+        assert!(
+            err.to_string().contains("bitwise operations require bytes or byte arrays, got int and int"),
+            "unexpected error for {operator}: {err}"
+        );
+    }
+}
+
+#[test]
+fn allows_bitwise_operations_on_bytes() {
+    for (operator, expected) in [("&", 0x04), ("|", 0x3f), ("^", 0x3b)] {
+        let source = format!(
+            r#"
+                contract Bitwise() {{
+                    entry main() {{
+                        byte x = 0x34;
+                        byte y = 0x0f;
+                        byte result = x {operator} y;
+                        require(result == {expected});
+                    }}
+                }}
+            "#
+        );
+
+        let compiled = compile_contract(&source, &[], CompileOptions::default())
+            .unwrap_or_else(|err| panic!("byte operands for {operator} should compile: {err}"));
+        let result = run_bytecode_with_selector(compiled.bytecode, None);
+        assert!(result.is_ok(), "byte operands for {operator} should execute: {result:?}");
+    }
+}
+
+#[test]
+fn rejects_bitwise_operations_mixing_bytes_and_byte_arrays() {
+    for operator in ["&", "|", "^"] {
+        let source = format!(
+            r#"
+                contract Bitwise() {{
+                    entry main() {{
+                        byte x = 0x12;
+                        byte[1] y = byte[_](0x34);
+                        byte result = x {operator} y;
+                        require(result == 0);
+                    }}
+                }}
+            "#
+        );
+
+        let err = compile_contract(&source, &[], CompileOptions::default())
+            .expect_err(&format!("mixed byte and byte-array operands for {operator} should be rejected"));
+        assert!(
+            err.to_string().contains("bitwise operations require bytes or byte arrays, got byte and byte[1]"),
+            "unexpected error for {operator}: {err}"
+        );
+    }
+}
+
+#[test]
+fn rejects_bitwise_operations_on_different_sized_byte_arrays() {
+    for operator in ["&", "|", "^"] {
+        let source = format!(
+            r#"
+                contract Bitwise() {{
+                    entry main() {{
+                        byte[2] x = byte[_](0x1234);
+                        byte[3] y = byte[_](0x56789a);
+                        byte[] result = x {operator} y;
+                        require(result.length > 0);
+                    }}
+                }}
+            "#
+        );
+
+        let err = compile_contract(&source, &[], CompileOptions::default())
+            .expect_err(&format!("different-sized byte arrays for {operator} should be rejected"));
+        assert!(
+            err.to_string().contains("bitwise operations require byte arrays of equal size, got byte[2] and byte[3]"),
+            "unexpected error for {operator}: {err}"
+        );
+    }
+}
+
+#[test]
+fn allows_bitwise_operations_on_dynamic_byte_arrays_and_checks_size_at_runtime() {
+    for (operator, expected) in [("&", vec![0x00, 0x04]), ("|", vec![0x5f, 0x3f]), ("^", vec![0x5f, 0x3b])] {
+        let source = format!(
+            r#"
+                contract Bitwise() {{
+                    entry main(byte[] x, byte[] y, byte[] expected) {{
+                        require((x {operator} y) == expected);
+                    }}
+                }}
+            "#
+        );
+        let compiled = compile_contract(&source, &[], CompileOptions::default())
+            .unwrap_or_else(|err| panic!("dynamic byte arrays for {operator} should compile: {err}"));
+
+        let sigscript = compiled
+            .build_sig_script(
+                "main",
+                vec![Expr::dynamic_bytes(vec![0x12, 0x34]), Expr::dynamic_bytes(vec![0x4d, 0x0f]), Expr::dynamic_bytes(expected)],
+            )
+            .expect("matching dynamic byte-array arguments should build");
+        let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
+        assert!(result.is_ok(), "matching dynamic byte arrays for {operator} should execute: {result:?}");
+
+        let sigscript = compiled
+            .build_sig_script(
+                "main",
+                vec![Expr::dynamic_bytes(vec![0x12, 0x34]), Expr::dynamic_bytes(vec![0x4d]), Expr::dynamic_bytes(vec![0x00, 0x00])],
+            )
+            .expect("different-sized dynamic byte-array arguments should build");
+        let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
+        assert!(result.is_err(), "different-sized dynamic byte arrays for {operator} should fail at runtime");
+    }
+}
+
+#[test]
 fn build_sig_script_rejects_unknown_function() {
     let source = r#"
         contract C() {


### PR DESCRIPTION
Closes #166 

  Make `&`, `|`, and `^` operate only on byte values and byte arrays, preventing integer operands from compiling when their runtime encoding widths may differ.

  ## Language Behavior Changes

  - Singular `byte` operands are supported:

  ```javascript
  byte result = byte(0x34) & byte(0x0F);
  ```

  - Fixed byte-array operands must have the same size:

  ```javascript
  byte[2] result = byte[2](0x1234) ^ byte[2](0xFFFF);
  ```

  - Differently sized fixed byte arrays are rejected during type checking.
  - Two dynamic byte arrays are allowed, with equal lengths enforced by the VM at runtime.
  - Mixing a singular `byte` with a byte array is rejected.
  - Bitwise operations on `int` values are no longer allowed.
