### PR TITLE
  Define explicit scalar byte and integer conversions

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -820,8 +820,10 @@ entry casts(byte[32] data, byte[65] sigBytes, byte[32] keyBytes, byte[] someData
 
 The scalar `byte(...)` conversion accepts an existing `byte` value or an integer
 literal in the range `0..=255`. It does not narrow variables or other non-literal
-`int` expressions. Converting a scalar `byte` to `int` with `int(byteValue)` is
-allowed.
+`int` expressions. `int(byteValue)` is not allowed for scalar `byte` expressions;
+use `signed(byteValue)` or `unsigned(byteValue)` to select the intended numeric
+interpretation. Scalar `byte` expressions cannot be used directly with
+arithmetic operators.
 
 Use `value as byte` to encode a runtime `int` as one byte. It fails at runtime when the value does
 not fit the VM's one-byte signed-magnitude script-number encoding (for example,
@@ -927,6 +929,27 @@ Convert boolean to integer (true = 1, false = 0):
 
 ```javascript
 int x = int(false);  // 0
+```
+
+**`signed(byte value): int`**
+
+Interpret a scalar byte as a one-byte signed-magnitude script number. This is a
+pass-through cast and does not change its byte encoding:
+
+```javascript
+byte b = 0xff;
+int x = signed(b);  // -127
+```
+
+**`unsigned(byte value): int`**
+
+Interpret the byte's full unsigned value by appending a zero byte to its numeric
+encoding:
+
+```javascript
+int i = 255;
+byte b = 255;
+require(unsigned(b) == i);
 ```
 
 ---

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -818,6 +818,11 @@ entry casts(byte[32] data, byte[65] sigBytes, byte[32] keyBytes, byte[] someData
 }
 ```
 
+The scalar `byte(...)` conversion accepts an existing `byte` value or an integer
+literal in the range `0..=255`. It does not narrow variables or other non-literal
+`int` expressions. Converting a scalar `byte` to `int` with `int(byteValue)` is
+allowed.
+
 **Example:**
 
 ```javascript

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -823,6 +823,10 @@ literal in the range `0..=255`. It does not narrow variables or other non-litera
 `int` expressions. Converting a scalar `byte` to `int` with `int(byteValue)` is
 allowed.
 
+Use `value as byte` to encode a runtime `int` as one byte. It fails at runtime when the value does
+not fit the VM's one-byte signed-magnitude script-number encoding (for example,
+`128`).
+
 **Example:**
 
 ```javascript

--- a/silverscript-lang/src/compiler/builtin_types.rs
+++ b/silverscript-lang/src/compiler/builtin_types.rs
@@ -57,7 +57,7 @@ pub(super) fn indexed_introspection_type(kind: IndexedIntrospectionKind) -> Type
 
 pub(super) fn builtin_return(name: &str) -> Option<BuiltinReturn> {
     let value_type = match name {
-        "int" => scalar(TypeBase::Int),
+        "int" | "signed" | "unsigned" => scalar(TypeBase::Int),
         "bool" => scalar(TypeBase::Bool),
         "byte" => scalar(TypeBase::Byte),
         "string" => scalar(TypeBase::String),
@@ -133,6 +133,7 @@ pub(super) fn constructor_parameters(name: &str) -> Option<Vec<(&'static str, Ty
 
 pub(super) fn builtin_parameters(name: &str) -> Option<Vec<(&'static str, TypeRef)>> {
     Some(match name {
+        "signed" | "unsigned" => vec![("value", scalar(TypeBase::Byte))],
         "length" | "sha256" | "blake2b" | "blake3" => vec![("data", byte_array(ArrayDim::Dynamic))],
         "blake2bWithKey" => vec![("data", byte_array(ArrayDim::Dynamic)), ("key", byte_array(ArrayDim::Dynamic))],
         "blake3WithKey" => vec![("data", byte_array(ArrayDim::Dynamic)), ("key", byte_array(ArrayDim::Fixed(32)))],

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -4,7 +4,7 @@ use super::infer_array::lower_inferred_array_sizes;
 use super::inline_functions::lower_inline_functions;
 use super::locals::lower_local_aliases;
 use super::stack_bindings::StackBindings;
-use super::static_check::static_check_contract;
+use super::static_check::{static_check_contract, validate_declaration_names};
 use super::ternary::lower_ternaries;
 use super::*;
 use kaspa_txscript::EngineFlags;
@@ -41,6 +41,8 @@ pub(super) fn compile_contract_impl<'i>(
     options: CompileOptions,
     source: Option<&'i str>,
 ) -> Result<CompiledContract<'i>, CompilerError> {
+    validate_declaration_names(contract)?;
+
     let mut constants: HashMap<String, Expr<'i>> =
         contract.constants.iter().map(|constant| (constant.name.clone(), constant.expr.clone())).collect();
     for (param, value) in contract.params.iter().zip(constructor_args.iter()) {

--- a/silverscript-lang/src/compiler/compile/expression/builtin.rs
+++ b/silverscript-lang/src/compiler/compile/expression/builtin.rs
@@ -107,8 +107,12 @@ fn compile_as_cast<'i>(ctx: &mut CompileExprContext<'_, '_, 'i>, args: &[Expr<'i
     let [source] = args else {
         return Err(CompilerError::Unsupported("'as' conversion expects one source expression".to_string()));
     };
-    let size = array_type_size(cast_type, ctx.env.constants)
-        .ok_or_else(|| CompilerError::Unsupported("byte size in 'as byte[N]' must be known at compile time".to_string()))?;
+    let size = if cast_type.is_byte() {
+        1
+    } else {
+        array_type_size(cast_type, ctx.env.constants)
+            .ok_or_else(|| CompilerError::Unsupported("byte size in 'as byte[N]' must be known at compile time".to_string()))?
+    };
     compile_call_arg_with_context(ctx, source)?;
     ctx.push_int(i64::try_from(size).map_err(|_| CompilerError::Unsupported("byte size is too large".to_string()))?)?;
     ctx.emit_op(OpNum2Bin, -1)?;

--- a/silverscript-lang/src/compiler/compile/expression/builtin.rs
+++ b/silverscript-lang/src/compiler/compile/expression/builtin.rs
@@ -19,6 +19,8 @@ pub(super) fn compile_call_expr<'i>(
         "sha256" => compile_sha256_call(ctx, args),
         "length" => compile_length_call(ctx, args),
         "byte" => compile_byte_sequence_cast_call(ctx, "byte[1]", args),
+        "signed" => compile_typed_builtin_args(ctx, "signed", args),
+        "unsigned" => compile_unsigned_call(ctx, args),
         "int" | "bool" | "string" | "sig" | "pubkey" | "datasig" => compile_passthrough_cast_call(ctx, name, args),
         name if parse_type_ref(name)
             .is_ok_and(|type_ref| matches!(type_ref.base, TypeBase::Byte) && type_ref.array_dims.len() == 1) =>
@@ -135,6 +137,13 @@ fn compile_passthrough_cast_call<'i>(
         return Err(CompilerError::Unsupported(format!("{name}() expects a single argument")));
     }
     compile_call_arg_with_context(ctx, &args[0])
+}
+
+fn compile_unsigned_call<'i>(ctx: &mut CompileExprContext<'_, '_, 'i>, args: &[Expr<'i>]) -> Result<(), CompilerError> {
+    compile_typed_builtin_args(ctx, "unsigned", args)?;
+    ctx.push_data(&[0])?;
+    ctx.emit_op(OpCat, -1)?;
+    Ok(())
 }
 
 fn compile_byte_sequence_cast_call<'i>(

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -2,6 +2,41 @@ use super::*;
 use semver::{Comparator, Op, Version, VersionReq};
 use std::collections::{HashMap, HashSet};
 
+pub(super) fn validate_declaration_names(contract: &ContractAst<'_>) -> Result<(), CompilerError> {
+    let mut names = HashSet::new();
+    for param in &contract.params {
+        if !names.insert(param.name.as_str()) {
+            return Err(
+                CompilerError::Unsupported(format!("duplicate contract parameter name '{}'", param.name)).with_span(&param.name_span)
+            );
+        }
+    }
+
+    names.clear();
+    for constant in &contract.constants {
+        if !names.insert(constant.name.as_str()) {
+            return Err(
+                CompilerError::Unsupported(format!("duplicate constant name '{}'", constant.name)).with_span(&constant.name_span)
+            );
+        }
+    }
+
+    for function in &contract.functions {
+        names.clear();
+        for param in &function.params {
+            if !names.insert(param.name.as_str()) {
+                return Err(CompilerError::Unsupported(format!(
+                    "duplicate parameter name '{}' in function '{}'",
+                    param.name, function.name
+                ))
+                .with_span(&param.name_span));
+            }
+        }
+    }
+
+    Ok(())
+}
+
 pub(super) fn static_check_contract<'i>(
     contract: &ContractAst<'i>,
     constructor_args: &[Expr<'i>],

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -238,14 +238,18 @@ pub(super) fn check_call<'i>(
     if let Some(cast_type) = as_cast_type(name) {
         check_arity("as", args, 1)?;
         if !matches!(cast_type.base, TypeBase::Byte)
-            || !matches!(cast_type.array_dims.as_slice(), [ArrayDim::Fixed(_) | ArrayDim::Constant(_)])
+            || !(cast_type.is_byte() || matches!(cast_type.array_dims.as_slice(), [ArrayDim::Fixed(_) | ArrayDim::Constant(_)]))
         {
-            return Err(CompilerError::Unsupported("'as' conversion requires a fixed byte[N] target".to_string()));
+            return Err(CompilerError::Unsupported("'as' conversion requires byte or a fixed byte[N] target".to_string()));
         }
         check_expr(&args[0], Some(&scalar_type(TypeBase::Int)), ctx)
-            .map_err(|_| CompilerError::Unsupported("'as byte[N]' source must be int".to_string()))?;
-        let size = array_type_size(&cast_type, ctx.constants)
-            .ok_or_else(|| CompilerError::Unsupported("byte size in 'as byte[N]' must be known at compile time".to_string()))?;
+            .map_err(|_| CompilerError::Unsupported("'as byte' source must be int".to_string()))?;
+        let size = if cast_type.is_byte() {
+            1
+        } else {
+            array_type_size(&cast_type, ctx.constants)
+                .ok_or_else(|| CompilerError::Unsupported("byte size in 'as byte[N]' must be known at compile time".to_string()))?
+        };
         if size == 0 || size > 8 {
             return Err(CompilerError::Unsupported("byte size in 'as byte[N]' must be between 1 and 8".to_string()));
         }

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -275,6 +275,17 @@ pub(super) fn check_call<'i>(
     {
         check_arity(name, args, 1)?;
         let source_type = check_expr(&args[0], None, ctx)?;
+        if cast_type.is_byte() && source_type.is_int() {
+            match &args[0].kind {
+                ExprKind::Int(value) => {
+                    u8::try_from(*value)
+                        .map_err(|_| CompilerError::Unsupported(format!("integer literal {value} is out of range for byte")))?;
+                }
+                _ => {
+                    return Err(CompilerError::Unsupported("cannot cast non-literal int expression to byte".to_string()));
+                }
+            }
+        }
         if matches!(cast_type.base, TypeBase::Byte) && cast_type.is_array() && source_type.is_int() {
             return Err(CompilerError::Unsupported(format!(
                 "cannot cast int to {}; use 'value as byte[N]' instead",

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -279,6 +279,9 @@ pub(super) fn check_call<'i>(
     {
         check_arity(name, args, 1)?;
         let source_type = check_expr(&args[0], None, ctx)?;
+        if cast_type.is_int() && source_type.is_byte() {
+            return Err(CompilerError::Unsupported("cannot cast byte to int; use signed() or unsigned() instead".to_string()));
+        }
         if cast_type.is_byte() && source_type.is_int() {
             match &args[0].kind {
                 ExprKind::Int(value) => {
@@ -416,9 +419,6 @@ fn check_binary<'i>(
         }
         BinaryOp::Add if left_type.is_array() && right_type.is_array() => concat_types(&left_type, &right_type, ctx.constants)
             .ok_or_else(|| CompilerError::Unsupported("array concatenation requires identical element types".to_string())),
-        BinaryOp::Add if left_type.is_byte() || right_type.is_byte() => {
-            Err(CompilerError::Unsupported("byte values do not support '+'".to_string()))
-        }
         BinaryOp::Add if left_type.is_string() && right_type.is_string() => Ok(scalar_type(TypeBase::String)),
         BinaryOp::BitOr | BinaryOp::BitXor | BinaryOp::BitAnd => {
             if left_type.is_byte() && right_type.is_byte() {

--- a/silverscript-lang/tests/apps/chess/chess_pawn.sil
+++ b/silverscript-lang/tests/apps/chess/chess_pawn.sil
@@ -169,7 +169,7 @@ contract ChessPawn(
                 if (moving_is_black) {
                     arrived_num = arrived_num + 8;
                 }
-                arrived_piece = byte(arrived_num);
+                arrived_piece = arrived_num as byte;
             } else {
                 require(promo_piece == 0);
             }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -1,4 +1,6 @@
 mod common;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
 use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus_core::Hash;
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
@@ -15,7 +17,7 @@ use kaspa_txscript::{
     EngineCtx, EngineFlags, SeqCommitAccessor, TxScriptEngine, parse_script, pay_to_address_script, pay_to_script_hash_script,
     pay_to_script_hash_signature_script_with_flags, script_to_str, serialize_i64,
 };
-use silverscript_lang::ast::{Expr, ExprKind, Statement, format_contract_ast, parse_contract_ast, parse_type_ref};
+use silverscript_lang::ast::{ContractAst, Expr, ExprKind, Statement, format_contract_ast, parse_contract_ast, parse_type_ref};
 use silverscript_lang::compiler::{
     COMPILER_VERSION, CompileOptions, CompiledContract, CovenantDeclCallOptions, FunctionAbiEntry, FunctionInputAbi, compile_contract,
     compile_contract_ast, compile_debug_expr, function_branch_index, generated_covenant_auth_entrypoint_name, struct_object,
@@ -11271,6 +11273,64 @@ fn byte_array_to_int_cast_compiles_without_extra_opcodes_and_executes() {
 }
 
 #[test]
+fn scalar_int_and_byte_cast_directionality() {
+    for expression in ["value", "value + 1"] {
+        let source = format!(
+            r#"
+            contract Test() {{
+                entry test(int value) {{
+                    byte narrowed = byte({expression});
+                    require(narrowed == narrowed);
+                }}
+            }}
+            "#
+        );
+        let err = compile_contract(&source, &[], CompileOptions::default())
+            .expect_err("non-literal int expressions must not cast to scalar byte");
+        assert!(err.to_string().contains("cannot cast non-literal int expression to byte"), "unexpected error: {err}");
+    }
+
+    let literal_source = r#"
+        contract Test() {
+            entry test() {
+                byte zero = byte(0);
+                byte value = byte(42);
+                byte max = byte(255);
+                require(zero == byte(0));
+                require(value == byte(42));
+                require(max == byte(255));
+            }
+        }
+    "#;
+    compile_contract(literal_source, &[], CompileOptions::default()).expect("in-range int literals may cast to byte");
+
+    let out_of_range_source = r#"
+        contract Test() {
+            entry test() {
+                byte invalid = byte(256);
+                require(invalid == invalid);
+            }
+        }
+    "#;
+    let err = compile_contract(out_of_range_source, &[], CompileOptions::default())
+        .expect_err("out-of-range int literal must not cast to byte");
+    assert!(err.to_string().contains("integer literal 256 is out of range for byte"), "unexpected error: {err}");
+
+    let widening_source = r#"
+        contract Test() {
+            entry test(byte value) {
+                int widened = int(value);
+                require(widened == 42);
+            }
+        }
+    "#;
+    let compiled = compile_contract(widening_source, &[], CompileOptions::default()).expect("byte-to-int cast must compile");
+    assert!(!compiled.bytecode.contains(&OpBin2Num), "int(byte) remains a pass-through cast");
+    let sigscript = compiled.build_sig_script("test", vec![Expr::byte(42)]).expect("byte argument encodes");
+    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript).is_ok(), "byte-to-int cast must execute");
+}
+
+#[test]
 fn empty_array_statement_expr_evaluation_compiles_to_empty_array_data() {
     let source = r#"
         contract Test() {
@@ -13455,5 +13515,227 @@ fn rejects_duplicate_function_names() {
         let source = format!("contract DuplicateFunctions() {{{duplicate}}}");
         let err = compile_contract(&source, &[], CompileOptions::default()).expect_err("duplicate function names should be rejected");
         assert!(err.to_string().contains("duplicate function name"), "unexpected error: {err}");
+    }
+}
+
+#[test]
+fn rejects_duplicate_declaration_names() {
+    let cases = [
+        (
+            "contract DuplicateCtor(int value, int value) { entry spend() { require(true); } }",
+            vec![Expr::int(1), Expr::int(2)],
+            "value",
+            "duplicate contract parameter name 'value'",
+        ),
+        (
+            "contract DuplicateEntry() { entry spend(int value, int value) { require(value == value); } }",
+            vec![],
+            "value",
+            "duplicate parameter name 'value' in function 'spend'",
+        ),
+        (
+            "contract DuplicateHelper() { function helper(int value, int value) { require(true); } entry spend() { require(true); } }",
+            vec![],
+            "value",
+            "duplicate parameter name 'value' in function 'helper'",
+        ),
+        (
+            "contract DuplicateConstant() { int constant VALUE = 1; int constant VALUE = 2; entry spend() { require(true); } }",
+            vec![],
+            "VALUE",
+            "duplicate constant name 'VALUE'",
+        ),
+    ];
+
+    for (source, constructor_args, duplicate_name, expected_error) in cases {
+        let source_error = compile_contract(source, &constructor_args, CompileOptions::default())
+            .expect_err("source compilation must reject duplicate declarations");
+        assert_eq!(source_error.root().to_string(), format!("unsupported feature: {expected_error}"));
+        let span = source_error.span().expect("source error identifies the second declaration");
+        assert_eq!(&source[span.start..span.end], duplicate_name);
+
+        let ast = parse_contract_ast(source).expect("duplicate declarations remain representable in the public AST");
+        let ast_error = compile_contract_ast(&ast, &constructor_args, CompileOptions::default())
+            .expect_err("public AST compilation must reject duplicate declarations");
+        assert_eq!(ast_error.root().to_string(), source_error.root().to_string());
+    }
+}
+
+#[derive(Clone, Debug)]
+enum ConformancePureExpr {
+    Int(i64),
+    Add(Box<Self>, Box<Self>),
+    Sub(Box<Self>, Box<Self>),
+    Mul(Box<Self>, Box<Self>),
+    Eq(Box<Self>, Box<Self>),
+    Lt(Box<Self>, Box<Self>),
+    And(Box<Self>, Box<Self>),
+    Or(Box<Self>, Box<Self>),
+    Not(Box<Self>),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ConformanceValue {
+    Int(i64),
+    Bool(bool),
+}
+
+impl ConformancePureExpr {
+    fn eval(&self) -> ConformanceValue {
+        match self {
+            Self::Int(value) => ConformanceValue::Int(*value),
+            Self::Add(left, right) => ConformanceValue::Int(conformance_int(left.eval()) + conformance_int(right.eval())),
+            Self::Sub(left, right) => ConformanceValue::Int(conformance_int(left.eval()) - conformance_int(right.eval())),
+            Self::Mul(left, right) => ConformanceValue::Int(conformance_int(left.eval()) * conformance_int(right.eval())),
+            Self::Eq(left, right) => ConformanceValue::Bool(left.eval() == right.eval()),
+            Self::Lt(left, right) => ConformanceValue::Bool(conformance_int(left.eval()) < conformance_int(right.eval())),
+            Self::And(left, right) => ConformanceValue::Bool(conformance_bool(left.eval()) && conformance_bool(right.eval())),
+            Self::Or(left, right) => ConformanceValue::Bool(conformance_bool(left.eval()) || conformance_bool(right.eval())),
+            Self::Not(value) => ConformanceValue::Bool(!conformance_bool(value.eval())),
+        }
+    }
+
+    fn source(&self) -> String {
+        match self {
+            Self::Int(value) => value.to_string(),
+            Self::Add(left, right) => format!("({} + {})", left.source(), right.source()),
+            Self::Sub(left, right) => format!("({} - {})", left.source(), right.source()),
+            Self::Mul(left, right) => format!("({} * {})", left.source(), right.source()),
+            Self::Eq(left, right) => format!("({} == {})", left.source(), right.source()),
+            Self::Lt(left, right) => format!("({} < {})", left.source(), right.source()),
+            Self::And(left, right) => format!("({} && {})", left.source(), right.source()),
+            Self::Or(left, right) => format!("({} || {})", left.source(), right.source()),
+            Self::Not(value) => format!("!({})", value.source()),
+        }
+    }
+}
+
+fn conformance_int(value: ConformanceValue) -> i64 {
+    match value {
+        ConformanceValue::Int(value) => value,
+        ConformanceValue::Bool(_) => panic!("generator produced an ill-typed integer expression"),
+    }
+}
+
+fn conformance_bool(value: ConformanceValue) -> bool {
+    match value {
+        ConformanceValue::Bool(value) => value,
+        ConformanceValue::Int(_) => panic!("generator produced an ill-typed boolean expression"),
+    }
+}
+
+fn next_conformance_seed(seed: &mut u64) -> u64 {
+    *seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+    *seed
+}
+
+fn generate_conformance_int(seed: &mut u64, depth: usize) -> ConformancePureExpr {
+    if depth == 0 {
+        return ConformancePureExpr::Int((next_conformance_seed(seed) % 17) as i64 - 8);
+    }
+    let left = Box::new(generate_conformance_int(seed, depth - 1));
+    let right = Box::new(generate_conformance_int(seed, depth - 1));
+    match next_conformance_seed(seed) % 3 {
+        0 => ConformancePureExpr::Add(left, right),
+        1 => ConformancePureExpr::Sub(left, right),
+        _ => ConformancePureExpr::Mul(left, right),
+    }
+}
+
+fn generate_conformance_bool(seed: &mut u64, depth: usize) -> ConformancePureExpr {
+    if depth == 0 {
+        let left = Box::new(generate_conformance_int(seed, 1));
+        let right = Box::new(generate_conformance_int(seed, 1));
+        return if next_conformance_seed(seed) & 1 == 0 {
+            ConformancePureExpr::Eq(left, right)
+        } else {
+            ConformancePureExpr::Lt(left, right)
+        };
+    }
+    match next_conformance_seed(seed) % 3 {
+        0 => ConformancePureExpr::Not(Box::new(generate_conformance_bool(seed, depth - 1))),
+        1 => ConformancePureExpr::And(
+            Box::new(generate_conformance_bool(seed, depth - 1)),
+            Box::new(generate_conformance_bool(seed, depth - 1)),
+        ),
+        _ => ConformancePureExpr::Or(
+            Box::new(generate_conformance_bool(seed, depth - 1)),
+            Box::new(generate_conformance_bool(seed, depth - 1)),
+        ),
+    }
+}
+
+fn compile_and_execute_conformance_assertion(assertion: &str) {
+    let source = format!("contract Generated() {{ entry spend() {{ require({assertion}); }} }}");
+    let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("generated well-typed program compiles");
+    run_bytecode_with_selector(compiled.bytecode, None).expect("reference result agrees with local VM");
+}
+
+#[test]
+fn bounded_reference_evaluator_matches_local_vm() {
+    let mut seed = 0x05ee_dc0d_ed15_ca11_u64;
+    for _case in 0..64 {
+        let expr = generate_conformance_bool(&mut seed, 2);
+        let expected = conformance_bool(expr.eval());
+        compile_and_execute_conformance_assertion(&format!("{} == {expected}", expr.source()));
+    }
+}
+
+#[test]
+fn bounded_metamorphic_variants_preserve_behavior() {
+    let variants = [
+        "int alpha = 2 + 3; require(alpha == 5);",
+        "int renamed = 2 + 3; require(renamed == 5);",
+        "int alpha = 5; require(alpha == 5);",
+        "int alpha = helper(2, 3); require(alpha == 5);",
+        "int alpha = false ? (1 / 0) : 5; require(alpha == 5);",
+    ];
+    for body in variants {
+        let helper = if body.contains("helper") { "function helper(int a, int b): int { return a + b; }" } else { "" };
+        let source = format!("contract Meta() {{ {helper} entry spend() {{ {body} }} }}");
+        let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("metamorphic variant compiles");
+        run_bytecode_with_selector(compiled.bytecode, None).expect("metamorphic variant executes");
+    }
+}
+
+#[test]
+fn formatting_and_ast_round_trip_preserve_artifact() {
+    let source = "contract RoundTrip(int seed) { int state = seed; entry spend() { require(state == 4); } }";
+    let args = [Expr::int(4)];
+    let original = compile_contract(source, &args, CompileOptions::default()).expect("source compiles");
+    let ast = parse_contract_ast(source).expect("source parses");
+    let formatted = format_contract_ast(&ast);
+    let reparsed = parse_contract_ast(&formatted).expect("formatted source parses");
+    let from_ast = compile_contract_ast(&reparsed, &args, CompileOptions::default()).expect("public AST path compiles");
+    assert_eq!(original.bytecode, from_ast.bytecode);
+    assert_eq!(original.abi, from_ast.abi);
+    assert_eq!(original.state_layout, from_ast.state_layout);
+}
+
+#[test]
+fn debug_recording_does_not_change_executable_artifact() {
+    let source = "contract DebugInvariant() { entry spend() { int x = 2 + 3; require(x == 5); } }";
+    let plain = compile_contract(source, &[], CompileOptions::default()).expect("plain compile");
+    let debug = compile_contract(source, &[], CompileOptions { record_debug_infos: true, ..CompileOptions::default() })
+        .expect("debug compile");
+    assert_eq!(plain.abi, debug.abi);
+    assert_eq!(plain.state_layout, debug.state_layout);
+    assert!(plain.debug_info.is_none());
+    assert!(debug.debug_info.is_some());
+    run_bytecode_with_selector(plain.bytecode, None).expect("plain artifact executes");
+    run_bytecode_with_selector(debug.bytecode, None).expect("debug artifact executes with equivalent semantics");
+}
+
+#[test]
+fn public_ast_robustness_seeds_return_without_panicking() {
+    let seeds = [
+        r#"{"name":"NoFunctions","params":[],"constants":[],"functions":[]}"#,
+        r#"{"name":"UnknownType","params":[],"constants":[],"functions":[{"name":"spend","params":[{"type_ref":{"base":"Missing"},"name":"x"}],"entrypoint":true,"body":[]}] }"#,
+        r#"{"name":"BadReturn","params":[],"constants":[],"functions":[{"name":"spend","params":[],"entrypoint":true,"return_types":[{"base":"int"}],"body":[]}] }"#,
+    ];
+    for seed in seeds {
+        let ast: ContractAst<'_> = serde_json::from_str(seed).expect("seed is valid public AST JSON");
+        let outcome = catch_unwind(AssertUnwindSafe(|| compile_contract_ast(&ast, &[], CompileOptions::default())));
+        assert!(outcome.is_ok(), "public AST compilation panicked for seed: {seed}");
     }
 }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -11148,6 +11148,45 @@ fn int_as_fixed_bytes_has_a_fixed_result_type_and_uses_num2bin() {
 }
 
 #[test]
+fn int_as_byte_uses_num2bin_and_executes() {
+    let source = r#"
+        contract Test() {
+            entry test(int x) {
+                byte encoded = x as byte;
+                require(encoded == byte(42));
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("int as byte compiles");
+    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    assert_eq!(opcodes.matches("OpNum2Bin").count(), 1, "int as byte must emit one OpNum2Bin: {opcodes}");
+
+    let sigscript = compiled.build_sig_script("test", vec![Expr::int(42)]).expect("int argument encodes");
+    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript).is_ok(), "one-byte numeric conversion should execute");
+}
+
+#[test]
+fn int_as_byte_fails_at_runtime_when_value_does_not_fit() {
+    let source = r#"
+        contract Test() {
+            entry test(int x) {
+                byte encoded = x as byte;
+                require(encoded == encoded);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("int as byte compiles");
+    let sigscript = compiled.build_sig_script("test", vec![Expr::int(128)]).expect("int argument encodes");
+    let err = run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect_err("128 needs two script-number bytes");
+    assert_eq!(
+        err,
+        kaspa_txscript_errors::TxScriptError::Serialization(kaspa_txscript_errors::SerializationError::NumberTooLong(128, 1))
+    );
+}
+
+#[test]
 fn int_as_fixed_bytes_accepts_a_compile_time_size_constant() {
     let source = r#"
         contract Test() {
@@ -11167,7 +11206,7 @@ fn int_as_fixed_bytes_accepts_a_compile_time_size_constant() {
 fn int_as_fixed_bytes_rejects_invalid_source_target_and_size() {
     let cases = [
         ("byte[] data = byte[](0x01); byte[_] encoded = data as byte[4];", "source must be int"),
-        ("int x = 1; byte[] encoded = x as byte[];", "requires a fixed byte[N] target"),
+        ("int x = 1; byte[] encoded = x as byte[];", "requires byte or a fixed byte[N] target"),
         ("int x = 1; byte[_] encoded = x as byte[_];", "cannot infer fixed array size"),
         ("int x = 1; byte[_] encoded = x as byte[9];", "must be between 1 and 8"),
     ];

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -1188,36 +1188,73 @@ fn byte_equality_with_out_of_range_rhs_int_literal_is_rejected() {
 }
 
 #[test]
-fn rejects_adding_byte_values() {
-    let source = r#"
-        contract Bytes() {
-            entry main() {
-                byte x = 5;
-                byte y = 7;
-                require(x + y > 0);
-            }
-        }
-    "#;
+fn rejects_arithmetic_operations_on_byte_expressions() {
+    for operator in ["+", "-", "*", "/", "%"] {
+        let literal_source = format!(
+            r#"
+                contract ByteLiterals() {{
+                    entry main() {{
+                        int result = byte(6) {operator} byte(2);
+                        require(result == 0);
+                    }}
+                }}
+            "#
+        );
+        compile_contract(&literal_source, &[], CompileOptions::default())
+            .expect_err(&format!("byte literals should not support {operator} arithmetic"));
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("byte addition should be rejected");
-    assert!(err.to_string().contains("byte values do not support '+'"), "unexpected error: {err}");
+        let variable_source = format!(
+            r#"
+                contract ByteVariables() {{
+                    entry main() {{
+                        byte b1 = 6;
+                        byte b2 = 2;
+                        int result = b1 {operator} b2;
+                        require(result == 0);
+                    }}
+                }}
+            "#
+        );
+        compile_contract(&variable_source, &[], CompileOptions::default())
+            .expect_err(&format!("byte variables should not support {operator} arithmetic"));
+    }
 }
 
 #[test]
-fn rejects_assigning_sum_of_byte_values_to_byte() {
+fn rejects_negating_a_byte_expression() {
     let source = r#"
         contract Bytes() {
             entry main() {
-                byte x = 5;
-                byte y = 7;
-                byte z = x + y;
-                require(OpBin2Num(z) == 12);
+                byte value = 5;
+                int result = -value;
+                require(result == 0);
             }
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("byte addition assignment should be rejected");
-    assert!(err.to_string().contains("byte values do not support '+'"), "unexpected error: {err}");
+    compile_contract(source, &[], CompileOptions::default()).expect_err("negating a byte should be rejected");
+}
+
+#[test]
+fn allows_arithmetic_after_signed_or_unsigned_byte_conversion() {
+    let source = r#"
+        contract Bytes() {
+            entry main() {
+                byte b1 = 5;
+                byte b2 = 7;
+                int signedResult = signed(b1) + signed(b2);
+                int unsignedResult = unsigned(b1) + unsigned(b2);
+                require(signedResult == 12);
+                require(unsignedResult == 12);
+            }
+        }
+    "#;
+
+    let compiled =
+        compile_contract(source, &[], CompileOptions::default()).expect("explicit byte conversions should allow arithmetic");
+    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    assert_eq!(opcodes.matches("OpAdd").count(), 2, "converted byte arithmetic must emit OpAdd: {opcodes}");
+    assert!(run_bytecode_with_selector(compiled.bytecode, None).is_ok(), "converted byte arithmetic should execute");
 }
 
 #[test]
@@ -11261,6 +11298,8 @@ fn builtin_function_arguments_are_type_checked() {
         ("length", "length(1) >= 0", "argument 'data' expects byte[], got int"),
         ("sha256", "sha256(1).length == 32", "argument 'data' expects byte[], got int"),
         ("blake3", "blake3(false).length == 32", "argument 'data' expects byte[], got bool"),
+        ("signed conversion", "signed(false) == 0", "argument 'value' expects byte, got bool"),
+        ("unsigned conversion", "unsigned(false) == 0", "argument 'value' expects byte, got bool"),
         ("checkSig", "checkSig(1, 2)", "argument 'signature' expects sig, got int"),
         ("transaction index", "OpOutpointTxId(false).length == 32", "argument 'idx' expects int, got bool"),
         ("transaction substring", "OpTxPayloadSubstr(false, 1).length >= 0", "argument 'start' expects int, got bool"),
@@ -11354,19 +11393,70 @@ fn scalar_int_and_byte_cast_directionality() {
     let err = compile_contract(out_of_range_source, &[], CompileOptions::default())
         .expect_err("out-of-range int literal must not cast to byte");
     assert!(err.to_string().contains("integer literal 256 is out of range for byte"), "unexpected error: {err}");
+}
 
-    let widening_source = r#"
+#[test]
+fn int_cast_rejects_scalar_byte_expressions() {
+    let variable_source = r#"
         contract Test() {
             entry test(byte value) {
                 int widened = int(value);
-                require(widened == 42);
+                require(widened == widened);
             }
         }
     "#;
-    let compiled = compile_contract(widening_source, &[], CompileOptions::default()).expect("byte-to-int cast must compile");
-    assert!(!compiled.bytecode.contains(&OpBin2Num), "int(byte) remains a pass-through cast");
-    let sigscript = compiled.build_sig_script("test", vec![Expr::byte(42)]).expect("byte argument encodes");
-    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript).is_ok(), "byte-to-int cast must execute");
+    let err = compile_contract(variable_source, &[], CompileOptions::default()).expect_err("int(byte variable) must be rejected");
+    assert!(err.to_string().contains("use signed() or unsigned()"), "unexpected error: {err}");
+
+    let literal_source = r#"
+        contract Test() {
+            entry test() {
+                int widened = int(byte(42));
+                require(widened == widened);
+            }
+        }
+    "#;
+    let err = compile_contract(literal_source, &[], CompileOptions::default()).expect_err("int(byte expression) must be rejected");
+    assert!(err.to_string().contains("use signed() or unsigned()"), "unexpected error: {err}");
+}
+
+#[test]
+fn signed_byte_cast_is_a_passthrough_with_signed_numeric_semantics() {
+    let source = r#"
+        contract Test() {
+            entry test(byte value) {
+                int converted = signed(value);
+                require(converted == -127);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("signed(byte) compiles");
+    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    assert!(!opcodes.contains("OpCat"), "signed(byte) must be a passthrough: {opcodes}");
+    assert!(!opcodes.contains("OpBin2Num"), "signed(byte) must not normalize its operand: {opcodes}");
+
+    let sigscript = compiled.build_sig_script("test", vec![Expr::byte(255)]).expect("byte argument encodes");
+    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript).is_ok(), "0xff must have signed value -127");
+}
+
+#[test]
+fn unsigned_byte_cast_appends_zero_and_preserves_255() {
+    let source = r#"
+        contract Test() {
+            entry test() {
+                int i = 255;
+                byte b = 255;
+                require(unsigned(b) == i);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("unsigned(byte) compiles");
+    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    assert_eq!(opcodes.matches("OpCat").count(), 1, "unsigned(byte) must append one zero byte: {opcodes}");
+    assert!(!opcodes.contains("OpBin2Num"), "unsigned(byte) must use concatenation rather than normalization: {opcodes}");
+    assert!(run_bytecode_with_selector(compiled.bytecode, None).is_ok(), "unsigned(0xff) must equal 255");
 }
 
 #[test]

--- a/silverscript-lang/tests/examples/bytes1_equals_byte.sil
+++ b/silverscript-lang/tests/examples/bytes1_equals_byte.sil
@@ -2,7 +2,7 @@ pragma silverscript ^0.1.0;
 
 contract Bytes1EqualsByte() {
     entry hello(int a, byte b) {
-        byte c = byte(a);
+        byte c = a as byte;
         require(b == c);
     }
 }

--- a/silverscript-lang/tests/examples/int_to_byte.sil
+++ b/silverscript-lang/tests/examples/int_to_byte.sil
@@ -2,7 +2,7 @@ pragma silverscript ^0.1.0;
 
 contract IntToByte() {
     entry hello(int a, byte b) {
-        byte c = byte(a);
+        byte c = a as byte;
         require(b == c);
     }
 }

--- a/silverscript-lang/tests/examples/kcc20.sil
+++ b/silverscript-lang/tests/examples/kcc20.sil
@@ -14,9 +14,9 @@ contract KCC20(byte[32] genesisPk, int genesisAmount, byte genesisIdentifierType
                 require(checkSig(sigs[i], pubkey(prevStates[i].ownerIdentifier)));
             } else if(prevStates[i].identifierType == IDENTIFIER_SCRIPT_HASH){
                 byte[] spk = byte[](new ScriptPubKeyP2SH(prevStates[i].ownerIdentifier));
-                require(tx.inputs[int(witnesses[i])].scriptPubKey == spk);
+                require(tx.inputs[unsigned(witnesses[i])].scriptPubKey == spk);
             } else if(prevStates[i].identifierType == IDENTIFIER_COVENANT_ID){
-                require(OpInputCovenantId(int(witnesses[i])) == prevStates[i].ownerIdentifier);
+                require(OpInputCovenantId(unsigned(witnesses[i])) == prevStates[i].ownerIdentifier);
             } else {
                 require(false);
             }


### PR DESCRIPTION
Clarifies conversions between scalar `byte` and `int`, removing ambiguous numeric interpretations. It also rejects duplicate declaration names instead of silently accepting them.

  ## Language Behavior Changes

  - Runtime integers can be converted to a scalar byte with `as byte`:

  ```javascript
  int value = 42;
  byte encoded = value as byte;
  ```

  The conversion fails at runtime if the value cannot fit the VM’s one-byte signed-magnitude encoding.

  - `byte(...)` only accepts existing byte values or integer literals from `0` through `255`. It no longer narrows runtime integer expressions:

  ```javascript
  byte literal = byte(255); // valid

  int value = 42;
  byte encoded = byte(value); // invalid
  byte encoded = value as byte; // valid
  ```

  - Scalar bytes must use an explicit numeric interpretation when converted to integers:

  ```javascript
  byte value = 0xff;

  int signedValue = signed(value);     // -127
  int unsignedValue = unsigned(value); // 255
  ```

  `int(byteValue)` is no longer valid.

  - Scalar byte expressions cannot be used directly with arithmetic operators. Convert them first:

  ```javascript
  byte left = 5;
  byte right = 7;

  int signedSum = signed(left) + signed(right);
  int unsignedSum = unsigned(left) + unsigned(right);
  ```

  - Duplicate contract parameters, constants, and function parameters now produce compiler errors.