### PR TITLE
  Tighten SilverScript type and evaluation semantics

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -827,6 +827,30 @@ use `signed(byteValue)` or `unsigned(byteValue)` to select the intended numeric
 interpretation. Scalar `byte` expressions cannot be used directly with
 arithmetic operators.
 
+### Casts are unchecked type assertions
+
+Representation-preserving casts assume that the runtime value already has the
+representation required by the target type. They do not emit a runtime length or
+format check. The compiler rejects incompatibilities it can prove at compile
+time, but a cast from a dynamically sized value to a fixed-size or opaque byte
+type trusts the programmer's assertion.
+
+For example, check a dynamic value before treating it as `byte[32]`:
+
+```javascript
+entry checkedCast(byte[] data) {
+    require(data.length == 32);
+    byte[32] hash = byte[32](data);
+}
+```
+
+Without the explicit `require`, `byte[32](data)` does not prove that `data`
+contains 32 bytes. Code using casts to `byte[N]`, `pubkey`, `sig`, or `datasig`
+is responsible for validating any runtime size or format properties on which it
+relies. After a cast, compile-time properties such as a fixed array's `.length`
+come from the asserted target type and are not evidence that the runtime value
+was checked.
+
 Use `value as byte` to encode a runtime `int` as one byte. It fails at runtime when the value does
 not fit the VM's one-byte signed-magnitude script-number encoding (for example,
 `128`).

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -759,14 +759,13 @@ byte[] combined = a + b;  // 0x12345678
 
 **Split:**
 
-`split(int)` divides a byte array at a specific index and returns a two-value
-tuple. A constant split index gives the left part a fixed size; the right part
-is fixed too when the source size is known. Use `.0` for the left part and `.1`
-for the right part:
+`split(int)` divides an array at a specific index and returns a two-value tuple.
+Both parts are dynamic arrays with the same element type as the source. Use `.0`
+for the left part and `.1` for the right part:
 
 ```javascript
 byte[] data = byte[](0x1234567890abcdef);
-byte[4] left = data.split(4).0;  // 0x12345678
+byte[] left = data.split(4).0;   // 0x12345678
 byte[] right = data.split(4).1;  // 0x90abcdef
 ```
 
@@ -774,7 +773,7 @@ You can also destructure both parts at once:
 
 ```javascript
 byte[] data = byte[](0x1234567890abcdef);
-(byte[4] left, byte[] right) = data.split(4);
+(byte[] left, byte[] right) = data.split(4);
 ```
 
 **Slice:**
@@ -1249,7 +1248,7 @@ function getPair(): (int, int) {
 }
 
 entry example(byte[32] data) {
-    (byte[16] left, byte[16] right) = data.split(16);
+    (byte[] left, byte[] right) = data.split(16);
     (int x, int y) = getPair();
 }
 ```
@@ -1284,19 +1283,18 @@ entry example() {
 
 **Split:**
 
-Divide `byte[]` into two parts at a given index. A constant index gives the
-left part a fixed size, while the right part remains dynamic unless the source
-also has a fixed size. The result is accessed like other tuple returns:
+Divide an array into two dynamic parts at a given index. Both parts retain the
+source array's element type. The result is accessed like other tuple returns:
 
 ```javascript
 byte[] data = byte[](0x1122334455667788);
 
 // Split at byte 4
-byte[4] left = data.split(4).0;  // 0x11223344
+byte[] left = data.split(4).0;   // 0x11223344
 byte[] right = data.split(4).1;  // 0x55667788
 
 // Destructure both parts with types
-(byte[4] a, byte[] b) = data.split(4);
+(byte[] a, byte[] b) = data.split(4);
 ```
 
 **Slice:**

--- a/silverscript-lang/src/compiler/compile/statement.rs
+++ b/silverscript-lang/src/compiler/compile/statement.rs
@@ -108,7 +108,7 @@ fn compile_param_size_validations<'i>(
             param.type_ref.base.fixed_byte_sequence_len()
         };
         let is_dynamic_array = param.type_ref.is_array() && exact_size.is_none();
-        if exact_size.is_none() && !is_dynamic_array && !param.type_ref.is_int() {
+        if exact_size.is_none() && !is_dynamic_array && !param.type_ref.is_int() && !param.type_ref.is_bool() {
             continue;
         }
 
@@ -130,11 +130,12 @@ fn compile_param_size_validations<'i>(
             builder.add_i64(0)?;
             builder.add_op(OpNumEqualVerify)?;
         } else {
-            // The int case.
-
-            // VM script numbers may use zero through eight bytes. Reject a
-            // ninth byte before any numeric opcode attempts to decode it.
-            builder.add_i64(9)?;
+            // VM script numbers may use zero through eight bytes. Bools use
+            // the empty encoding for false and a single byte for true. Reject
+            // wider values before their interpretation can depend on the
+            // opcode consuming them.
+            let exclusive_max_size = if param.type_ref.is_bool() { 2 } else { 9 };
+            builder.add_i64(exclusive_max_size)?;
             builder.add_op(OpLessThan)?;
             builder.add_op(OpVerify)?;
         }

--- a/silverscript-lang/src/compiler/inline_functions.rs
+++ b/silverscript-lang/src/compiler/inline_functions.rs
@@ -402,23 +402,43 @@ impl<'i, 'd> Inliner<'i, 'd> {
             lowered.extend(self.lower_statement(statement, &mut local_scope, visited_functions)?);
         }
 
-        if let (Some(bindings), Some(return_exprs)) = (bindings, return_exprs) {
-            for (binding, expr) in bindings.iter().zip(return_exprs.iter()) {
-                let (prelude, renamed_expr) = self.lower_expr(expr, &local_scope, visited_functions)?;
-                lowered.extend(prelude);
-                self.push_lowered_statement(
-                    &mut lowered,
-                    Statement::VariableDefinition {
-                        type_ref: binding.type_ref.clone(),
+        if let Some(return_exprs) = return_exprs {
+            if let Some(bindings) = bindings {
+                for (binding, expr) in bindings.iter().zip(return_exprs.iter()) {
+                    let (prelude, renamed_expr) = self.lower_expr(expr, &local_scope, visited_functions)?;
+                    lowered.extend(prelude);
+                    self.push_lowered_statement(
+                        &mut lowered,
+                        Statement::VariableDefinition {
+                            type_ref: binding.type_ref.clone(),
+                            modifiers: Vec::new(),
+                            name: binding.name.clone(),
+                            expr: Some(renamed_expr),
+                            span,
+                            type_span: binding.type_span,
+                            modifier_spans: Vec::new(),
+                            name_span: binding.name_span,
+                        },
+                    );
+                }
+            } else {
+                for (index, (return_type, expr)) in function.return_types.iter().zip(return_exprs).enumerate() {
+                    let (mut discard_body, renamed_expr) = self.lower_expr(expr, &local_scope, visited_functions)?;
+                    // A value-returning helper called as a statement still has to evaluate its return expressions:
+                    // they may fault or perform observable VM operations. Bind each unused result inside a block so
+                    // normal block cleanup explicitly drops it immediately after evaluation.
+                    discard_body.push(Statement::VariableDefinition {
+                        type_ref: return_type.clone(),
                         modifiers: Vec::new(),
-                        name: binding.name.clone(),
+                        name: self.fresh_visible_name(&format!("__discarded_return_{index}")),
                         expr: Some(renamed_expr),
-                        span,
-                        type_span: binding.type_span,
+                        span: expr.span,
+                        type_span: function.return_type_spans.get(index).copied().unwrap_or_default(),
                         modifier_spans: Vec::new(),
-                        name_span: binding.name_span,
-                    },
-                );
+                        name_span: span::Span::default(),
+                    });
+                    self.push_lowered_statement(&mut lowered, Statement::Block { body: discard_body, span: expr.span });
+                }
             }
         }
 

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -327,6 +327,12 @@ fn validate_function_signatures<'i>(
         }
 
         let has_return = function.body.iter().any(statement_contains_return);
+        if !function.return_types.is_empty() && !has_return {
+            return Err(CompilerError::Unsupported(format!(
+                "function '{}' declares return types but has no return statement",
+                function.name
+            )));
+        }
         if has_return {
             if !matches!(function.body.last(), Some(Statement::Return { .. })) {
                 return Err(CompilerError::Unsupported("return statement must be the last statement".to_string()));

--- a/silverscript-lang/src/compiler/structs/scalar_expr.rs
+++ b/silverscript-lang/src/compiler/structs/scalar_expr.rs
@@ -76,28 +76,30 @@ pub(super) fn lower_scalar_expr<'i>(
             Ok(Expr::new(ExprKind::Unary { op: *op, expr: Box::new(lower_scalar_expr(expr, scope, lowerer)?) }, span))
         }
         ExprKind::Binary { op, left, right } => {
-            if matches!(op, BinaryOp::Eq | BinaryOp::Ne)
-                && let ExprKind::Identifier(left_name) = &left.kind
-                && let Some(left_type) = scope.type_of(left_name)
-                && is_struct_array(left_type, structs)
-            {
-                if let ExprKind::Identifier(right_name) = &right.kind
-                    && scope.type_of(right_name).is_some_and(|right_type| right_type != left_type)
-                {
-                    return Err(CompilerError::Unsupported("struct array comparison requires matching types".to_string()));
+            if matches!(op, BinaryOp::Eq | BinaryOp::Ne) {
+                let left_type = struct_array_expr_type(left, scope, structs, lowerer.contract_constants)?;
+                let right_type = struct_array_expr_type(right, scope, structs, lowerer.contract_constants)?;
+                if let Some(expected_type) = left_type.as_ref().or(right_type.as_ref()) {
+                    if left_type
+                        .as_ref()
+                        .zip(right_type.as_ref())
+                        .is_some_and(|(left, right)| !type_refs_equal(left, right, lowerer.contract_constants))
+                    {
+                        return Err(CompilerError::Unsupported("struct array comparison requires matching types".to_string()));
+                    }
+                    let left_leaves = lower_struct_array_expr(left, expected_type, scope, lowerer)?;
+                    let right_leaves = lower_struct_array_expr(right, expected_type, scope, lowerer)?;
+                    let comparison_op = *op;
+                    let combination_op = if *op == BinaryOp::Eq { BinaryOp::And } else { BinaryOp::Or };
+                    let comparisons = left_leaves.into_iter().zip(right_leaves).map(|(left, right)| {
+                        Expr::new(ExprKind::Binary { op: comparison_op, left: Box::new(left), right: Box::new(right) }, span)
+                    });
+                    return comparisons
+                        .reduce(|left, right| {
+                            Expr::new(ExprKind::Binary { op: combination_op, left: Box::new(left), right: Box::new(right) }, span)
+                        })
+                        .ok_or_else(|| CompilerError::Unsupported("cannot compare empty struct arrays".to_string()));
                 }
-                let left_leaves = lower_struct_array_expr(left, left_type, scope, lowerer)?;
-                let right_leaves = lower_struct_array_expr(right, left_type, scope, lowerer)?;
-                let comparison_op = *op;
-                let combination_op = if *op == BinaryOp::Eq { BinaryOp::And } else { BinaryOp::Or };
-                let comparisons = left_leaves.into_iter().zip(right_leaves).map(|(left, right)| {
-                    Expr::new(ExprKind::Binary { op: comparison_op, left: Box::new(left), right: Box::new(right) }, span)
-                });
-                return comparisons
-                    .reduce(|left, right| {
-                        Expr::new(ExprKind::Binary { op: combination_op, left: Box::new(left), right: Box::new(right) }, span)
-                    })
-                    .ok_or_else(|| CompilerError::Unsupported("cannot compare empty struct arrays".to_string()));
             }
 
             Ok(Expr::new(
@@ -182,7 +184,7 @@ pub(super) fn lower_scalar_expr<'i>(
         )),
         ExprKind::UnarySuffix { source, kind, span: suffix_span } => {
             if matches!(kind, crate::ast::UnarySuffixKind::Length)
-                && let Some(type_ref) = struct_array_expr_type(source, scope, structs)
+                && let Some(type_ref) = struct_array_expr_type(source, scope, structs, lowerer.contract_constants)?
             {
                 let first_leaf = lower_struct_array_expr(source, &type_ref, scope, lowerer)?
                     .into_iter()
@@ -203,14 +205,26 @@ pub(super) fn lower_scalar_expr<'i>(
     }
 }
 
-fn struct_array_expr_type(expr: &Expr<'_>, scope: &LoweringScope, structs: &StructRegistry) -> Option<TypeRef> {
+fn struct_array_expr_type(
+    expr: &Expr<'_>,
+    scope: &LoweringScope,
+    structs: &StructRegistry,
+    constants: &HashMap<String, Expr<'_>>,
+) -> Result<Option<TypeRef>, CompilerError> {
     let type_ref = match &expr.kind {
         ExprKind::Identifier(name) => scope.type_of(name).cloned(),
         ExprKind::Array { type_ref, .. } => Some(type_ref.clone()),
-        ExprKind::Append { source, .. } | ExprKind::Split { source, .. } | ExprKind::Slice { source, .. } => {
-            struct_array_expr_type(source, scope, structs)
-        }
+        ExprKind::Append { source, args, .. } => struct_array_expr_type(source, scope, structs, constants)?
+            .and_then(|source_type| append_type(&source_type, args.len(), constants)),
+        ExprKind::Split { source, index, part, .. } => struct_array_expr_type(source, scope, structs, constants)?
+            .map(|source_type| crate::compiler::type_check::split_part_type(&source_type, index, *part, constants))
+            .transpose()?,
+        ExprKind::Slice { source, .. } => struct_array_expr_type(source, scope, structs, constants)?.and_then(|source_type| {
+            let mut element_type = source_type.array_element_type()?;
+            element_type.array_dims.push(ArrayDim::Dynamic);
+            Some(element_type)
+        }),
         _ => None,
-    }?;
-    is_struct_array(&type_ref, structs).then_some(type_ref)
+    };
+    Ok(type_ref.filter(|type_ref| is_struct_array(type_ref, structs)))
 }

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -49,7 +49,7 @@ pub(super) fn check_expr<'i>(
             let int_type = scalar_type(TypeBase::Int);
             check_expr(start, Some(&int_type), ctx)?;
             check_expr(end, Some(&int_type), ctx)?;
-            sequence_part_type(&source_type, "slice")?
+            slice_part_type(&source_type, start, end, ctx.constants)?
         }
         ExprKind::Append { source, args, .. } => {
             let source_type = check_expr(source, None, ctx)?;
@@ -562,20 +562,57 @@ fn sequence_part_type(type_ref: &TypeRef, operation: &str) -> Result<TypeRef, Co
     Err(CompilerError::Unsupported(format!("{operation} source must be an array, string, or fixed-byte type")))
 }
 
+fn known_sequence_length<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
+    array_type_size(type_ref, constants).or_else(|| type_ref.base.fixed_byte_sequence_len())
+}
+
+fn validate_constant_sequence_index<'i>(
+    operation: &str,
+    index_name: &str,
+    index: &Expr<'i>,
+    source_type: &TypeRef,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<Option<i64>, CompilerError> {
+    let Ok(index) = eval_const_int(index, constants) else { return Ok(None) };
+    if index < 0 {
+        return Err(CompilerError::Unsupported(format!("{operation} {index_name} {index} is out of bounds")));
+    }
+    if let Some(source_size) = known_sequence_length(source_type, constants)
+        && usize::try_from(index).is_ok_and(|index| index > source_size)
+    {
+        return Err(CompilerError::Unsupported(format!(
+            "{operation} {index_name} {index} is out of bounds for sequence of length {source_size}"
+        )));
+    }
+    Ok(Some(index))
+}
+
+fn slice_part_type<'i>(
+    source_type: &TypeRef,
+    start: &Expr<'i>,
+    end: &Expr<'i>,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<TypeRef, CompilerError> {
+    let result_type = sequence_part_type(source_type, "slice")?;
+    let start = validate_constant_sequence_index("slice", "start", start, source_type, constants)?;
+    let end = validate_constant_sequence_index("slice", "end", end, source_type, constants)?;
+    if let (Some(start), Some(end)) = (start, end)
+        && start > end
+    {
+        return Err(CompilerError::Unsupported(format!("slice start {start} is greater than end {end}")));
+    }
+    Ok(result_type)
+}
+
 pub(super) fn split_part_type<'i>(
     source_type: &TypeRef,
     index: &Expr<'i>,
     _part: SplitPart,
     constants: &HashMap<String, Expr<'i>>,
 ) -> Result<TypeRef, CompilerError> {
-    if let Ok(index) = eval_const_int(index, constants)
-        && let Some(source_size) = array_type_size(source_type, constants).or_else(|| source_type.base.fixed_byte_sequence_len())
-        && (index < 0 || usize::try_from(index).is_ok_and(|index| index > source_size))
-    {
-        return Err(CompilerError::Unsupported(format!("split index {index} is out of bounds for array of length {source_size}")));
-    }
-
-    sequence_part_type(source_type, "split")
+    let result_type = sequence_part_type(source_type, "split")?;
+    validate_constant_sequence_index("split", "index", index, source_type, constants)?;
+    Ok(result_type)
 }
 
 fn check_constructor<'i>(name: &str, args: &[Expr<'i>], ctx: &TypeCheckContext<'_, 'i>) -> Result<TypeRef, CompilerError> {

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -565,38 +565,17 @@ fn sequence_part_type(type_ref: &TypeRef, operation: &str) -> Result<TypeRef, Co
 pub(super) fn split_part_type<'i>(
     source_type: &TypeRef,
     index: &Expr<'i>,
-    part: SplitPart,
+    _part: SplitPart,
     constants: &HashMap<String, Expr<'i>>,
 ) -> Result<TypeRef, CompilerError> {
-    if source_type.is_string() {
-        return Ok(source_type.clone());
+    if let Ok(index) = eval_const_int(index, constants)
+        && let Some(source_size) = array_type_size(source_type, constants).or_else(|| source_type.base.fixed_byte_sequence_len())
+        && (index < 0 || usize::try_from(index).is_ok_and(|index| index > source_size))
+    {
+        return Err(CompilerError::Unsupported(format!("split index {index} is out of bounds for array of length {source_size}")));
     }
 
-    let (mut element_type, source_size) = if source_type.is_array() {
-        let element_type =
-            source_type.array_element_type().ok_or_else(|| CompilerError::Unsupported("split source must be an array".to_string()))?;
-        (element_type, array_type_size(source_type, constants))
-    } else if let Some(source_size) = source_type.base.fixed_byte_sequence_len() {
-        (scalar_type(TypeBase::Byte), Some(source_size))
-    } else {
-        return Err(CompilerError::Unsupported("split source must be an array, string, or fixed-byte type".to_string()));
-    };
-    let constant_index = eval_const_int(index, constants).ok().and_then(|value| usize::try_from(value).ok());
-    let dimension = match (constant_index, part) {
-        (Some(index), SplitPart::Left) => ArrayDim::Fixed(index),
-        (Some(index), SplitPart::Right) => match source_size {
-            Some(source_size) if index <= source_size => ArrayDim::Fixed(source_size - index),
-            Some(source_size) => {
-                return Err(CompilerError::Unsupported(format!(
-                    "split index {index} is out of bounds for array of length {source_size}"
-                )));
-            }
-            None => ArrayDim::Dynamic,
-        },
-        (None, _) => ArrayDim::Dynamic,
-    };
-    element_type.array_dims.push(dimension);
-    Ok(element_type)
+    sequence_part_type(source_type, "split")
 }
 
 fn check_constructor<'i>(name: &str, args: &[Expr<'i>], ctx: &TypeCheckContext<'_, 'i>) -> Result<TypeRef, CompilerError> {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -2418,6 +2418,55 @@ fn rejects_entrypoint_return_by_default() {
 }
 
 #[test]
+fn allowed_entrypoint_return_requires_a_return_statement() {
+    let source = r#"
+        contract EntryReturn() {
+            entry main() : int {
+                require(true);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions { allow_entrypoint_return: true, ..CompileOptions::default() })
+        .expect_err("a return-typed entrypoint must return a value");
+    assert!(err.to_string().contains("function 'main' declares return types but has no return statement"), "unexpected error: {err}");
+}
+
+#[test]
+fn allowed_entrypoint_return_checks_the_return_value_type() {
+    let source = r#"
+        contract EntryReturn() {
+            entry main() : int {
+                return false;
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions { allow_entrypoint_return: true, ..CompileOptions::default() })
+        .expect_err("an entrypoint return value must match its declared type");
+    assert!(err.to_string().contains("return value expects int"), "unexpected error: {err}");
+}
+
+#[test]
+fn helper_with_declared_return_type_requires_a_return_statement() {
+    let source = r#"
+        contract HelperReturn() {
+            function value() : int {
+                require(true);
+            }
+
+            entry main() {
+                value();
+                require(true);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("a return-typed helper must return a value");
+    assert!(err.to_string().contains("function 'value' declares return types but has no return statement"), "unexpected error: {err}");
+}
+
+#[test]
 fn build_sig_script_rejects_mismatched_bytes_length() {
     let source = r#"
         contract C() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -13358,7 +13358,7 @@ fn runs_split_on_non_byte_array() {
         contract SplitNonByteArray() {
             entry main() {
                 int[] values = int[]{10, 20, 30, 40};
-                (int[1] left, int[] right) = values.split(1);
+                (int[] left, int[] right) = values.split(1);
                 require(left.length == 1);
                 require(left[0] == 10);
                 require(right == int[]{20, 30, 40});
@@ -13391,13 +13391,13 @@ fn runtime_split_index_produces_dynamic_array_parts() {
 }
 
 #[test]
-fn constant_split_index_produces_fixed_left_and_dynamic_right_for_dynamic_source() {
+fn constant_split_index_produces_dynamic_parts_for_dynamic_source() {
     let source = r#"
         contract SplitConstantIndex() {
             int constant N = 2;
 
             entry main(int[] values) {
-                (int[N] left, int[] right) = values.split(N);
+                (int[] left, int[] right) = values.split(N);
                 require(left.length == 2);
                 require(left[0] == 10);
                 require(left[1] == 20);
@@ -13408,22 +13408,23 @@ fn constant_split_index_produces_fixed_left_and_dynamic_right_for_dynamic_source
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("constant split index should fix the left size");
+    let compiled =
+        compile_contract(source, &[], CompileOptions::default()).expect("constant split index should preserve dynamic parts");
     let sigscript = compiled.build_sig_script("main", vec![vec![10i64, 20, 30, 40].into()]).expect("sigscript builds");
     let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_ok(), "constant-index split of a dynamic source should execute successfully: {result:?}");
 }
 
 #[test]
-fn constant_split_index_produces_fixed_parts_for_fixed_source() {
+fn constant_split_index_produces_dynamic_parts_for_fixed_source() {
     let source = r#"
         contract SplitFixedSource() {
             int constant N = 1;
 
             entry main() {
                 int[4] values = int[4]{10, 20, 30, 40};
-                int[N] left = values.split(N).0;
-                int[3] right = values.split(N).1;
+                int[] left = values.split(N).0;
+                int[] right = values.split(N).1;
                 require(left.length == 1);
                 require(left[0] == 10);
                 require(right.length == 3);
@@ -13434,7 +13435,7 @@ fn constant_split_index_produces_fixed_parts_for_fixed_source() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("fixed source split should infer both sizes");
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("fixed source split should return dynamic parts");
     let result = run_bytecode_with_selector(compiled.bytecode, None);
     assert!(result.is_ok(), "constant-index split of a fixed source should execute successfully: {result:?}");
 }
@@ -13532,12 +13533,12 @@ fn runs_split_and_slice_on_struct_array() {
                     S {number: 20, tag: byte[_](0x0304)},
                     S {number: 30, tag: byte[_](0x0506)}
                 };
-                S[1] left = values.split(1).0;
+                S[] left = values.split(1).0;
                 S[] right = values.split(1).1;
                 S[] part = values.slice(1, 3);
 
                 require(left.length == 1);
-                require(left == S[_]{S {number: 10, tag: byte[_](0x0102)}});
+                require(left == S[]{S {number: 10, tag: byte[_](0x0102)}});
                 require(right == S[]{
                     S {number: 20, tag: byte[_](0x0304)},
                     S {number: 30, tag: byte[_](0x0506)}
@@ -13634,7 +13635,7 @@ fn struct_array_comparisons_accept_structured_expressions_on_either_side() {
                 require(S[]{S {value: 8}} != one);
                 require(S[]{S {value: 7}, S {value: 8}} == one.append(S {value: 8}));
                 require(S[]{S {value: 7}} == two.slice(0, 1));
-                require(S[_]{S {value: 7}} == two.split(1).0);
+                require(S[]{S {value: 7}} == two.split(1).0);
                 require(S[]{S {value: 7}} == identity(one));
 
                 require(one == S[]{S {value: 7}});
@@ -13657,9 +13658,9 @@ fn allows_sequence_operations_on_string_and_fixed_byte_types() {
         contract ByteSequenceOperations() {
             entry main(string text, pubkey publicKey, sig signature, datasig dataSignature) {
                 (string textLeft, string textRight) = text.split(1);
-                (byte[1] pubkeyLeft, byte[31] pubkeyRight) = publicKey.split(1);
-                (byte[1] sigLeft, byte[64] sigRight) = signature.split(1);
-                (byte[1] datasigLeft, byte[63] datasigRight) = dataSignature.split(1);
+                (byte[] pubkeyLeft, byte[] pubkeyRight) = publicKey.split(1);
+                (byte[] sigLeft, byte[] sigRight) = signature.split(1);
+                (byte[] datasigLeft, byte[] datasigRight) = dataSignature.split(1);
                 string textSlice = text.slice(0, 1);
                 byte[] pubkeySlice = publicKey.slice(0, 1);
                 byte[] sigSlice = signature.slice(0, 1);
@@ -13688,49 +13689,47 @@ fn runtime_split_index_produces_dynamic_parts_for_fixed_byte_types() {
 }
 
 #[test]
-fn infers_fixed_array_sizes_from_fixed_byte_split_parts() {
+fn fixed_byte_split_parts_are_dynamic_arrays() {
     let source = r#"
         contract InferredFixedByteSequenceSplit() {
             entry main(pubkey publicKey) {
-                byte[_] left = publicKey.split(4).0;
-                byte[_] right = publicKey.split(4).1;
+                byte[] left = publicKey.split(4).0;
+                byte[] right = publicKey.split(4).1;
                 require(left.length == 4);
                 require(right.length == 28);
             }
         }
     "#;
 
-    compile_contract(source, &[], CompileOptions::default())
-        .expect("inferred array declarations should use fixed-byte split result sizes");
+    compile_contract(source, &[], CompileOptions::default()).expect("fixed-byte split results should be dynamic byte arrays");
 }
 
 #[test]
-fn infers_fixed_array_size_for_tuple_split_binding() {
+fn inferred_tuple_split_binding_is_dynamic() {
     let source = r#"
         contract InferredTupleSplitBinding() {
             entry main(byte[] values) {
-                (byte[_] left, byte[] right) = values.split(4);
+                (byte[] left, byte[] right) = values.split(4);
                 require(left.length == 4);
             }
         }
     "#;
 
-    compile_contract(source, &[], CompileOptions::default())
-        .expect("an inferred tuple binding should use the corresponding split result size");
+    compile_contract(source, &[], CompileOptions::default()).expect("tuple split bindings should use dynamic arrays");
 }
 
 #[test]
-fn rejects_fixed_byte_split_bindings_that_do_not_match_inferred_sizes() {
+fn rejects_fixed_bindings_for_dynamic_split_parts() {
     let source = r#"
         contract FixedByteSequenceSplitMismatch() {
             entry main(pubkey publicKey) {
-                (byte[1] left, byte[30] right) = publicKey.split(1);
+                (byte[1] left, byte[31] right) = publicKey.split(1);
             }
         }
     "#;
 
     let err = compile_contract(source, &[], CompileOptions::default())
-        .expect_err("constant fixed-byte split parts must have their inferred sizes");
+        .expect_err("split parts are dynamic even when their runtime sizes are known");
     assert!(err.to_string().contains("type mismatch"), "unexpected error: {err}");
 }
 

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -5367,6 +5367,65 @@ fn runs_slice_reconstruction_and_compare_runtime_example() {
 }
 
 #[test]
+fn rejects_invalid_constant_slice_bounds() {
+    let cases = [
+        (
+            "dynamic array negative start",
+            "contract C() { entry main(int[] value) { int[] part = value.slice(-1, 0); } }",
+            "out of bounds",
+        ),
+        (
+            "dynamic array negative end",
+            "contract C() { entry main(int[] value) { int[] part = value.slice(0, -1); } }",
+            "out of bounds",
+        ),
+        ("slice start after end", "contract C() { entry main(int[] value) { int[] part = value.slice(2, 1); } }", "greater than end"),
+        (
+            "fixed array end beyond length",
+            "contract C() { entry main(int[4] value) { int[] part = value.slice(0, 5); } }",
+            "out of bounds",
+        ),
+        (
+            "fixed array start beyond length",
+            "contract C() { entry main(int[4] value, int end) { int[] part = value.slice(5, end); } }",
+            "out of bounds",
+        ),
+        (
+            "pubkey end beyond length",
+            "contract C() { entry main(pubkey value) { byte[] part = value.slice(0, 33); } }",
+            "out of bounds",
+        ),
+        ("sig end beyond length", "contract C() { entry main(sig value) { byte[] part = value.slice(0, 66); } }", "out of bounds"),
+        (
+            "datasig end beyond length",
+            "contract C() { entry main(datasig value) { byte[] part = value.slice(0, 65); } }",
+            "out of bounds",
+        ),
+    ];
+
+    for (case, source, expected) in cases {
+        let error = compile_contract(source, &[], CompileOptions::default()).expect_err(case);
+        assert!(error.to_string().contains(expected), "unexpected error for {case}: {error}");
+    }
+}
+
+#[test]
+fn allows_constant_slice_bounds_at_sequence_end() {
+    let source = r#"
+        contract SliceBoundary() {
+            entry main(int[4] values, pubkey publicKey, sig signature, datasig dataSignature) {
+                int[] arrayTail = values.slice(4, 4);
+                byte[] pubkeyTail = publicKey.slice(32, 32);
+                byte[] sigTail = signature.slice(65, 65);
+                byte[] datasigTail = dataSignature.slice(64, 64);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default()).expect("empty slices at a sequence's end should compile");
+}
+
+#[test]
 fn allows_concat_of_int_arrays_with_plus() {
     let source = r#"
         contract Arrays() {
@@ -13484,6 +13543,38 @@ fn constant_split_index_produces_dynamic_parts_for_fixed_source() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("fixed source split should return dynamic parts");
     let result = run_bytecode_with_selector(compiled.bytecode, None);
     assert!(result.is_ok(), "constant-index split of a fixed source should execute successfully: {result:?}");
+}
+
+#[test]
+fn rejects_constant_split_indices_outside_sequence_bounds() {
+    let cases = [
+        ("dynamic array negative index", "contract C() { entry main(int[] value) { int[] part = value.split(-1).0; } }"),
+        ("fixed array index beyond end", "contract C() { entry main(int[4] value) { int[] part = value.split(5).1; } }"),
+        ("pubkey index beyond end", "contract C() { entry main(pubkey value) { byte[] part = value.split(33).0; } }"),
+        ("sig index beyond end", "contract C() { entry main(sig value) { byte[] part = value.split(66).1; } }"),
+        ("datasig index beyond end", "contract C() { entry main(datasig value) { byte[] part = value.split(65).0; } }"),
+    ];
+
+    for (case, source) in cases {
+        let error = compile_contract(source, &[], CompileOptions::default()).expect_err(case);
+        assert!(error.to_string().contains("out of bounds"), "unexpected error for {case}: {error}");
+    }
+}
+
+#[test]
+fn allows_constant_split_indices_at_sequence_end() {
+    let source = r#"
+        contract SplitBoundary() {
+            entry main(int[4] values, pubkey publicKey, sig signature, datasig dataSignature) {
+                int[] arrayTail = values.split(4).1;
+                byte[] pubkeyTail = publicKey.split(32).1;
+                byte[] sigTail = signature.split(65).1;
+                byte[] datasigTail = dataSignature.split(64).1;
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default()).expect("splitting at a sequence's end should compile");
 }
 
 #[test]

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -4052,7 +4052,7 @@ fn compiles_function_call_assignment_and_verifies() {
 }
 
 #[test]
-fn compiles_function_call_statement_elides_unused_return_expression() {
+fn function_call_statement_evaluates_and_drops_unused_return_expression() {
     let source = r#"
         contract Calls() {
             function f(int a) : (int) {
@@ -4068,7 +4068,8 @@ fn compiles_function_call_statement_elides_unused_return_expression() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let selector = selector_for(&compiled, "main");
-    assert!(!compiled.bytecode.contains(&OpAdd), "unused inline return expressions should be elided entirely");
+    let asm = script_to_str(&compiled.bytecode).expect("script should stringify");
+    assert!(asm.contains("OpAdd OpDrop"), "unused inline return expression should be evaluated and dropped: {asm}");
     assert!(run_bytecode_with_selector(compiled.bytecode, selector).is_ok());
 }
 
@@ -9584,6 +9585,51 @@ fn value_returning_builtin_statement_discards_result() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("value-returning builtin statement should compile");
     let asm = script_to_str(&compiled.bytecode).expect("builtin statement script should stringify");
     assert!(asm.ends_with("OpSHA256 OpDrop OpTrue"), "builtin statement result should be discarded: {asm}");
+}
+
+#[test]
+fn discarded_helper_return_expressions_are_evaluated_and_dropped() {
+    let source = r#"
+        contract DiscardedHelperReturn() {
+            function hashes() : (byte[32], byte[32]) {
+                return(sha256(byte[]("first")), sha256(byte[]("second")));
+            }
+
+            entry main() {
+                hashes();
+                require(true);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("discarded helper returns should compile");
+    let asm = script_to_str(&compiled.bytecode).expect("script should stringify");
+    assert_eq!(asm.matches("OpSHA256").count(), 2, "both return expressions must be evaluated: {asm}");
+    assert_eq!(asm.matches("OpDrop").count(), 2, "both discarded return values must be dropped: {asm}");
+}
+
+#[test]
+fn discarded_nested_helper_return_expression_is_evaluated() {
+    let source = r#"
+        contract NestedDiscardedHelperReturn() {
+            function fail() : int {
+                return(1 / 0);
+            }
+
+            function outer() : int {
+                return(fail());
+            }
+
+            entry main() {
+                outer();
+                require(true);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("nested discarded return should compile");
+    let result = run_bytecode_with_selector(compiled.bytecode, None);
+    assert!(result.is_err(), "the nested discarded division by zero must execute");
 }
 
 fn assert_r0_type_error(source: &str, expected: &str) {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -9978,6 +9978,30 @@ fn canonicalizes_bool_comparison_operands_for_equality_and_inequality() {
         let body = script_builder()
             .add_op(OpOver)
             .unwrap()
+            .add_op(OpSize)
+            .unwrap()
+            .add_i64(2)
+            .unwrap()
+            .add_op(OpLessThan)
+            .unwrap()
+            .add_op(OpVerify)
+            .unwrap()
+            .add_op(OpDrop)
+            .unwrap()
+            .add_op(OpDup)
+            .unwrap()
+            .add_op(OpSize)
+            .unwrap()
+            .add_i64(2)
+            .unwrap()
+            .add_op(OpLessThan)
+            .unwrap()
+            .add_op(OpVerify)
+            .unwrap()
+            .add_op(OpDrop)
+            .unwrap()
+            .add_op(OpOver)
+            .unwrap()
             .add_op(OpOver)
             .unwrap()
             .add_op(OpNot)
@@ -11517,7 +11541,7 @@ fn entrypoint_int_argument_accepts_below_nine_bytes_and_rejects_nine() {
 }
 
 #[test]
-fn entrypoint_bool_argument_has_no_size_validation() {
+fn entrypoint_bool_argument_accepts_at_most_one_byte() {
     let source = r#"
         contract BoolSize() {
             entry main(bool value) {
@@ -11526,12 +11550,35 @@ fn entrypoint_bool_argument_has_no_size_validation() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("bool parameter should compile");
-    let expected =
-        script_builder().add_op(OpTrue).unwrap().add_op(OpVerify).unwrap().add_op(OpDrop).unwrap().add_op(OpTrue).unwrap().drain();
+    let expected = script_builder()
+        .add_op(OpDup)
+        .unwrap()
+        .add_op(OpSize)
+        .unwrap()
+        .add_i64(2)
+        .unwrap()
+        .add_op(OpLessThan)
+        .unwrap()
+        .add_op(OpVerify)
+        .unwrap()
+        .add_op(OpDrop)
+        .unwrap()
+        .add_op(OpTrue)
+        .unwrap()
+        .add_op(OpVerify)
+        .unwrap()
+        .add_op(OpDrop)
+        .unwrap()
+        .add_op(OpTrue)
+        .unwrap()
+        .drain();
     assert_eq!(compiled.bytecode, expected);
 
-    let oversized_bool = script_builder().add_data_with_push_opcode(&[1; 9]).unwrap().drain();
-    assert!(run_bytecode_with_sigscript(compiled.bytecode, oversized_bool).is_ok());
+    let sigscript = |size: usize| script_builder().add_data_with_push_opcode(&vec![1; size]).unwrap().drain();
+    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript(0)).is_ok());
+    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript(1)).is_ok());
+    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript(2)).is_err());
+    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript(9)).is_err());
 }
 
 #[test]

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -13617,6 +13617,41 @@ fn runs_struct_array_equality_and_inequality_comparisons() {
 }
 
 #[test]
+fn struct_array_comparisons_accept_structured_expressions_on_either_side() {
+    let source = r#"
+        contract StructArrayComparisonSymmetry() {
+            struct S { int value; }
+
+            function identity(S[] values): S[] {
+                return(values);
+            }
+
+            entry main() {
+                S[] one = S[]{S {value: 7}};
+                S[] two = S[]{S {value: 7}, S {value: 8}};
+
+                require(S[]{S {value: 7}} == one);
+                require(S[]{S {value: 8}} != one);
+                require(S[]{S {value: 7}, S {value: 8}} == one.append(S {value: 8}));
+                require(S[]{S {value: 7}} == two.slice(0, 1));
+                require(S[_]{S {value: 7}} == two.split(1).0);
+                require(S[]{S {value: 7}} == identity(one));
+
+                require(one == S[]{S {value: 7}});
+                require(one.append(S {value: 8}) == S[]{S {value: 7}, S {value: 8}});
+                require(two.slice(0, 1) == S[]{S {value: 7}});
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default())
+        .expect("struct-array comparisons should be symmetric for supported structured expressions");
+    let selector = selector_for(&compiled, "main");
+    let result = run_bytecode_with_selector(compiled.bytecode, selector);
+    assert!(result.is_ok(), "symmetric struct-array comparisons should execute successfully: {}", result.unwrap_err());
+}
+
+#[test]
 fn allows_sequence_operations_on_string_and_fixed_byte_types() {
     let source = r#"
         contract ByteSequenceOperations() {

--- a/silverscript-lang/tests/examples/double_split.sil
+++ b/silverscript-lang/tests/examples/double_split.sil
@@ -2,7 +2,7 @@ pragma silverscript ^0.1.0;
 
 contract DoubleSplit(byte[20] pkh) {
     entry spend() {
-        byte[_] actualPkh = tx.inputs[1].scriptPubKey.split(23).0.split(3).1;
+        byte[20] actualPkh = byte[20](tx.inputs[1].scriptPubKey.split(23).0.split(3).1);
         require(pkh == actualPkh);
     }
 }

--- a/silverscript-lang/tests/examples/hodl_vault.sil
+++ b/silverscript-lang/tests/examples/hodl_vault.sil
@@ -7,8 +7,7 @@ contract HodlVault(
     int priceTarget
 ) {
     entry spend(sig ownerSig, datasig oracleSig, byte[] oracleMessage) {
-        byte[_] blockHeightBin = oracleMessage.split(4).0;
-        byte[_] priceBin = byte[4](oracleMessage.split(4).1);
+        (byte[] blockHeightBin, byte[] priceBin) = oracleMessage.split(4);
         int blockHeight = int(blockHeightBin);
         int price = int(priceBin);
 

--- a/silverscript-lang/tests/examples/hodl_vault.sil
+++ b/silverscript-lang/tests/examples/hodl_vault.sil
@@ -8,8 +8,8 @@ contract HodlVault(
 ) {
     entry spend(sig ownerSig, datasig oracleSig, byte[] oracleMessage) {
         (byte[] blockHeightBin, byte[] priceBin) = oracleMessage.split(4);
-        int blockHeight = int(blockHeightBin);
-        int price = int(priceBin);
+        int blockHeight = int(byte[4](blockHeightBin));
+        int price = int(byte[4](priceBin));
 
         require(blockHeight >= minBlock);
         require(tx.time >= blockHeight);

--- a/silverscript-lang/tests/examples/split_or_slice_signature.sil
+++ b/silverscript-lang/tests/examples/split_or_slice_signature.sil
@@ -3,8 +3,8 @@ pragma silverscript ^0.1.0;
 contract Test(sig signature) {
     entry spend() {
         // Assume Schnorr
-        byte[_] hashtype1 = signature.split(64).1;
-        byte[1] hashtype2 = byte[1](signature.slice(64, 65));
+        byte[_] hashtype1 = byte[1](signature.split(64).1);
+        byte[_] hashtype2 = byte[1](signature.slice(64, 65));
         require(hashtype1 == byte[1](0x01));
         require(hashtype2 == byte[1](0x01));
     }

--- a/silverscript-lang/tests/examples/tuple_unpacking_parameter.sil
+++ b/silverscript-lang/tests/examples/tuple_unpacking_parameter.sil
@@ -2,7 +2,7 @@ pragma silverscript ^0.1.0;
 
 contract Test() {
     entry split(byte[32] b) {
-        (byte[16] x, byte[16] y) =  b.split(16);
+        (byte[] x, byte[] y) =  b.split(16);
         require(x == y);
     }
 }

--- a/silverscript-lang/tests/examples/tuple_unpacking_single_side_type.sil
+++ b/silverscript-lang/tests/examples/tuple_unpacking_single_side_type.sil
@@ -2,7 +2,7 @@ pragma silverscript ^0.1.0;
 
 contract Test() {
     entry split(byte[] b) {
-        (byte[16] x, byte[] y) = b.split(16);
+        (byte[] x, byte[] y) = b.split(16);
         require(byte[](x) == y);
     }
 }


### PR DESCRIPTION
 This PR closes several gaps between SilverScript’s static types and runtime behavior. It strengthens return validation and ABI decoding, preserves side effects from unused return values,
  standardizes sequence operation types, validates constant sequence bounds, and generalizes struct-array comparisons.

  ## Language Behavior Changes

  - Functions declaring return types must contain a return statement. This also applies to entrypoints when entrypoint returns are enabled.

  - Runtime `bool` entrypoint arguments must use at most one byte. Wider stack values are rejected before the entrypoint body executes.

  - Calling a value-returning function as a statement still evaluates its return expressions. Any resulting values are discarded afterward, preserving faults and other observable operations.

  ```sil
  function read(): int {
      return potentiallyFailingOperation();
  }

  entry main() {
      read(); // still executes the return expression
  }
  ```

  - `split(n)` preserves the source element type and returns two dynamic parts:

  ```sil
  S[] values = S[]{...};
  (S[] left, S[] right) = values.split(1);
  ```

  For fixed-byte sequences such as `pubkey`, `sig`, and `datasig`, each result is `byte[]`.

  - `slice(start, end)` similarly returns a dynamic array with the source element type. Slicing a fixed-byte sequence returns `byte[]`.

  - Compile-time-known `split` and `slice` bounds are rejected when they are negative or exceed a statically known sequence length. A slice whose constant start is greater than its end is
  also rejected.

  ```sil
  entry main(byte[4] data) {
      byte[] invalid = data.slice(3, 2); // compile-time error
      data.split(5);                     // compile-time error
  }
  ```

  - Struct-array equality and inequality now work with general structured expressions on either side, rather than requiring a plain identifier.

  ```sil
  require(values.append(item) == expected);
  require(values.slice(0, 2) != other);
  ```

  Both operands must still have matching struct-array types.

  - The tutorial now documents representation-preserving casts as unchecked type assertions. Dynamic values cast to `byte[N]`, `pubkey`, `sig`, or `datasig` must be explicitly validated by
  the contract when runtime size or format matters.

  ```sil
  require(data.length == 32);
  byte[32] hash = byte[32](data);
  ```
