### PR TITLE
  Harden constant, state, comparison, and loop semantics

### DIFF
--- a/UNDEFINED-BEHAVIOUR.md
+++ b/UNDEFINED-BEHAVIOUR.md
@@ -1,0 +1,361 @@
+# Undefined behaviour
+
+SilverScript has undefined behaviour when a source operation reaches a case
+outside the language's defined semantics. The compiler is not required to
+reject such a contract.
+
+Undefined behaviour is not guaranteed to make execution fail. The compiler
+may remove, replace, fold, or avoid evaluating a statement, expression, or
+subexpression which would encounter undefined behaviour. If the resulting
+contract completes successfully, its result is `true` and the spend succeeds.
+It is also permitted to fail. Intermediate expression values are not
+specified.
+
+In particular, a contract must never use undefined behaviour as an implicit
+check which it expects to reject a transaction. A failure caused only by
+undefined behaviour is not an observable side effect whose evaluation the
+compiler must preserve.
+
+For example, the compiler may remove the unused definition below, including
+the division. The contract is permitted to succeed:
+
+```sil
+contract C() {
+    entry main() {
+        int unused = 1 / 0;
+        require(true);
+    }
+}
+```
+
+Before relying on an operation's result, the contract must validate all
+run-time values needed to satisfy the preconditions below. A failed `require`,
+an unsatisfied time constraint, an explicit termination, or a failed
+zero-knowledge proof is an intentional validation failure and is not
+classified as undefined behaviour here.
+
+## Integer expressions
+
+Run-time integers must be representable by the script integer format. In
+practice, an integer used by a numeric expression must fit in at most eight
+signed-magnitude bytes. The value `-2^63` is therefore not a usable run-time
+integer, even though it fits in Rust's `i64` type.
+
+The following cases are undefined behaviour:
+
+- Unary negation when the result is not representable.
+- Integer addition, subtraction, or multiplication when the result is not
+  representable.
+- Division when the divisor is zero, or when the result is not representable.
+- Remainder (`%`) when the divisor is zero.
+- Numeric, comparison, or boolean expressions applied to a value whose actual
+  run-time representation is not a valid integer for that operation. This can
+  happen after a cast which asserts a type without validating the bytes.
+
+For example, `b` must be checked before the division:
+
+```sil
+entry main(int a, int b) {
+    require(b != 0);
+    int quotient = a / b;
+}
+```
+
+Arithmetic overflow must likewise be ruled out by the contract's accepted
+input range:
+
+```sil
+entry main(int a, int b) {
+    // Undefined if the mathematical sum is outside the supported range.
+    int sum = a + b;
+}
+```
+
+Converting an integer to `byte[N]` is undefined if the value does not fit in
+exactly `N` signed-magnitude bytes. The same requirement applies when an
+integer is encoded as an element of `int[]` or as an integer state field.
+
+```sil
+entry main(int value) {
+    // Undefined when value cannot be represented in two bytes.
+    byte[2] encoded = value as byte[2];
+}
+```
+
+The low-level forms which convert bytes to an integer or request a run-time
+integer encoding width have the corresponding requirements: the input must be
+at most eight bytes, the requested width must be between zero and eight, and
+the integer must fit in the requested width.
+
+## Arrays, strings, and fixed-byte values
+
+### Evaluation and fixed lengths
+
+When the size of a value is known statically, the compiler may replace
+`.length` with that size without evaluating the value used as its receiver.
+Expressions inside an array literal are therefore not guaranteed to run when
+only the array's fixed length is observed.
+
+```sil
+contract C() {
+    entry main() {
+        // The length may be folded to 1 and the division omitted.
+        require(int[1]{1 / 0}.length == 1);
+    }
+}
+```
+
+The same optimization freedom applies when the fixed-size value is reached
+through a constant, cast, function result, conditional expression, or another
+compound expression.
+
+### Indexing
+
+For `value[index]`, `index` must be non-negative and strictly less than
+`value.length`. This applies to every array element type, including arrays of
+structs and multidimensional arrays.
+
+```sil
+entry main(byte[] data, int index) {
+    require(index >= 0);
+    require(index < data.length);
+    byte selected = data[index];
+}
+```
+
+### Struct arrays
+
+A struct array is represented by a separate encoded array for every scalar
+leaf of the struct. Nested struct fields therefore produce additional leaf
+arrays. A valid struct-array value must satisfy both of these conditions:
+
+- Every leaf array contains the same number of struct elements.
+- Every leaf array's byte length is a multiple of that leaf's encoded element
+  size.
+
+Supplying or producing a struct array which violates either condition, and
+then using it as a struct array, is undefined behaviour. This includes field
+access, indexing, assignment, function arguments and returns, `.split()`,
+`.slice()`, and `.append()`.
+
+The value of `items.length` may be obtained from only one leaf. It does not
+validate the cardinality of the other leaves. Consequently, checking
+`items.length` before indexing is insufficient unless the external encoding
+or the code which constructed `items` already guarantees that all leaves have
+matching cardinalities.
+
+```sil
+struct Item { int number; byte[2] tag; }
+
+entry main(Item[] items) {
+    // Suppose the encoded `number` leaf contains one element while the
+    // encoded `tag` leaf is empty. This check may still pass because length
+    // can be derived from the `number` leaf.
+    require(items.length == 1);
+
+    // This is undefined: the complete Item at index zero does not exist.
+    // Execution may fail, but it is not guaranteed to fail; if it returns,
+    // the contract result is true.
+    Item first = items[0];
+}
+```
+
+Only the leaf used to determine the length needs to be retained. Expressions
+which construct other leaves may be omitted entirely:
+
+```sil
+contract C() {
+    struct Item { int safe; int checked; }
+
+    entry main() {
+        // The `safe` leaf is enough to determine the length. Construction of
+        // the `checked` leaf, including its division, may be optimized away.
+        require(Item[]{Item {safe: 1, checked: 1 / 0}}.length == 1);
+    }
+}
+```
+
+Neither malformed leaf cardinality nor an undefined expression in an omitted
+leaf is guaranteed to cause failure. If the resulting contract completes, its
+result is `true`.
+
+### Splitting
+
+For `value.split(index)`, the index must satisfy
+`0 <= index <= value.length`. An index equal to the length is allowed and
+produces an empty right part.
+
+```sil
+entry main(byte[] data, int index) {
+    require(index >= 0);
+    require(index <= data.length);
+    (byte[] left, byte[] right) = data.split(index);
+}
+```
+
+### Slicing
+
+For `value.slice(start, end)`, the bounds must satisfy
+`0 <= start <= end <= value.length`. The end is exclusive.
+
+```sil
+entry main(byte[] data, int start, int end) {
+    require(start >= 0);
+    require(start <= end);
+    require(end <= data.length);
+    byte[] part = data.slice(start, end);
+}
+```
+
+These split and slice rules also apply to strings, fixed-byte values such as
+public keys and signatures, arrays whose elements occupy multiple bytes, and
+arrays of structs. Bounds are counted in source-level elements, not bytes.
+
+### Bitwise expressions
+
+Both operands of byte-array `&`, `|`, and `^` expressions must have the same
+run-time byte length. Equal dynamic types alone do not guarantee equal lengths.
+
+```sil
+entry main(byte[] a, byte[] b) {
+    require(a.length == b.length);
+    byte[] combined = a ^ b;
+}
+```
+
+### Concatenation, literals, and append
+
+A run-time array literal, string or array concatenation, and `.append()` must
+not create a single encoded value larger than the execution environment's
+maximum element size. The current limit is 1,000,000 bytes.
+
+```sil
+entry main(byte[] prefix, byte[] suffix) {
+    // The caller must ensure the combined value remains within the limit.
+    byte[] combined = prefix + suffix;
+    byte[] extended = combined.append(byte(0xff));
+}
+```
+
+The same limit applies to the encoded leaves of struct arrays and to temporary
+values created while constructing or replacing structs.
+
+### Cast layout assumptions
+
+Casts between byte-backed types assert that the source already has the target
+layout; they do not necessarily validate that layout at run time. Any later
+index, split, slice, bitwise expression, signature check, or state operation is
+undefined if that assertion was false.
+
+```sil
+entry main(byte[] raw) {
+    byte[4] claimed = byte[4](raw);
+    // Undefined unless raw really contained four bytes.
+    byte last = claimed[3];
+}
+```
+
+## Transaction and state expressions
+
+Every expression which selects a transaction input or output requires a
+non-negative index below the corresponding transaction count. This applies to
+value, script-public-key, signature-script, outpoint, sequence, DAA-score,
+coinbase, covenant-id, and related lookups.
+
+```sil
+entry main(int inputIndex, int outputIndex) {
+    require(inputIndex >= 0);
+    require(inputIndex < tx.inputs.length);
+    require(outputIndex >= 0);
+    require(outputIndex < tx.outputs.length);
+
+    int inputValue = tx.inputs[inputIndex].value;
+    int outputValue = tx.outputs[outputIndex].value;
+}
+```
+
+Low-level transaction substring expressions additionally require
+`0 <= start <= end <= selectedValue.length`. A selected substring must also
+fit within the maximum element size.
+
+Expressions which select the `k`th authorizing output, covenant input, or
+covenant output require `k` to be non-negative and below the corresponding
+count. The input index used for an authorizing-output lookup must itself be a
+valid transaction input index.
+
+State-reading expressions require both a valid input index and an input whose
+signature script contains the expected contract and state layout. Template
+prefix and suffix lengths must be non-negative, must describe ranges within
+the actual script, and must not overflow while offsets are calculated.
+
+```sil
+entry main(int inputIndex) {
+    require(inputIndex >= 0);
+    require(inputIndex < tx.inputs.length);
+    State previous = readInputState(inputIndex);
+}
+```
+
+The same rules apply to `readInputStateWithTemplate`. In addition, its supplied
+template lengths must match the template layout used by the selected input.
+
+Output-state validation requires a valid output index. Variants which obtain a
+template from an input also require a valid template-input index and valid
+template ranges. State values must be encodable in their declared layouts, and
+the reconstructed script must stay within the maximum element size.
+
+```sil
+entry main(int outputIndex, int nextValue) {
+    require(outputIndex >= 0);
+    require(outputIndex < tx.outputs.length);
+    validateOutputState(outputIndex, State { value: nextValue });
+}
+```
+
+A chain-block sequence-commit lookup is undefined when the supplied block is
+unknown or already pruned, is not in the selected chain, or is deeper than the
+available commitment window.
+
+## Cryptographic expressions
+
+Signature-checking expressions require structurally valid signatures and
+public keys. A structurally valid but cryptographically incorrect signature
+evaluates to `false`; malformed encoding, an unsupported signature hash type,
+or a malformed public key is undefined behaviour. Message-signature checks
+also require a digest of the required length.
+
+```sil
+entry main(byte[] rawSignature, byte[] rawKey) {
+    // These casts assert the layouts. The caller must supply valid encodings.
+    sig signature = sig(rawSignature);
+    pubkey key = pubkey(rawKey);
+    bool valid = checkSig(signature, key);
+}
+```
+
+For keyed hashing, the Blake2b key must be at most 64 bytes and the Blake3 key
+must be exactly 32 bytes. A cast to a fixed-size key does not make a value with
+the wrong run-time length valid.
+
+```sil
+entry main(byte[] data, byte[] key) {
+    require(key.length <= 64);
+    byte[32] digest = blake2bWithKey(data, key);
+}
+```
+
+## Loops
+
+A run-time `for` range uses integer subtraction to validate its range and
+integer addition to advance it. Both `end - start` and every increment through
+the final iteration must remain representable. The loop body inherits all
+other undefined-behaviour rules in this document.
+
+```sil
+entry main(int start, int end) {
+    // The accepted bounds must also rule out arithmetic overflow.
+    for (i, start, end, 100) {
+        require(i >= start);
+    }
+}
+```

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -408,6 +408,11 @@ bool gt = (a > b);    // true (greater than)
 bool ge = (a >= b);   // true (greater than or equal)
 ```
 
+The ordered operators `<`, `<=`, `>`, and `>=` accept only `int` operands.
+Convert a `byte` explicitly with `unsigned(byteValue)` or `signed(byteValue)`
+before ordering it. Equality and inequality remain available for other
+compatible types.
+
 ### Logical Operators
 
 ```javascript

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -734,6 +734,19 @@ require(z.length == 3);
 require(z[2] == byte[2](0x0506));
 ```
 
+**Array comparison:**
+
+`==` and `!=` are supported only when the array's base type has an unambiguous
+byte representation:
+
+- byte arrays at any supported dimension, such as `byte[]`, `byte[32][]`, and
+  `byte[2][3]`;
+- arrays of fixed-byte sequence types (`pubkey`, `sig`, and `datasig`), including
+  multidimensional forms such as `pubkey[2][]`.
+
+Arrays of `int`, `bool`, structs, and other element types cannot be compared as
+whole values. Compare their lengths and elements explicitly instead.
+
 ### String Operations
 
 **Concatenation:**

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1270,14 +1270,7 @@ contract MyContract() {
 }
 ```
 
-Constants can also be declared inside functions:
-
-```javascript
-entry example() {
-    string constant greeting = "Hello";
-    require(sha256(byte[](greeting)) != byte[32](0x0000000000000000000000000000000000000000000000000000000000000000));
-}
-```
+Constants can only be declared at contract level.
 
 ### Tuple Unpacking
 

--- a/silverscript-lang/src/compiler/compile/expression.rs
+++ b/silverscript-lang/src/compiler/compile/expression.rs
@@ -657,12 +657,11 @@ fn compile_length_expr<'i>(ctx: &mut CompileExprContext<'_, '_, 'i>, expr: &Expr
     Ok(())
 }
 
-fn is_byte_encoded_type(type_ref: &TypeRef) -> bool {
-    type_ref.is_array() || type_ref.is_byte() || type_ref.is_string() || type_ref.base.fixed_byte_sequence_len().is_some()
-}
-
 fn uses_bytewise_equality(type_ref: &TypeRef) -> bool {
-    is_byte_encoded_type(type_ref)
+    type_ref.is_byte()
+        || type_ref.is_string()
+        || type_ref.base.fixed_byte_sequence_len().is_some()
+        || (type_ref.is_array() && (matches!(type_ref.base, TypeBase::Byte) || type_ref.base.fixed_byte_sequence_len().is_some()))
 }
 
 fn uses_concat_for_add(type_ref: &TypeRef) -> bool {

--- a/silverscript-lang/src/compiler/compile/expression.rs
+++ b/silverscript-lang/src/compiler/compile/expression.rs
@@ -182,6 +182,7 @@ fn compile_array_literal_element<'i>(
         }
         (TypeBase::Bool, []) => {
             compile_expr_with_context(ctx, value, Some(element_type))?;
+            ctx.emit_op(Op0NotEqual, 0)?;
             ctx.push_int(1)?;
             ctx.emit_op(OpNum2Bin, -1)?;
             Ok(())
@@ -380,11 +381,9 @@ fn compile_binary_expr<'i>(
 
     if bool_eq {
         // Normalize operands to 0 or 1, so that we can use OpNumEqual and OpNumNotEqual for both equality and inequality.
-        ctx.emit_op(OpNot, 0)?;
-        ctx.emit_op(OpNot, 0)?;
+        ctx.emit_op(Op0NotEqual, 0)?;
         ctx.emit_op(OpSwap, 0)?;
-        ctx.emit_op(OpNot, 0)?;
-        ctx.emit_op(OpNot, 0)?;
+        ctx.emit_op(Op0NotEqual, 0)?;
     }
 
     match op {

--- a/silverscript-lang/src/compiler/for.rs
+++ b/silverscript-lang/src/compiler/for.rs
@@ -94,18 +94,44 @@ impl<'a, 'i> ForLowerer<'a, 'i> {
         }
 
         let lowered_body = self.lower_block(body)?;
+        // Runtime bound expressions establish the loop range at entry. Keep
+        // their values stable even if the body mutates variables they read.
+        let start_name = self.fresh_name(&format!("{ident}_start"));
+        let end_name = self.fresh_name(&format!("{ident}_end"));
         let accumulator_name = self.fresh_name(ident);
         let accumulator_type_ref = TypeRef { base: TypeBase::Int, array_dims: Vec::new() };
-        let mut lowered = vec![Statement::VariableDefinition {
-            type_ref: accumulator_type_ref.clone(),
-            modifiers: Vec::new(),
-            name: accumulator_name.clone(),
-            expr: Some(start.clone()),
-            span,
-            type_span: ident_span,
-            modifier_spans: Vec::new(),
-            name_span: ident_span,
-        }];
+        let mut lowered = vec![
+            Statement::VariableDefinition {
+                type_ref: accumulator_type_ref.clone(),
+                modifiers: Vec::new(),
+                name: start_name.clone(),
+                expr: Some(start.clone()),
+                span,
+                type_span: ident_span,
+                modifier_spans: Vec::new(),
+                name_span: ident_span,
+            },
+            Statement::VariableDefinition {
+                type_ref: accumulator_type_ref.clone(),
+                modifiers: Vec::new(),
+                name: end_name.clone(),
+                expr: Some(end.clone()),
+                span,
+                type_span: ident_span,
+                modifier_spans: Vec::new(),
+                name_span: ident_span,
+            },
+            Statement::VariableDefinition {
+                type_ref: accumulator_type_ref.clone(),
+                modifiers: Vec::new(),
+                name: accumulator_name.clone(),
+                expr: Some(Expr::identifier(&start_name)),
+                span,
+                type_span: ident_span,
+                modifier_spans: Vec::new(),
+                name_span: ident_span,
+            },
+        ];
 
         // This is a sanity check to prevent situations where end-start > max_iterations.
         // TODO: Consider moving check to debug-mode compilation.
@@ -114,7 +140,11 @@ impl<'a, 'i> ForLowerer<'a, 'i> {
                 ExprKind::Binary {
                     op: BinaryOp::Le,
                     left: Box::new(Expr::new(
-                        ExprKind::Binary { op: BinaryOp::Sub, left: Box::new(end.clone()), right: Box::new(start.clone()) },
+                        ExprKind::Binary {
+                            op: BinaryOp::Sub,
+                            left: Box::new(Expr::identifier(&end_name)),
+                            right: Box::new(Expr::identifier(&start_name)),
+                        },
                         span,
                     )),
                     right: Box::new(Expr::int(max_iterations)),
@@ -131,7 +161,7 @@ impl<'a, 'i> ForLowerer<'a, 'i> {
                 ExprKind::Binary {
                     op: BinaryOp::Lt,
                     left: Box::new(Expr::identifier(&accumulator_name)),
-                    right: Box::new(end.clone()),
+                    right: Box::new(Expr::identifier(&end_name)),
                 },
                 span,
             );

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -181,6 +181,7 @@ pub(super) fn static_check_contract<'i>(
     for (param, value) in contract.params.iter().zip(constructor_args) {
         constants.insert(param.name.clone(), value.clone());
     }
+    validate_constant_initializers(contract, &structs, &constants)?;
     validate_contract_field_initializers(contract, &structs, &constants)?;
     validate_function_signatures(contract, &structs, &constants, options)?;
 
@@ -191,6 +192,44 @@ pub(super) fn static_check_contract<'i>(
         {
             return Err(CompilerError::Unsupported(format!("constructor argument '{}' expects {}", param.name, param_type_name)));
         }
+    }
+
+    Ok(())
+}
+
+fn validate_constant_initializers<'i>(
+    contract: &ContractAst<'i>,
+    structs: &StructRegistry,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<(), CompilerError> {
+    let mut types = HashMap::new();
+    for param in &contract.params {
+        types.insert(param.name.clone(), param.type_ref.clone());
+    }
+    for constant in &contract.constants {
+        types.insert(constant.name.clone(), constant.type_ref.clone());
+    }
+    let functions = contract.functions.iter().map(|function| (function.name.clone(), function)).collect::<HashMap<_, _>>();
+
+    for constant in &contract.constants {
+        let type_name = constant.type_ref.type_name();
+        ensure_array_elements_have_known_size(&constant.type_ref, structs, constants, &type_name)
+            .map_err(|err| err.with_span(&constant.type_span))?;
+        validate_expr_matches_type(&constant.expr, &constant.type_ref, &types, structs, constants, &functions, &contract.fields)
+            .map_err(|err| {
+                map_declared_type_error(
+                    err,
+                    "constant",
+                    &constant.name,
+                    &type_name,
+                    &constant.expr,
+                    &constant.type_ref,
+                    &types,
+                    structs,
+                    constants,
+                )
+                .with_span(&constant.expr.span)
+            })?;
     }
 
     Ok(())

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -79,7 +79,14 @@ fn validate_statement_declaration_names<'i>(
 ) -> Result<(), CompilerError> {
     for statement in statements {
         match statement {
-            Statement::VariableDefinition { name, name_span, .. } => insert_variable_name(names, name, name_span)?,
+            Statement::VariableDefinition { name, name_span, modifiers, modifier_spans, .. } => {
+                if let Some(index) = modifiers.iter().position(|modifier| modifier == "constant") {
+                    let modifier_span = modifier_spans.get(index).unwrap_or(name_span);
+                    return Err(CompilerError::Unsupported("constant declarations are only allowed at contract level".to_string())
+                        .with_span(modifier_span));
+                }
+                insert_variable_name(names, name, name_span)?;
+            }
             Statement::TupleAssignment { left_name, left_name_span, right_name, right_name_span, .. } => {
                 insert_variable_name(names, left_name, left_name_span)?;
                 insert_variable_name(names, right_name, right_name_span)?;
@@ -342,6 +349,7 @@ fn validate_function_signatures<'i>(
         }
     }
     let functions = contract.functions.iter().map(|function| (function.name.clone(), function)).collect::<HashMap<_, _>>();
+    let constant_names = contract.constants.iter().map(|constant| constant.name.clone()).collect::<HashSet<_>>();
 
     for function in &contract.functions {
         if function.entrypoint {
@@ -393,6 +401,7 @@ fn validate_function_signatures<'i>(
             constants,
             &functions,
             &contract.fields,
+            &constant_names,
         )?;
     }
 
@@ -432,8 +441,10 @@ fn validate_statement_shapes<'i>(
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
     contract_fields: &[ContractFieldAst<'i>],
+    constant_names: &HashSet<String>,
 ) -> Result<(), CompilerError> {
-    let mut ctx = ValidateStatementShapesContext { types, return_types, structs, constants, functions, contract_fields };
+    let mut ctx =
+        ValidateStatementShapesContext { types, return_types, structs, constants, functions, contract_fields, constant_names };
 
     for stmt in statements {
         match stmt {
@@ -457,7 +468,7 @@ fn validate_statement_shapes<'i>(
             Statement::Require { expr, .. } => validate_require_statement_shape(&mut ctx, expr)?,
             Statement::TimeOp { expr, .. } => validate_time_op_statement_shape(&mut ctx, expr)?,
             Statement::Console { args, .. } => validate_console_statement_shape(&mut ctx, args)?,
-            Statement::Assign { name, expr, .. } => validate_assign_statement_shape(&mut ctx, name, expr)?,
+            Statement::Assign { name, expr, name_span, .. } => validate_assign_statement_shape(&mut ctx, name, expr, name_span)?,
             Statement::Block { body, .. } => validate_block_statement_shape(&mut ctx, body)?,
             Statement::If { condition, then_branch, else_branch, .. } => {
                 validate_if_statement_shape(&mut ctx, condition, then_branch, else_branch.as_deref())?
@@ -478,6 +489,7 @@ struct ValidateStatementShapesContext<'a, 'i> {
     constants: &'a HashMap<String, Expr<'i>>,
     functions: &'a HashMap<String, &'a FunctionAst<'i>>,
     contract_fields: &'a [ContractFieldAst<'i>],
+    constant_names: &'a HashSet<String>,
 }
 
 impl<'a, 'i> ValidateStatementShapesContext<'a, 'i> {
@@ -747,7 +759,14 @@ fn validate_assign_statement_shape<'i>(
     ctx: &mut ValidateStatementShapesContext<'_, 'i>,
     name: &str,
     expr: &Expr<'i>,
+    name_span: &span::Span<'i>,
 ) -> Result<(), CompilerError> {
+    if ctx.constant_names.contains(name) {
+        return Err(CompilerError::Unsupported(format!("cannot assign to contract constant '{name}'")).with_span(name_span));
+    }
+    if ctx.contract_fields.iter().any(|field| field.name == name) {
+        return Err(CompilerError::Unsupported(format!("cannot assign to state field '{name}'")).with_span(name_span));
+    }
     if let Some(type_ref) = ctx.types.get(name).cloned() {
         let type_name = type_ref.type_name();
         ctx.check_expr(expr, Some(&type_ref)).map_err(|err| {
@@ -773,6 +792,7 @@ fn validate_if_statement_shape<'i>(
         ctx.constants,
         ctx.functions,
         ctx.contract_fields,
+        ctx.constant_names,
     )?;
     if let Some(else_branch) = else_branch {
         let mut else_types = ctx.types.clone();
@@ -784,6 +804,7 @@ fn validate_if_statement_shape<'i>(
             ctx.constants,
             ctx.functions,
             ctx.contract_fields,
+            ctx.constant_names,
         )?;
     }
     Ok(())
@@ -794,7 +815,16 @@ fn validate_block_statement_shape<'i>(
     body: &[Statement<'i>],
 ) -> Result<(), CompilerError> {
     let mut block_types = ctx.types.clone();
-    validate_statement_shapes(body, &mut block_types, ctx.return_types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
+    validate_statement_shapes(
+        body,
+        &mut block_types,
+        ctx.return_types,
+        ctx.structs,
+        ctx.constants,
+        ctx.functions,
+        ctx.contract_fields,
+        ctx.constant_names,
+    )
 }
 
 fn validate_for_statement_shape<'i>(
@@ -811,7 +841,16 @@ fn validate_for_statement_shape<'i>(
     ctx.check_expr(max_iterations, Some(&int_type))?;
     let mut body_types = ctx.types.clone();
     body_types.insert(ident.to_string(), int_type);
-    validate_statement_shapes(body, &mut body_types, ctx.return_types, ctx.structs, ctx.constants, ctx.functions, ctx.contract_fields)
+    validate_statement_shapes(
+        body,
+        &mut body_types,
+        ctx.return_types,
+        ctx.structs,
+        ctx.constants,
+        ctx.functions,
+        ctx.contract_fields,
+        ctx.constant_names,
+    )
 }
 
 fn validate_struct_destructure_bindings<'i>(

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -439,7 +439,15 @@ fn check_binary<'i>(
         })?
     };
     match op {
-        BinaryOp::Eq | BinaryOp::Ne => Ok(scalar_type(TypeBase::Bool)),
+        BinaryOp::Eq | BinaryOp::Ne => {
+            if left_type.is_array() && !supports_array_comparison(&left_type) {
+                return Err(CompilerError::Unsupported(format!(
+                    "array comparison is only supported for byte arrays and arrays of fixed-byte sequence types, got {}",
+                    left_type.type_name()
+                )));
+            }
+            Ok(scalar_type(TypeBase::Bool))
+        }
         BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => {
             let left_is_numeric = left_type.is_int() || left_type.is_byte();
             let right_is_numeric = right_type.is_int() || right_type.is_byte();
@@ -490,6 +498,10 @@ fn check_binary<'i>(
             Ok(int_type)
         }
     }
+}
+
+fn supports_array_comparison(type_ref: &TypeRef) -> bool {
+    matches!(type_ref.base, TypeBase::Byte) || type_ref.base.fixed_byte_sequence_len().is_some()
 }
 
 fn check_struct_literal<'i>(

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -449,11 +449,9 @@ fn check_binary<'i>(
             Ok(scalar_type(TypeBase::Bool))
         }
         BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => {
-            let left_is_numeric = left_type.is_int() || left_type.is_byte();
-            let right_is_numeric = right_type.is_int() || right_type.is_byte();
-            if !left_is_numeric || !right_is_numeric {
+            if !left_type.is_int() || !right_type.is_int() {
                 return Err(CompilerError::Unsupported(format!(
-                    "ordered comparison requires numeric operands, got {} and {}",
+                    "ordered comparison requires int operands, got {} and {}",
                     left_type.type_name(),
                     right_type.type_name()
                 )));

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -6053,6 +6053,51 @@ fn runs_runtime_bounded_for_loop_example() {
 }
 
 #[test]
+fn runtime_for_loop_snapshots_compound_bound_expressions_before_the_body() {
+    let source = r#"
+        contract RuntimeLoopBounds() {
+            entry main(int start, int end) {
+                int count = 0;
+                int total = 0;
+
+                for (i, start + 1, end + 1, 3) {
+                    count = count + 1;
+                    total = total + i;
+                    start = 100;
+                    end = -100;
+                }
+
+                require(count == 3);
+                require(total == 6);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let sigscript = compiled.build_sig_script("main", vec![0.into(), 3.into()]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    assert!(result.is_ok(), "mutating variables used by bound expressions must not change the snapshotted range: {result:?}");
+}
+
+#[test]
+fn runtime_for_loop_evaluates_each_bound_expression_once() {
+    let source = r#"
+        contract RuntimeLoopBoundEvaluation() {
+            entry main() {
+                for (i, tx.inputs.length - 1, tx.outputs.length + 1, 3) {
+                    require(i >= 0);
+                }
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode should stringify");
+    assert_eq!(opcodes.matches("OpTxInputCount").count(), 1, "the start expression must be evaluated once: {opcodes}");
+    assert_eq!(opcodes.matches("OpTxOutputCount").count(), 1, "the end expression must be evaluated once: {opcodes}");
+}
+
+#[test]
 fn rejects_runtime_for_loop_range_above_max_iterations() {
     let source = r#"
         contract RuntimeLoop() {
@@ -12851,7 +12896,7 @@ fn ternary_lowering_initializes_generated_results_for_supported_types() {
                     : Pair {number: 1, flag: false};
                 require(int_result >= 0);
                 require(bool_result || !bool_result);
-                require(byte_result >= 0);
+                require(byte_result == value || byte_result == 1);
                 require(string_result.length > 0);
                 require(fixed_array_result.length == 2);
                 require(dynamic_array_result.length == 2);
@@ -14964,21 +15009,23 @@ fn allows_fixed_array_cast_with_compatible_encoded_size() {
 }
 
 #[test]
-fn rejects_ordered_comparisons_for_non_numeric_operands() {
-    for operator in ["<", "<=", ">", ">="] {
-        let source = format!(
-            r#"
-                contract OrderedComparison() {{
-                    entry main() {{
-                        require("aaaaaaaaa" {operator} "bbbbbbbbb");
+fn rejects_ordered_comparisons_for_non_int_operands() {
+    for (type_name, left, right) in [("string", "\"aaaaaaaaa\"", "\"bbbbbbbbb\""), ("byte", "byte(0xff)", "byte(0x01)")] {
+        for operator in ["<", "<=", ">", ">="] {
+            let source = format!(
+                r#"
+                    contract OrderedComparison() {{
+                        entry main() {{
+                            require({left} {operator} {right});
+                        }}
                     }}
-                }}
-            "#
-        );
-        let err = compile_contract(&source, &[], CompileOptions::default())
-            .err()
-            .unwrap_or_else(|| panic!("string operands for {operator} should be rejected"));
-        assert!(err.to_string().contains("ordered comparison requires numeric operands"), "unexpected error for {operator}: {err}");
+                "#
+            );
+            let err = compile_contract(&source, &[], CompileOptions::default())
+                .err()
+                .unwrap_or_else(|| panic!("{type_name} operands for {operator} should be rejected"));
+            assert!(err.to_string().contains("ordered comparison requires int operands"), "unexpected error for {operator}: {err}");
+        }
     }
 }
 

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -4787,19 +4787,23 @@ fn array_literal_codegen_uses_declared_element_type() {
 
 #[test]
 fn bool_array_literal_normalizes_runtime_elements_to_one_byte() {
-    let source = r#"
-        contract Arrays() {
-            entry main(bool x) {
-                bool[] values = bool[]{x, false};
-                require(byte[2](values) == byte[_](0x0100));
-            }
-        }
-    "#;
+    for (witness, expected) in [(2, "0100"), (0x80, "0000")] {
+        let source = format!(
+            r#"
+                contract Arrays() {{
+                    entry main(bool x) {{
+                        bool[] values = bool[]{{x, false}};
+                        require(byte[2](values) == byte[_](0x{expected}));
+                    }}
+                }}
+            "#
+        );
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::bool(true)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
-    assert!(result.is_ok(), "bool[] literal elements should each occupy one byte: {result:?}");
+        let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile succeeds");
+        let sigscript = script_builder().add_data_with_push_opcode(&[witness]).unwrap().drain();
+        let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+        assert!(result.is_ok(), "bool[] literal witness {witness:#04x} should normalize to 0x{expected}: {result:?}");
+    }
 }
 
 #[test]
@@ -4836,9 +4840,9 @@ fn bool_array_append_normalizes_runtime_elements_to_one_byte() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::bool(true)]).expect("sigscript builds");
+    let sigscript = script_builder().add_data_with_push_opcode(&[2]).unwrap().drain();
     let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
-    assert!(result.is_ok(), "bool[] append elements should each occupy one byte: {result:?}");
+    assert!(result.is_ok(), "truthy bool[] append elements should be normalized to 0x01: {result:?}");
 }
 
 #[test]
@@ -10109,15 +10113,11 @@ fn canonicalizes_bool_comparison_operands_for_equality_and_inequality() {
             .unwrap()
             .add_op(OpOver)
             .unwrap()
-            .add_op(OpNot)
-            .unwrap()
-            .add_op(OpNot)
+            .add_op(Op0NotEqual)
             .unwrap()
             .add_op(OpSwap)
             .unwrap()
-            .add_op(OpNot)
-            .unwrap()
-            .add_op(OpNot)
+            .add_op(Op0NotEqual)
             .unwrap()
             .add_op(compare_op)
             .unwrap()
@@ -10406,15 +10406,11 @@ fn compiles_opcode_builtins() {
                 .unwrap()
                 .add_i64(0)
                 .unwrap()
-                .add_op(OpNot)
-                .unwrap()
-                .add_op(OpNot)
+                .add_op(Op0NotEqual)
                 .unwrap()
                 .add_op(OpSwap)
                 .unwrap()
-                .add_op(OpNot)
-                .unwrap()
-                .add_op(OpNot)
+                .add_op(Op0NotEqual)
                 .unwrap()
                 .add_op(OpNumEqual)
                 .unwrap()

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -11914,6 +11914,83 @@ fn accepts_array_type_with_constant_size() {
 }
 
 #[test]
+fn rejects_contract_constant_initializer_type_mismatches() {
+    let cases = [
+        ("int constant VALUE = true;", "scalar mismatch"),
+        ("bool constant VALUE = 1;", "reverse scalar mismatch"),
+        ("int[2] constant VALUE = bool[2]{true, false};", "array element mismatch"),
+        ("int[2] constant VALUE = int[1]{1};", "fixed array size mismatch"),
+        ("string[] constant VALUE = string[]{\"value\"};", "unknown-width array element"),
+        (
+            "struct Pair { int amount; bool enabled; } Pair constant VALUE = Pair {amount: true, enabled: false};",
+            "struct field mismatch",
+        ),
+    ];
+
+    for (declaration, description) in cases {
+        let source = format!(
+            r#"
+                contract ConstantType() {{
+                    {declaration}
+                    entry main() {{ require(true); }}
+                }}
+            "#
+        );
+        compile_contract(&source, &[], CompileOptions::default()).expect_err(&format!("{description} should fail compilation"));
+    }
+}
+
+#[test]
+fn accepts_well_typed_constant_dependencies_on_constructor_params_and_constants() {
+    let source = r#"
+        contract ConstantDependencies(int base) {
+            int constant NEXT = base + 1;
+            int constant RESULT = NEXT + 1;
+
+            entry main() {
+                require(RESULT == base + 2);
+            }
+        }
+    "#;
+
+    let compiled =
+        compile_contract(source, &[3.into()], CompileOptions::default()).expect("well-typed constant dependencies should compile");
+    let result = run_bytecode_with_sigscript(compiled.bytecode, Vec::new());
+    assert!(result.is_ok(), "constant dependencies should retain their runtime value: {result:?}");
+}
+
+#[test]
+fn mismatched_contract_constant_reports_the_initializer_span() {
+    let source = r#"
+        contract ConstantType() {
+            int constant VALUE = true;
+            entry main() { require(true); }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("the mismatched constant must fail compilation");
+    assert!(err.to_string().contains("constant 'VALUE' expects int"), "unexpected error: {err}");
+    let span = err.span().expect("the constant initializer should be identified");
+    assert_eq!(&source[span.start..span.end], "true");
+}
+
+#[test]
+fn rejects_function_local_constant_initializer_type_mismatch() {
+    let source = r#"
+        contract ConstantType() {
+            entry main() {
+                int constant value = true;
+                require(true);
+            }
+        }
+    "#;
+
+    let err =
+        compile_contract(source, &[], CompileOptions::default()).expect_err("the mismatched local constant must fail compilation");
+    assert!(err.to_string().contains("variable 'value' expects int"), "unexpected error: {err}");
+}
+
+#[test]
 fn rejects_cyclic_constant_array_dimensions() {
     let cases = ["int constant A = A;".to_string(), "int constant A = B; int constant B = A;".to_string()];
 

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -11975,22 +11975,6 @@ fn mismatched_contract_constant_reports_the_initializer_span() {
 }
 
 #[test]
-fn rejects_function_local_constant_initializer_type_mismatch() {
-    let source = r#"
-        contract ConstantType() {
-            entry main() {
-                int constant value = true;
-                require(true);
-            }
-        }
-    "#;
-
-    let err =
-        compile_contract(source, &[], CompileOptions::default()).expect_err("the mismatched local constant must fail compilation");
-    assert!(err.to_string().contains("variable 'value' expects int"), "unexpected error: {err}");
-}
-
-#[test]
 fn rejects_cyclic_constant_array_dimensions() {
     let cases = ["int constant A = A;".to_string(), "int constant A = B; int constant B = A;".to_string()];
 
@@ -12615,6 +12599,94 @@ fn rejects_duplicate_variable_definition_in_same_scope() {
     assert!(err.to_string().contains("variable 'value' is already defined"), "unexpected error: {err}");
     let span = err.span().expect("the duplicate declaration should be identified");
     assert_eq!(&source[span.start..span.end], "value");
+}
+
+#[test]
+fn rejects_constant_declarations_inside_functions() {
+    let cases = [
+        "int constant value = 1;",
+        "{ bool constant value = true; }",
+        "if (true) { byte[1] constant value = byte[1](0x01); }",
+        "for (i, 0, 1, 1) { int constant value = i; }",
+    ];
+
+    for declaration in cases {
+        let source = format!(
+            r#"
+                contract LocalConstant() {{
+                    entry main() {{
+                        {declaration}
+                        require(true);
+                    }}
+                }}
+            "#
+        );
+        let err = compile_contract(&source, &[], CompileOptions::default())
+            .expect_err("constant declarations inside functions must fail compilation");
+        assert!(err.to_string().contains("constant declarations are only allowed at contract level"), "unexpected error: {err}");
+        let span = err.span().expect("the local constant modifier should be identified");
+        assert_eq!(&source[span.start..span.end], "constant");
+    }
+}
+
+#[test]
+fn rejects_assignments_to_contract_constants() {
+    let cases = [
+        ("int constant VALUE = 1;", "VALUE = 2;", "VALUE"),
+        ("int[2] constant VALUES = int[2]{1, 2};", "VALUES = int[2]{3, 4};", "VALUES"),
+        (
+            "struct Pair { int left; int right; } Pair constant PAIR = Pair {left: 1, right: 2};",
+            "PAIR = Pair {left: 3, right: 4};",
+            "PAIR",
+        ),
+    ];
+
+    for (declaration, assignment, name) in cases {
+        let source = format!(
+            r#"
+                contract ConstantAssignment() {{
+                    {declaration}
+                    entry main() {{
+                        {{ {assignment} }}
+                        require(true);
+                    }}
+                }}
+            "#
+        );
+        let err = compile_contract(&source, &[], CompileOptions::default())
+            .expect_err("assigning to a contract constant must fail compilation");
+        assert!(err.to_string().contains(&format!("cannot assign to contract constant '{name}'")), "unexpected error: {err}");
+        let span = err.span().expect("the constant assignment target should be identified");
+        assert_eq!(&source[span.start..span.end], name);
+    }
+}
+
+#[test]
+fn rejects_assignments_to_state_fields() {
+    let cases = [
+        ("int value = 1;", "value = 2;", "value"),
+        ("int[2] values = int[2]{1, 2};", "values = int[2]{3, 4};", "values"),
+        ("struct Pair { int left; int right; } Pair pair = Pair {left: 1, right: 2};", "pair = Pair {left: 3, right: 4};", "pair"),
+    ];
+
+    for (declaration, assignment, name) in cases {
+        let source = format!(
+            r#"
+                contract StateFieldAssignment() {{
+                    {declaration}
+                    entry main() {{
+                        {{ {assignment} }}
+                        require(true);
+                    }}
+                }}
+            "#
+        );
+        let err =
+            compile_contract(&source, &[], CompileOptions::default()).expect_err("assigning to a state field must fail compilation");
+        assert!(err.to_string().contains(&format!("cannot assign to state field '{name}'")), "unexpected error: {err}");
+        let span = err.span().expect("the state field assignment target should be identified");
+        assert_eq!(&source[span.start..span.end], name);
+    }
 }
 
 #[test]

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -1639,7 +1639,7 @@ fn disallow_comparing_dynamic_and_fixed_int_arrays_without_cast() {
 }
 
 #[test]
-fn allows_comparing_dynamic_and_fixed_int_arrays_with_cast() {
+fn rejects_comparing_int_arrays_even_with_matching_casts() {
     let source = r#"
         contract Arrays() {
             entry main() {
@@ -1650,7 +1650,8 @@ fn allows_comparing_dynamic_and_fixed_int_arrays_with_cast() {
         }
     "#;
 
-    assert!(compile_contract(source, &[], CompileOptions::default()).is_ok(), "int[] == int[](int[1]) should compile");
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("int[] comparison should be rejected");
+    assert!(err.to_string().contains("array comparison is only supported"), "unexpected error: {err}");
 }
 
 #[test]
@@ -1763,9 +1764,20 @@ fn infers_fixed_sizes_for_multiple_array_element_types() {
                     pubkey(0x0303030303030303030303030303030303030303030303030303030303030303),
                     pubkey(0x0404040404040404040404040404040404040404040404040404040404040404)
                 };
-                require(ints == ints_expected);
-                require(flags == flags_expected);
-                require(keys == keys_expected);
+                require(ints.length == 4);
+                require(ints_expected.length == 4);
+                require(ints[0] == ints_expected[0]);
+                require(ints[1] == ints_expected[1]);
+                require(ints[2] == ints_expected[2]);
+                require(ints[3] == ints_expected[3]);
+                require(flags.length == 2);
+                require(flags_expected.length == 2);
+                require(flags[0] == flags_expected[0]);
+                require(flags[1] == flags_expected[1]);
+                require(keys.length == 2);
+                require(keys_expected.length == 2);
+                require(keys[0] == keys_expected[0]);
+                require(keys[1] == keys_expected[1]);
             }
         }
     "#;
@@ -4816,7 +4828,7 @@ fn runtime_and_compile_time_false_have_identical_bool_array_encoding() {
                 bool[] constArr = bool[]{true, false};
                 require(runtimeArr.length == 2);
                 require(constArr.length == 2);
-                require(runtimeArr == constArr);
+                require(byte[2](runtimeArr) == byte[2](constArr));
             }
         }
     "#;
@@ -5701,6 +5713,53 @@ fn fails_array_equality_comparison() {
     let sigscript = script_builder().drain();
     let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
     assert!(result.is_err());
+}
+
+#[test]
+fn allows_comparison_of_byte_and_fixed_byte_sequence_arrays() {
+    let source = r#"
+        contract Arrays() {
+            entry main(
+                byte[] bytes,
+                byte[2][] byteRows,
+                pubkey[] publicKeys,
+                pubkey[2][] publicKeyRows,
+                sig[] signatures,
+                datasig[] dataSignatures
+            ) {
+                require(bytes == bytes);
+                require(byteRows == byteRows);
+                require(publicKeys == publicKeys);
+                require(publicKeyRows == publicKeyRows);
+                require(signatures == signatures);
+                require(dataSignatures == dataSignatures);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default())
+        .expect("byte arrays and arrays of fixed-byte sequence types should support comparison");
+}
+
+#[test]
+fn rejects_comparison_of_non_byte_arrays() {
+    let cases = [
+        ("int array equality", "contract C() { entry main(int[] values) { require(values == values); } }", "int[]"),
+        ("bool array inequality", "contract C() { entry main(bool[] values) { require(values != values); } }", "bool[]"),
+        ("multidimensional int array", "contract C() { entry main(int[2][] values) { require(values == values); } }", "int[2][]"),
+        (
+            "struct array equality",
+            "contract C() { struct S { int value; } entry main(S[] values) { require(values == values); } }",
+            "S[]",
+        ),
+    ];
+
+    for (name, source, type_name) in cases {
+        let err = compile_contract(source, &[], CompileOptions::default()).expect_err(name);
+        let message = err.to_string();
+        assert!(message.contains("array comparison is only supported"), "{name}: unexpected error: {err}");
+        assert!(message.contains(type_name), "{name}: missing rejected type in error: {err}");
+    }
 }
 
 #[test]
@@ -13462,7 +13521,10 @@ fn runs_split_on_non_byte_array() {
                 (int[] left, int[] right) = values.split(1);
                 require(left.length == 1);
                 require(left[0] == 10);
-                require(right == int[]{20, 30, 40});
+                require(right.length == 3);
+                require(right[0] == 20);
+                require(right[1] == 30);
+                require(right[2] == 40);
             }
         }
     "#;
@@ -13479,8 +13541,12 @@ fn runtime_split_index_produces_dynamic_array_parts() {
         contract SplitDynamicIndex() {
             entry main(int[] values, int n) {
                 (int[] left, int[] right) = values.split(n);
-                require(left == int[]{10, 20});
-                require(right == int[]{30, 40});
+                require(left.length == 2);
+                require(left[0] == 10);
+                require(left[1] == 20);
+                require(right.length == 2);
+                require(right[0] == 30);
+                require(right[1] == 40);
             }
         }
     "#;
@@ -13640,7 +13706,9 @@ fn runs_slice_on_non_byte_array() {
             entry main() {
                 int[] values = int[]{10, 20, 30, 40};
                 int[] part = values.slice(1, 3);
-                require(part == int[]{20, 30});
+                require(part.length == 2);
+                require(part[0] == 20);
+                require(part[1] == 30);
             }
         }
     "#;
@@ -13671,15 +13739,18 @@ fn runs_split_and_slice_on_struct_array() {
                 S[] part = values.slice(1, 3);
 
                 require(left.length == 1);
-                require(left == S[]{S {number: 10, tag: byte[_](0x0102)}});
-                require(right == S[]{
-                    S {number: 20, tag: byte[_](0x0304)},
-                    S {number: 30, tag: byte[_](0x0506)}
-                });
-                require(part == S[]{
-                    S {number: 20, tag: byte[_](0x0304)},
-                    S {number: 30, tag: byte[_](0x0506)}
-                });
+                require(left[0].number == 10);
+                require(left[0].tag == byte[_](0x0102));
+                require(right.length == 2);
+                require(right[0].number == 20);
+                require(right[0].tag == byte[_](0x0304));
+                require(right[1].number == 30);
+                require(right[1].tag == byte[_](0x0506));
+                require(part.length == 2);
+                require(part[0].number == 20);
+                require(part[0].tag == byte[_](0x0304));
+                require(part[1].number == 30);
+                require(part[1].tag == byte[_](0x0506));
             }
         }
     "#;
@@ -13691,98 +13762,39 @@ fn runs_split_and_slice_on_struct_array() {
 }
 
 #[test]
-fn runs_struct_array_equality_and_inequality_comparisons() {
-    let source = r#"
-        contract StructArrayComparisons() {
-            struct Details {
-                bool active;
-                int score;
-            }
-
-            struct Item {
-                int id;
-                byte[2] tag;
-                Details details;
-            }
-
-            entry main() {
-                Item[] values = Item[]{
-                    Item {id: 1, tag: byte[_](0x0102), details: Details {active: true, score: 10}},
-                    Item {id: 2, tag: byte[_](0x0304), details: Details {active: false, score: 20}}
-                };
-                Item[] same = Item[]{
-                    Item {id: 1, tag: byte[_](0x0102), details: Details {active: true, score: 10}},
-                    Item {id: 2, tag: byte[_](0x0304), details: Details {active: false, score: 20}}
-                };
-                Item[] differentId = Item[]{
-                    Item {id: 1, tag: byte[_](0x0102), details: Details {active: true, score: 10}},
-                    Item {id: 3, tag: byte[_](0x0304), details: Details {active: false, score: 20}}
-                };
-                Item[] differentTag = Item[]{
-                    Item {id: 1, tag: byte[_](0x0102), details: Details {active: true, score: 10}},
-                    Item {id: 2, tag: byte[_](0x0506), details: Details {active: false, score: 20}}
-                };
-                Item[] differentNestedField = Item[]{
-                    Item {id: 1, tag: byte[_](0x0102), details: Details {active: true, score: 10}},
-                    Item {id: 2, tag: byte[_](0x0304), details: Details {active: true, score: 20}}
-                };
-                Item[] shorter = Item[]{
-                    Item {id: 1, tag: byte[_](0x0102), details: Details {active: true, score: 10}}
-                };
-                Item[] empty;
-
-                require(values == same);
-                require(!(values != same));
-                require(values != differentId);
-                require(values != differentTag);
-                require(values != differentNestedField);
-                require(values != shorter);
-                require(!(values == differentId));
-                require(empty == Item[]{});
-                require(empty != values);
-            }
-        }
-    "#;
-
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("struct array comparisons should compile");
-    let selector = selector_for(&compiled, "main");
-    let result = run_bytecode_with_selector(compiled.bytecode, selector);
-    assert!(result.is_ok(), "struct array comparisons should execute successfully: {}", result.unwrap_err());
+fn rejects_struct_array_equality_and_inequality_comparisons() {
+    for operator in ["==", "!="] {
+        let source = format!(
+            r#"
+                contract StructArrayComparisons() {{
+                    struct Item {{ int id; byte[2] tag; }}
+                    entry main(Item[] values) {{
+                        require(values {operator} values);
+                    }}
+                }}
+            "#
+        );
+        let err = compile_contract(&source, &[], CompileOptions::default()).expect_err("struct-array comparison should fail");
+        assert!(err.to_string().contains("array comparison is only supported"), "unexpected error: {err}");
+    }
 }
 
 #[test]
-fn struct_array_comparisons_accept_structured_expressions_on_either_side() {
-    let source = r#"
-        contract StructArrayComparisonSymmetry() {
-            struct S { int value; }
-
-            function identity(S[] values): S[] {
-                return(values);
-            }
-
-            entry main() {
-                S[] one = S[]{S {value: 7}};
-                S[] two = S[]{S {value: 7}, S {value: 8}};
-
-                require(S[]{S {value: 7}} == one);
-                require(S[]{S {value: 8}} != one);
-                require(S[]{S {value: 7}, S {value: 8}} == one.append(S {value: 8}));
-                require(S[]{S {value: 7}} == two.slice(0, 1));
-                require(S[]{S {value: 7}} == two.split(1).0);
-                require(S[]{S {value: 7}} == identity(one));
-
-                require(one == S[]{S {value: 7}});
-                require(one.append(S {value: 8}) == S[]{S {value: 7}, S {value: 8}});
-                require(two.slice(0, 1) == S[]{S {value: 7}});
-            }
-        }
-    "#;
-
-    let compiled = compile_contract(source, &[], CompileOptions::default())
-        .expect("struct-array comparisons should be symmetric for supported structured expressions");
-    let selector = selector_for(&compiled, "main");
-    let result = run_bytecode_with_selector(compiled.bytecode, selector);
-    assert!(result.is_ok(), "symmetric struct-array comparisons should execute successfully: {}", result.unwrap_err());
+fn rejects_struct_array_comparisons_with_structured_expressions_on_either_side() {
+    for comparison in ["S[]{S {value: 7}} == values", "values == S[]{S {value: 7}}"] {
+        let source = format!(
+            r#"
+                contract StructArrayComparisonSymmetry() {{
+                    struct S {{ int value; }}
+                    entry main(S[] values) {{
+                        require({comparison});
+                    }}
+                }}
+            "#
+        );
+        let err = compile_contract(&source, &[], CompileOptions::default()).expect_err("struct-array comparison should fail");
+        assert!(err.to_string().contains("array comparison is only supported"), "unexpected error: {err}");
+    }
 }
 
 #[test]

--- a/silverscript-lang/tests/examples/simple_constant.sil
+++ b/silverscript-lang/tests/examples/simple_constant.sil
@@ -1,8 +1,9 @@
 pragma silverscript ^0.1.0;
 
 contract Test() {
+    string constant m = "hello";
+
     entry hello() {
-        string constant m = "hello";
         require(m == "hello");
     }
 }


### PR DESCRIPTION
  This change tightens several language rules that could otherwise produce surprising runtime behavior and documents SilverScript’s undefined-behaviour boundaries.

  ## Language Behavior Changes

  - Ordered comparisons (`<`, `<=`, `>`, and `>=`) now accept only `int` operands. Bytes require an explicit signed or unsigned conversion.

  ```sil
  byte a = byte(0xff);
  byte b = byte(0x01);
  require(unsigned(a) > unsigned(b));
  ```

  - Runtime `for` loop bounds are evaluated exactly once when entering the loop. Mutating variables referenced by the original bound expressions no longer changes the established range.

  ```sil
  for (i, start, end, 3) {
      end = 0; // Does not shorten the loop.
  }
  ```

  - Contract constant initializers must match their declared types, including array dimensions, element types, and struct shapes.

  ```sil
  int constant VALUE = true; // Compilation error.
  ```

  - Constants may only be declared at contract level. Function-local `constant` declarations are rejected.

  ```sil
  entry main() {
      int constant value = 1; // Compilation error.
  }
  ```

  - Contract constants and state fields cannot be reassigned from function bodies.

  ```sil
  contract Counter() {
      int value = 0;
      int constant LIMIT = 10;

      entry main() {
          value = 1;  // Compilation error.
          LIMIT = 20; // Compilation error.
      }
  }
  ```

  - The language documentation now defines undefined behaviour and its optimization implications. This covers invalid integer operations, out-of-bounds sequence operations, malformed struct
  arrays, unchecked cast layouts, invalid transaction or state access, malformed cryptographic values, and overflowing runtime loop arithmetic.

  Undefined behaviour must not be used as an implicit transaction check: evaluation and failure are not guaranteed, and affected expressions may be optimized away.