### PR TITLE
Normalize bool in state fields and when converting to int

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -967,13 +967,16 @@ byte[8] encodedAmount = amount as byte[8];
 The source value must be an `int`, and `N` must be known at compile time and
 between 1 and 8. The conversion expression has type `byte[N]`.
 
-**`int(bool value): int`**
+**`boolValue as int`**
 
 Convert boolean to integer (true = 1, false = 0):
 
 ```javascript
-int x = int(false);  // 0
+int x = false as int;  // 0
 ```
+
+The conversion normalizes every truthy boolean representation to `1` and every
+false boolean representation to `0`.
 
 **`signed(byte value): int`**
 

--- a/silverscript-lang/src/compiler/compile/expression/builtin.rs
+++ b/silverscript-lang/src/compiler/compile/expression/builtin.rs
@@ -109,6 +109,12 @@ fn compile_as_cast<'i>(ctx: &mut CompileExprContext<'_, '_, 'i>, args: &[Expr<'i
     let [source] = args else {
         return Err(CompilerError::Unsupported("'as' conversion expects one source expression".to_string()));
     };
+    if cast_type.is_int() {
+        // The only valid 'as int' conversion is from bool, which is checked by the type checker. The compiler just needs to emit the Op0NotEqual opcode to normalize the boolean value.
+        compile_call_arg_with_context(ctx, source)?;
+        ctx.emit_op(Op0NotEqual, 0)?;
+        return Ok(());
+    }
     let size = if cast_type.is_byte() {
         1
     } else {

--- a/silverscript-lang/src/compiler/compile/state.rs
+++ b/silverscript-lang/src/compiler/compile/state.rs
@@ -489,7 +489,11 @@ where
         let prefix = data_prefix(field_size)?;
         emitter.push_data(&prefix)?;
         compile_expr(new_value, Some(&type_ref), &env, &mut emitter)?;
-        if type_ref.is_int() || type_ref.is_bool() {
+        if type_ref.is_bool() {
+            emitter.emit_op(Op0NotEqual, 0)?;
+            emitter.push_int(field_size as i64)?;
+            emitter.emit_op(OpNum2Bin, -1)?;
+        } else if type_ref.is_int() {
             emitter.push_int(field_size as i64)?;
             emitter.emit_op(OpNum2Bin, -1)?;
         }

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -238,6 +238,11 @@ pub(super) fn check_call<'i>(
     }
     if let Some(cast_type) = as_cast_type(name) {
         check_arity("as", args, 1)?;
+        if cast_type.is_int() {
+            check_expr(&args[0], Some(&scalar_type(TypeBase::Bool)), ctx)
+                .map_err(|_| CompilerError::Unsupported("'as int' source must be bool".to_string()))?;
+            return Ok(Some(cast_type));
+        }
         if !matches!(cast_type.base, TypeBase::Byte)
             || !(cast_type.is_byte() || matches!(cast_type.array_dims.as_slice(), [ArrayDim::Fixed(_) | ArrayDim::Constant(_)]))
         {
@@ -280,6 +285,9 @@ pub(super) fn check_call<'i>(
     {
         check_arity(name, args, 1)?;
         let source_type = check_expr(&args[0], None, ctx)?;
+        if cast_type.is_int() && source_type.is_bool() {
+            return Err(CompilerError::Unsupported("cannot cast bool to int with int(); use 'value as int' instead".to_string()));
+        }
         if cast_type.is_int() && source_type.is_byte() {
             return Err(CompilerError::Unsupported("cannot cast byte to int; use signed() or unsigned() instead".to_string()));
         }
@@ -334,7 +342,6 @@ fn validate_scalar_cast_compatibility<'i>(
 ) -> Result<(), CompilerError> {
     let compatible = if cast_type.is_int() {
         source_type.is_int()
-            || source_type.is_bool()
             || matches!(source_type.base, TypeBase::Byte)
                 && source_type.array_dims.len() == 1
                 && array_type_size(source_type, constants).is_some_and(|size| size <= 8)

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -6800,6 +6800,35 @@ fn runs_validate_output_state() {
 }
 
 #[test]
+fn validate_output_state_normalizes_runtime_bool_fields() {
+    let source = r#"
+        contract C(bool initial) {
+            bool flag = initial;
+
+            entry main(bool next) {
+                validateOutputState(0, State {flag: next});
+            }
+        }
+    "#;
+
+    let input_compiled = compile_contract(source, &[Expr::bool(false)], CompileOptions::default()).expect("input contract compiles");
+    let raw_truthy_arg = script_builder().add_data_with_push_opcode(&[2]).unwrap().drain();
+    let signature_script =
+        pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), raw_truthy_arg).expect("P2SH signature script builds");
+    let input = test_input(0, signature_script);
+
+    let output_compiled = compile_contract(source, &[Expr::bool(true)], CompileOptions::default()).expect("output contract compiles");
+    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output =
+        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&output_compiled.bytecode), covenant: None };
+    let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
+    let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
+
+    let result = execute_input(tx, vec![utxo_entry], 0);
+    assert!(result.is_ok(), "truthy 0x02 must serialize as the same boolean state as canonical true: {result:?}");
+}
+
+#[test]
 fn runs_validate_output_state_with_state_variable() {
     let source = r#"
         contract C(int initX, byte[2] initY) {
@@ -12111,6 +12140,48 @@ fn rejects_integer_to_byte_array_casts() {
     "#;
     let err = compile_contract(source, &[], CompileOptions::default()).expect_err("sized byte[] cast should be rejected");
     assert!(err.to_string().contains("byte[]() expects 1 arguments"), "unexpected error: {err}");
+}
+
+#[test]
+fn bool_as_int_normalizes_vm_truthiness() {
+    let source = r#"
+        contract Test() {
+            entry main(bool value) {
+                int normalized = value as int;
+                require(normalized == 1);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("bool as int compiles");
+    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    assert_eq!(opcodes.matches("Op0NotEqual").count(), 1, "bool as int must normalize VM truthiness exactly once: {opcodes}");
+
+    let raw_truthy_arg = script_builder().add_data_with_push_opcode(&[2]).unwrap().drain();
+    let result = run_bytecode_with_sigscript(compiled.bytecode, raw_truthy_arg);
+    assert!(result.is_ok(), "truthy 0x02 must normalize to integer 1: {result:?}");
+}
+
+#[test]
+fn function_style_int_cast_rejects_bool_expressions() {
+    let source = r#"
+        contract Test() {
+            entry main(bool value) {
+                int converted = int(value);
+                require(converted == 1);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("int(bool) must be rejected");
+    assert!(err.to_string().contains("cannot cast bool to int with int(); use 'value as int' instead"), "unexpected error: {err}");
+}
+
+#[test]
+fn as_int_rejects_non_bool_expressions() {
+    let source = "contract Test() { entry main(int value) { int converted = value as int; require(converted == value); } }";
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("only bool expressions may use as int");
+    assert!(err.to_string().contains("'as int' source must be bool"), "unexpected error: {err}");
 }
 
 #[test]

--- a/silverscript-lang/tests/examples/everything.sil
+++ b/silverscript-lang/tests/examples/everything.sil
@@ -9,7 +9,7 @@ contract Test(int x, string y) {
         int i = 400 + x;
         byte[] b = byte[](byte[_](0x007364897987fe87)) + byte[](y);
 
-        int myVariable = 10 - int(false); // they can go at the end of the line
+        int myVariable = 10 - false as int; // they can go at the end of the line
         int myOtherVariable = (i + myVariable) % 2;
         require(myOtherVariable /* And comments can be included within lines */ < i);
 

--- a/silverscript-lang/tests/examples/simple_cast.sil
+++ b/silverscript-lang/tests/examples/simple_cast.sil
@@ -2,7 +2,7 @@ pragma silverscript ^0.1.0;
 
 contract Test(int x, string y) {
     entry hello(sig s, pubkey pk) {
-        int myVariable = 10 - int(true);
+        int myVariable = 10 - true as int;
         int myOtherVariable = 20 + myVariable % 2;
         require(myOtherVariable > x);
 


### PR DESCRIPTION
  Normalize boolean values at language boundaries so every truthy value becomes `1` and every false value becomes `0`.

  Boolean-to-integer conversion now uses `as int`, while the ambiguous `int(bool)` form is rejected.

  ## Language Behavior Changes

  - Convert booleans to integers with `as int`:

  ```sil
  bool enabled = true;
  int value = enabled as int; // 1
  ```

  - `as int` accepts only boolean expressions. Other integer conversions continue to use their existing syntax.
  - `int(booleanExpression)` is rejected with guidance to use `booleanExpression as int`.
  - Boolean conversion follows VM truthiness and always produces canonical integers:
    - False values become `0`.
    - Any truthy representation becomes `1`.
  - Boolean state fields are canonicalized before serialization, ensuring equivalent truthy representations produce the same state encoding.
