### PR TITLE
fix(sdk): minimal byte encoding for sigscript args

### DIFF
--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -419,7 +419,7 @@ fn push_sigscript_non_array_arg<'i>(builder: &mut ScriptBuilder, arg: Expr<'i>) 
             builder.add_data(value.as_bytes())?;
         }
         ExprKind::Byte(value) => {
-            builder.add_data_with_push_opcode(&[value])?;
+            builder.add_data(&[value])?;
         }
         // This is not intended for byte-arrays, but for pubkey, datasig, etc.
         ExprKind::Array { values, .. } if values.iter().all(|value| matches!(&value.kind, ExprKind::Byte(_))) => {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -1103,23 +1103,6 @@ fn build_sig_script_builds_expected_script() {
 }
 
 #[test]
-fn standalone_byte_argument_uses_minimal_push() {
-    let source = r#"
-        contract Test() {
-            entry step(byte marker) { require(true); }
-        }
-    "#;
-
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let cases: &[(u8, &[u8])] = &[(0x01, &[0x51]), (0x81, &[0x4f]), (0x42, &[0x01, 0x42])];
-
-    for &(value, expected) in cases {
-        let sigscript = compiled.build_sig_script("step", vec![Expr::byte(value)]).expect("byte sigscript builds");
-        assert_eq!(sigscript.as_slice(), expected, "non-minimal encoding for byte value 0x{value:02x}");
-    }
-}
-
-#[test]
 fn byte_variable_from_int_literal_uses_raw_byte_push() {
     let source = r#"
         contract Bytes() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -1103,6 +1103,23 @@ fn build_sig_script_builds_expected_script() {
 }
 
 #[test]
+fn standalone_byte_argument_uses_minimal_push() {
+    let source = r#"
+        contract Test() {
+            entry step(byte marker) { require(true); }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let cases: &[(u8, &[u8])] = &[(0x01, &[0x51]), (0x81, &[0x4f]), (0x42, &[0x01, 0x42])];
+
+    for &(value, expected) in cases {
+        let sigscript = compiled.build_sig_script("step", vec![Expr::byte(value)]).expect("byte sigscript builds");
+        assert_eq!(sigscript.as_slice(), expected, "non-minimal encoding for byte value 0x{value:02x}");
+    }
+}
+
+#[test]
 fn byte_variable_from_int_literal_uses_raw_byte_push() {
     let source = r#"
         contract Bytes() {


### PR DESCRIPTION
in `build_sig_script`:
```rust
ExprKind::Byte(value) => {
  builder.add_data_with_push_opcode(&[value])?;
}
```

was producing non minimal encoding for byte sigscript arg. this PR changes that to minimal pushes.