### PR TITLE
Add shared covenant delegate policies and configurable ABI names

### DIFF
--- a/debugger/cli/src/main.rs
+++ b/debugger/cli/src/main.rs
@@ -209,7 +209,7 @@ fn build_covenant_input_sigscript<'i>(
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let entrypoint_name = target.generated_entrypoint_name_for(is_leader);
     let typed_args = if target.binding == DebugCovenantBinding::Cov && !is_leader {
-        Vec::new()
+        parse_call_args(&compiled.ast, &entrypoint_name, raw_args)?
     } else {
         let function = compiled
             .ast

--- a/debugger/cli/src/main.rs
+++ b/debugger/cli/src/main.rs
@@ -910,22 +910,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             } else {
                 active_sigscript.clone()
             }
-        } else if let Some(target) = covenant_target.as_ref()
-            && target.binding == DebugCovenantBinding::Cov
-            && input_covenant_ids[input_idx] == active_covenant_id
-            && input_redeem_scripts[input_idx].is_some()
-        {
-            let is_leader = Some(input_idx) == companion_leader_index;
-            let input_ctor_raw = tx.inputs[input_idx].constructor_args.clone().unwrap_or_else(|| raw_ctor_args.clone());
-            let input_compiled = compile_contract_for_raw_ctor_args(&source, &parsed_contract, &input_ctor_raw)?;
-            let auto_action = build_covenant_input_sigscript(
-                &input_compiled,
-                target,
-                is_leader,
-                &raw_args,
-                covenant_group_output_states.as_deref(),
-            )?;
-            combine_action_and_redeem(&auto_action, input_redeem_scripts[input_idx].as_ref().expect("checked is_some above"))?
         } else if let Some(redeem) = input_redeem_scripts[input_idx].as_ref() {
             sigscript_push_bytecode(redeem)
         } else {

--- a/debugger/cli/tests/cli_tests.rs
+++ b/debugger/cli/tests/cli_tests.rs
@@ -359,6 +359,73 @@ contract CovDebugDemo(int initial_value) {
     )
 }
 
+fn write_covenant_distinct_delegate_args_fixture() -> (std::path::PathBuf, std::path::PathBuf) {
+    write_fixture_files(
+        "cov_distinct_delegate_args.sil",
+        "cov_distinct_delegate_args.test.json",
+        r#"pragma silverscript ^0.1.0;
+
+contract CovDistinctDelegateArgs() {
+    #[covenant(binding = cov, from = 2, to = 2)]
+    function transfer(int amount, bool allowed) {
+        require(amount >= 0);
+        require(allowed);
+    }
+
+    #[covenant.delegate]
+    function authorizeDelegate(byte[] witness) {
+        require(witness.length > 0);
+    }
+}
+"#,
+        r#"{
+  "tests": [
+    {
+      "name": "leader_uses_only_leader_args",
+      "function": "transfer",
+      "args": [1, true],
+      "expect": "pass",
+      "tx": {
+        "active_input_index": 0,
+        "inputs": [
+          {
+            "utxo_value": 5000,
+            "covenant_id": "0x1111111111111111111111111111111111111111111111111111111111111111"
+          },
+          {
+            "utxo_value": 5000,
+            "covenant_id": "0x1111111111111111111111111111111111111111111111111111111111111111"
+          }
+        ],
+        "outputs": []
+      }
+    },
+    {
+      "name": "delegate_uses_only_delegate_args",
+      "function": "transfer",
+      "args": ["0x01"],
+      "expect": "pass",
+      "tx": {
+        "active_input_index": 1,
+        "inputs": [
+          {
+            "utxo_value": 5000,
+            "covenant_id": "0x1111111111111111111111111111111111111111111111111111111111111111"
+          },
+          {
+            "utxo_value": 5000,
+            "covenant_id": "0x1111111111111111111111111111111111111111111111111111111111111111"
+          }
+        ],
+        "outputs": []
+      }
+    }
+  ]
+}
+"#,
+    )
+}
+
 fn write_state_first_auth_transition_fixture() -> (std::path::PathBuf, std::path::PathBuf) {
     write_fixture_files(
         "state_first_transition.sil",
@@ -1165,6 +1232,31 @@ fn cli_debugger_runs_source_level_covenant_tests() {
         );
         let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(stdout.contains("PASS"), "missing PASS output for {test_name}: {stdout}");
+    }
+}
+
+#[test]
+fn cli_debugger_does_not_reuse_active_args_for_covenant_companions() {
+    let (script_path, test_file_path) = write_covenant_distinct_delegate_args_fixture();
+
+    for test_name in ["leader_uses_only_leader_args", "delegate_uses_only_delegate_args"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_cli-debugger"))
+            .arg(&script_path)
+            .arg("--run")
+            .arg("--test-file")
+            .arg(&test_file_path)
+            .arg("--test-name")
+            .arg(test_name)
+            .output()
+            .expect("run covenant debug test with distinct leader and delegate args");
+
+        assert!(
+            output.status.success(),
+            "expected success for {test_name}, status={:?}, stdout={}, stderr={}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 }
 

--- a/debugger/session/src/covenant.rs
+++ b/debugger/session/src/covenant.rs
@@ -1,10 +1,7 @@
 use std::collections::HashSet;
 
 use silverscript_lang::ast::{ContractAst, FunctionAst};
-use silverscript_lang::compiler::{
-    CompiledContract, generated_covenant_auth_entrypoint_name, generated_covenant_delegate_entrypoint_name,
-    generated_covenant_leader_entrypoint_name,
-};
+use silverscript_lang::compiler::CompiledContract;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CovenantBinding {
@@ -31,6 +28,7 @@ pub struct ResolvedCovenantCallTarget {
     pub mode: CovenantMode,
     pub source_binding: Option<CovenantSourceBinding>,
     pub generated_entrypoint_name: String,
+    pub delegate_entrypoint_name: Option<String>,
     pub policy_function_name: String,
     pub generated_function_names: HashSet<String>,
 }
@@ -46,12 +44,12 @@ impl ResolvedCovenantCallTarget {
 
     pub fn generated_entrypoint_name_for(&self, is_leader: bool) -> String {
         match self.binding {
-            CovenantBinding::Auth => generated_covenant_auth_entrypoint_name(&self.source_name),
+            CovenantBinding::Auth => self.generated_entrypoint_name.clone(),
             CovenantBinding::Cov => {
                 if is_leader {
-                    generated_covenant_leader_entrypoint_name(&self.source_name)
+                    self.generated_entrypoint_name.clone()
                 } else {
-                    generated_covenant_delegate_entrypoint_name()
+                    self.delegate_entrypoint_name.clone().expect("a resolved cov-bound declaration has a shared delegate entrypoint")
                 }
             }
         }
@@ -66,39 +64,15 @@ pub fn resolve_covenant_call_target<'i>(
     let function =
         contract.functions.iter().find(|function| function.name == function_name && is_covenant_source_function(function))?;
 
-    let auth_entrypoint_name = generated_covenant_auth_entrypoint_name(function_name);
-    let leader_entrypoint_name = generated_covenant_leader_entrypoint_name(function_name);
-    let has_auth_entrypoint = abi_contains_function(compiled, &auth_entrypoint_name);
-    let has_leader_entrypoint = abi_contains_function(compiled, &leader_entrypoint_name);
-
-    let binding = if has_auth_entrypoint {
-        CovenantBinding::Auth
-    } else if has_leader_entrypoint {
-        CovenantBinding::Cov
-    } else {
-        return None;
-    };
-
-    let generated_entrypoint_name = match binding {
-        CovenantBinding::Auth => auth_entrypoint_name.clone(),
-        CovenantBinding::Cov => {
-            if !has_leader_entrypoint {
-                return None;
-            }
-            leader_entrypoint_name.clone()
-        }
-    };
+    let generated_entrypoint_name = compiled.covenant_decl_entrypoint_name(function_name, true)?.to_string();
+    let nonleader_entrypoint_name = compiled.covenant_decl_entrypoint_name(function_name, false)?.to_string();
+    let binding = if generated_entrypoint_name == nonleader_entrypoint_name { CovenantBinding::Auth } else { CovenantBinding::Cov };
+    let delegate_entrypoint_name = (binding == CovenantBinding::Cov).then_some(nonleader_entrypoint_name);
 
     let mut generated_function_names = HashSet::from([generated_covenant_policy_name(function_name)]);
-    if has_auth_entrypoint {
-        generated_function_names.insert(auth_entrypoint_name);
-    }
-    if has_leader_entrypoint {
-        generated_function_names.insert(leader_entrypoint_name);
-    }
-
-    if binding == CovenantBinding::Cov {
-        generated_function_names.insert(generated_covenant_delegate_entrypoint_name());
+    generated_function_names.insert(generated_entrypoint_name.clone());
+    if let Some(delegate_entrypoint_name) = &delegate_entrypoint_name {
+        generated_function_names.insert(delegate_entrypoint_name.clone());
     }
 
     Some(ResolvedCovenantCallTarget {
@@ -110,17 +84,22 @@ pub fn resolve_covenant_call_target<'i>(
             .first()
             .map(|param| CovenantSourceBinding { param_name: param.name.clone(), param_type_name: param.type_ref.type_name() }),
         generated_entrypoint_name,
+        delegate_entrypoint_name,
         policy_function_name: generated_covenant_policy_name(function_name),
         generated_function_names,
     })
 }
 
-fn abi_contains_function(compiled: &CompiledContract<'_>, function_name: &str) -> bool {
-    compiled.entry_by_name(function_name).is_some()
-}
-
 fn is_covenant_source_function(function: &FunctionAst<'_>) -> bool {
-    function.attributes.iter().any(|attribute| attribute.path.first().is_some_and(|segment| segment == "covenant"))
+    function.attributes.iter().any(|attribute| {
+        matches!(
+            attribute.path.as_slice(),
+            [head] if head == "covenant"
+        ) || matches!(
+            attribute.path.as_slice(),
+            [head, tail] if head == "covenant" && (tail == "singleton" || tail == "fanout")
+        )
+    })
 }
 
 fn generated_covenant_policy_name(function_name: &str) -> String {

--- a/debugger/session/src/covenant.rs
+++ b/debugger/session/src/covenant.rs
@@ -22,6 +22,12 @@ pub struct CovenantSourceBinding {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CovenantDelegateBodyTarget {
+    pub source_name: String,
+    pub policy_function_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedCovenantCallTarget {
     pub source_name: String,
     pub binding: CovenantBinding,
@@ -29,6 +35,7 @@ pub struct ResolvedCovenantCallTarget {
     pub source_binding: Option<CovenantSourceBinding>,
     pub generated_entrypoint_name: String,
     pub delegate_entrypoint_name: Option<String>,
+    pub delegate_body: Option<CovenantDelegateBodyTarget>,
     pub policy_function_name: String,
     pub generated_function_names: HashSet<String>,
 }
@@ -40,6 +47,15 @@ impl ResolvedCovenantCallTarget {
 
     pub fn matches_generated_name(&self, function_name: &str) -> bool {
         self.generated_function_names.contains(function_name)
+    }
+
+    pub fn display_name_for(&self, function_name: &str) -> Option<&str> {
+        if let Some(body) = &self.delegate_body {
+            if body.policy_function_name == function_name {
+                return Some(body.source_name.as_str());
+            }
+        }
+        (self.policy_function_name == function_name || self.matches_generated_name(function_name)).then_some(self.source_name.as_str())
     }
 
     pub fn generated_entrypoint_name_for(&self, is_leader: bool) -> String {
@@ -68,6 +84,13 @@ pub fn resolve_covenant_call_target<'i>(
     let nonleader_entrypoint_name = compiled.covenant_decl_entrypoint_name(function_name, false)?.to_string();
     let binding = if generated_entrypoint_name == nonleader_entrypoint_name { CovenantBinding::Auth } else { CovenantBinding::Cov };
     let delegate_entrypoint_name = (binding == CovenantBinding::Cov).then_some(nonleader_entrypoint_name);
+    let delegate_body = (binding == CovenantBinding::Cov)
+        .then(|| contract.functions.iter().find(|function| is_covenant_delegate_source_function(function)))
+        .flatten()
+        .map(|function| CovenantDelegateBodyTarget {
+            source_name: function.name.clone(),
+            policy_function_name: generated_covenant_delegate_policy_name(&function.name),
+        });
 
     let mut generated_function_names = HashSet::from([generated_covenant_policy_name(function_name)]);
     generated_function_names.insert(generated_entrypoint_name.clone());
@@ -85,8 +108,18 @@ pub fn resolve_covenant_call_target<'i>(
             .map(|param| CovenantSourceBinding { param_name: param.name.clone(), param_type_name: param.type_ref.type_name() }),
         generated_entrypoint_name,
         delegate_entrypoint_name,
+        delegate_body,
         policy_function_name: generated_covenant_policy_name(function_name),
         generated_function_names,
+    })
+}
+
+fn is_covenant_delegate_source_function(function: &FunctionAst<'_>) -> bool {
+    function.attributes.iter().any(|attribute| {
+        matches!(
+            attribute.path.as_slice(),
+            [head, tail] if head == "covenant" && tail == "delegate"
+        )
     })
 }
 
@@ -104,4 +137,8 @@ fn is_covenant_source_function(function: &FunctionAst<'_>) -> bool {
 
 fn generated_covenant_policy_name(function_name: &str) -> String {
     format!("__covenant_policy_{function_name}")
+}
+
+fn generated_covenant_delegate_policy_name(function_name: &str) -> String {
+    format!("__covenant_delegate_policy_{function_name}")
 }

--- a/debugger/session/src/session.rs
+++ b/debugger/session/src/session.rs
@@ -676,14 +676,8 @@ impl<'a, 'i> DebugSession<'a, 'i> {
     }
 
     fn display_function_name(&self, function_name: &str) -> String {
-        if self
-            .active_covenant_call()
-            .is_some_and(|call| call.policy_function_name == function_name || call.matches_generated_name(function_name))
-        {
-            return self
-                .active_covenant_call()
-                .map(ResolvedCovenantCallTarget::display_name)
-                .unwrap_or_else(|| function_name.to_string());
+        if let Some(display_name) = self.active_covenant_call().and_then(|call| call.display_name_for(function_name)) {
+            return display_name.to_string();
         }
         function_name.to_string()
     }

--- a/debugger/session/tests/debug_session_tests.rs
+++ b/debugger/session/tests/debug_session_tests.rs
@@ -1781,12 +1781,110 @@ fn covenant_debugger_resolves_overridden_public_entrypoint_names() -> Result<(),
     assert_eq!(target.generated_entrypoint_name_for(false), "transfer_delegator");
     assert!(target.matches_generated_name("transfer"));
     assert!(target.matches_generated_name("transfer_delegator"));
+    let delegate_body = target.delegate_body.as_ref().ok_or("missing delegate body target")?;
+    assert_eq!(delegate_body.source_name, "authorizeDelegate");
+    assert_eq!(delegate_body.policy_function_name, "__covenant_delegate_policy_authorizeDelegate");
+    assert_eq!(target.display_name_for(&delegate_body.policy_function_name), Some("authorizeDelegate"));
     assert!(resolve_covenant_call_target(&parsed, &compiled, "authorizeDelegate").is_none());
     Ok(())
 }
 
 fn push_redeem_script(bytecode: &[u8]) -> Vec<u8> {
     ScriptBuilder::new().add_data(bytecode).expect("push redeem script").drain()
+}
+
+#[test]
+fn debug_session_displays_source_name_inside_covenant_delegate_body() -> Result<(), Box<dyn Error>> {
+    let source = r#"pragma silverscript ^0.1.0;
+
+contract Routed() {
+    #[covenant(
+        binding = cov,
+        from = 2,
+        to = 1,
+        name = transfer,
+        delegate_name = transfer_delegator
+    )]
+    function transferPolicy(int amount) {
+        require(amount >= 0);
+    }
+
+    #[covenant.delegate]
+    function authorizeDelegate(byte[] witness) {
+        require(witness.length > 0);
+        require(witness.length < 2);
+    }
+}
+"#;
+
+    let parsed_contract = parse_contract_ast(source)?;
+    let compile_opts = CompileOptions { record_debug_infos: true, ..Default::default() };
+    let compiled = compile_contract(source, &[], compile_opts)?;
+    let target = resolve_covenant_call_target(&parsed_contract, &compiled, "transferPolicy").ok_or("missing covenant call target")?;
+    let delegate_sigscript =
+        compiled.build_sig_script(&target.generated_entrypoint_name_for(false), vec![Expr::dynamic_bytes(vec![7])])?;
+    let mut input_sigscript = delegate_sigscript.clone();
+    input_sigscript.extend_from_slice(&push_redeem_script(&compiled.bytecode));
+
+    let inputs = vec![
+        TransactionInput {
+            previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([0x66u8; 32]), index: 0 },
+            signature_script: input_sigscript.clone(),
+            sequence: 0,
+            compute_commit: SigopCount(0).into(),
+        },
+        TransactionInput {
+            previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([0x77u8; 32]), index: 0 },
+            signature_script: input_sigscript,
+            sequence: 0,
+            compute_commit: SigopCount(0).into(),
+        },
+    ];
+    let output = TransactionOutput { value: 1000, script_public_key: ScriptPublicKey::new(0, vec![OpTrue].into()), covenant: None };
+    let tx = Transaction::new(1, inputs, vec![output], 0, Default::default(), 0, vec![]);
+    let covenant_id = Hash::from_bytes([0x88u8; 32]);
+    let utxos = vec![
+        UtxoEntry::new(1000, pay_to_script_hash_script(&compiled.bytecode), 0, tx.is_coinbase(), Some(covenant_id)),
+        UtxoEntry::new(1000, pay_to_script_hash_script(&compiled.bytecode), 0, tx.is_coinbase(), Some(covenant_id)),
+    ];
+    let populated_tx = PopulatedTransaction::new(&tx, utxos);
+    let cov_ctx = CovenantsContext::from_tx(&populated_tx)?;
+
+    let sig_cache = Cache::new(10_000);
+    let reused_values = SigHashReusedValuesUnsync::new();
+    let ctx = EngineCtx::new(&sig_cache).with_reused(&reused_values).with_covenants_ctx(&cov_ctx);
+    let input_ref = &tx.inputs[1];
+    let utxo_ref = populated_tx.utxo(1).ok_or("missing active delegate utxo")?;
+    let engine = debugger_session::session::DebugEngine::from_transaction_input(
+        &populated_tx,
+        input_ref,
+        1,
+        utxo_ref,
+        ctx,
+        EngineFlags { covenants_enabled: true, ..Default::default() },
+    );
+    let shadow_ctx =
+        ShadowTxContext { tx: &populated_tx, input: input_ref, input_index: 1, utxo_entry: utxo_ref, covenants_ctx: &cov_ctx };
+    let mut session = DebugSession::full(&delegate_sigscript, &compiled.bytecode, source, compiled.debug_info.clone(), engine)?
+        .with_shadow_tx_context(shadow_ctx)
+        .with_covenant_mode(None, Some(target));
+
+    session.run_to_first_executed_statement()?;
+    assert_eq!(session.current_function_name().as_deref(), Some("transferPolicy"));
+
+    let mut visited = Vec::new();
+    for _ in 0..8 {
+        session.step_into()?.ok_or("expected to step into the delegate body")?;
+        let function_name = session.current_function_name();
+        visited.push((function_name.clone(), session.current_span().map(|span| span.line)));
+        if function_name.as_deref() == Some("authorizeDelegate") {
+            break;
+        }
+    }
+    assert_eq!(session.current_function_name().as_deref(), Some("authorizeDelegate"));
+    assert_eq!(session.call_stack().last().map(String::as_str), Some("authorizeDelegate"));
+    assert_eq!(session.current_span().map(|span| span.line), Some(18), "visited steps: {visited:?}");
+    Ok(())
 }
 
 fn with_cov_rebalance_session<F>(mut f: F) -> Result<(), Box<dyn Error>>

--- a/debugger/session/tests/debug_session_tests.rs
+++ b/debugger/session/tests/debug_session_tests.rs
@@ -1750,6 +1750,41 @@ fn covenant_debug_value(value: i64) -> DebugValue {
     DebugValue::Object(vec![("value".to_string(), DebugValue::Int(value))])
 }
 
+#[test]
+fn covenant_debugger_resolves_overridden_public_entrypoint_names() -> Result<(), Box<dyn Error>> {
+    let source = r#"
+        contract Routed() {
+            #[covenant(
+                binding = cov,
+                from = 2,
+                to = 2,
+                name = transfer,
+                delegate_name = transfer_delegator
+            )]
+            function transferPolicy(int amount) {
+                require(amount >= 0);
+            }
+
+            #[covenant.delegate]
+            function authorizeDelegate(byte[] witness) {
+                require(witness.length > 0);
+            }
+        }
+    "#;
+
+    let parsed = parse_contract_ast(source)?;
+    let compiled = compile_contract(source, &[], CompileOptions::default())?;
+    let target = resolve_covenant_call_target(&parsed, &compiled, "transferPolicy").ok_or("missing covenant call target")?;
+
+    assert_eq!(target.generated_entrypoint_name, "transfer");
+    assert_eq!(target.generated_entrypoint_name_for(true), "transfer");
+    assert_eq!(target.generated_entrypoint_name_for(false), "transfer_delegator");
+    assert!(target.matches_generated_name("transfer"));
+    assert!(target.matches_generated_name("transfer_delegator"));
+    assert!(resolve_covenant_call_target(&parsed, &compiled, "authorizeDelegate").is_none());
+    Ok(())
+}
+
 fn push_redeem_script(bytecode: &[u8]) -> Vec<u8> {
     ScriptBuilder::new().add_data(bytecode).expect("push redeem script").drain()
 }

--- a/docs/DECL.md
+++ b/docs/DECL.md
@@ -23,7 +23,7 @@ Only policy functions are annotated.
 Canonical form:
 
 ```js
-#[covenant(binding = auth|cov, from = X, to = Y, mode = verification|transition, groups = multiple|single, termination = disallowed|allowed)]
+#[covenant(binding = auth|cov, from = X, to = Y, mode = verification|transition, groups = multiple|single, termination = disallowed|allowed, name = public_name, delegate_name = public_delegate_name)]
 ```
 
 Common form (with inferred defaults):
@@ -48,6 +48,15 @@ entry recover(...) {
 }
 ```
 
+Optional contract-wide delegate verification body:
+
+```js
+#[covenant.delegate]
+function authorizeDelegate(byte[] witness) {
+    verifyOwner(owner, ownerScheme, witness);
+}
+```
+
 Rules:
 
 1. `binding = auth` means auth-context lowering (`OpAuth*`).
@@ -64,6 +73,19 @@ Rules:
     other covenant declarations must also use `binding = cov`.
 12. A handwritten entrypoint in a leader contract is rejected unless it carries
     `#[covenant.allow(rule = manual_entrypoint_in_leader_contract)]`.
+13. `name` overrides the public name of the generated auth or leader wrapper.
+14. `delegate_name` is valid only on `binding = cov` declarations and overrides
+    the public name of the one shared delegate wrapper. All cov-bound
+    declarations in a contract must resolve to the same delegate name, including
+    the `__delegate` default.
+15. A contract may contain at most one `#[covenant.delegate]` function. It must
+    be a non-entrypoint verification function with no return values, and the
+    annotation accepts no properties. A delegate body is rejected unless the
+    contract also has at least one `binding = cov` declaration.
+
+`name` and `delegate_name` values are identifiers, not strings. Generated
+public names undergo the same duplicate-function and reserved-name validation
+as handwritten names.
 
 ### 1:N verification
 
@@ -106,6 +128,31 @@ contract C(int max_ins, int max_outs) {
 #[covenant(binding = cov, from = max_ins, to = max_outs, mode = transition)]
 function transition(State[] prev_states, int fee) : (State[] new_states) {
     // compute and return new_states
+}
+```
+
+### KCC20-shaped transfer interface
+
+Here `State` is the contract's implicit KCC20 state type. The final ABI is
+`transfer(State[],byte[])` and `transfer_delegator(byte[])`:
+
+```js
+#[covenant(
+    binding = cov,
+    from = max_token_inputs,
+    to = max_token_outputs,
+    name = transfer,
+    delegate_name = transfer_delegator
+)]
+function transferPolicy(State[] prev_states, State[] next_states, byte[] witness) {
+    // Validate the complete shared transition and the leader's local owner.
+    verifyOwner(owner, ownerScheme, witness);
+}
+
+#[covenant.delegate]
+function authorizeDelegate(byte[] witness) {
+    // `owner` and `ownerScheme` are fields of this active input's instance.
+    verifyOwner(owner, ownerScheme, witness);
 }
 ```
 
@@ -206,18 +253,53 @@ No explicit `cov_id != false` check is needed; `OpCovOutputCount(cov_id)` fails 
 
 Given policy function `f`:
 
-1. `1:N` generates one entrypoint:
+1. An auth-bound declaration generates one entrypoint:
 
-    * `__f`
+    * `__covenant_entrypoint_auth_f` by default; or
+    * the declaration's `name` value.
 2. The first `N:M` declaration makes the contract a leader contract. Each
    declaration generates its own leader entrypoint, while the contract has one
    shared delegate entrypoint:
 
-    * `__leader_f`
-    * `__delegate`
+    * `__leader_f` by default, or the declaration's `name` value;
+    * `__delegate` by default, or the common `delegate_name` value.
 
-`__delegate` does not call policy. It enforces contract-level delegation-path
-invariants only and is shared by every cov-bound declaration in the contract.
+Public ABI dispatch tags are calculated after lowering, from the final public
+name and final exposed parameter types:
+
+```text
+blake3("entryName(type1,type2,...)")[0..4]
+```
+
+Consequently, a name override changes the protocol-visible dispatch tag.
+Compiler-internal policy names remain derived from source policy names and do
+not use public overrides. Covenant sigscript helpers and debugger routing resolve
+the final public wrapper names.
+
+### Shared delegate body
+
+Every cov-bound declaration in a contract uses the same generated delegate
+wrapper and, when present, the same `#[covenant.delegate]` body. The wrapper:
+
+1. derives the active input's covenant ID;
+2. rejects the first input in that covenant-ID group;
+3. calls the delegate body with the wrapper's ABI arguments.
+
+The delegate body's parameters become the public delegate entrypoint's
+parameters in the same order and with the same types. Its body may read current
+contract fields directly; no `State` argument is injected. It must return no
+values.
+
+There is deliberately no declaration property that selects a delegate body.
+Allowing each leader route to choose independently would let delegators invoke
+the weakest policy unless every leader authenticated the route selected by
+every input.
+
+For source compatibility, a leader contract with no `#[covenant.delegate]`
+body still receives the inert default delegate. That wrapper checks only that
+the active input is not the group leader and has no parameters. Protocols whose
+delegators have local obligations, including the default KCC20 transfer
+configuration, must declare a delegate body.
 
 ## Leader contracts
 
@@ -225,7 +307,8 @@ A `binding = cov` declaration generates its own leader entrypoint. A leader
 contract generates exactly one shared delegate entrypoint, regardless of how
 many cov-bound declarations it contains. The leader runs at covenant input zero
 and validates the shared covenant transition. A delegate runs at another
-covenant input and relies on input zero to perform that validation.
+covenant input, runs the shared delegate body if declared, and relies on input
+zero to perform the complete shared-transition validation.
 
 This makes delegation a contract-wide property. A generated delegate
 authenticates the contract at input zero, but cannot determine which entrypoint
@@ -292,6 +375,12 @@ contract VaultNM(
 
         require(in_sum >= out_sum);
     }
+
+    #[covenant.delegate]
+    function authorizeDelegate(sig owner_sig) {
+        // Example local delegate authorization.
+        require(checkSig(owner_sig, pubkey(owner)));
+    }
 }
 ```
 
@@ -314,6 +403,7 @@ contract VaultNM(
     // Compiler-lowered policy function (renamed to avoid collision with generated entrypoints)
     // same body as source:
     function __covenant_policy_conserve_and_bump(State[] prev_states, State[] new_states, sig leader_sig) { ... }
+    function __covenant_delegate_policy_authorizeDelegate(sig owner_sig) { ... }
 
     // Generated for N:M leader path
     entry __leader_conserve_and_bump(State[] new_states, sig leader_sig) {
@@ -355,10 +445,11 @@ contract VaultNM(
     }
 
     // Generated for N:M delegate path
-    entry __delegate() {
+    entry __delegate(sig owner_sig) {
         byte[32] cov_id = OpInputCovenantId(this.activeInputIndex);
         // delegate path must not be leader
         require(OpCovInputIdx(cov_id, 0) != this.activeInputIndex);
+        __covenant_delegate_policy_authorizeDelegate(owner_sig);
     }
 }
 ```
@@ -420,3 +511,22 @@ contract SeqCommitMirror(byte[32] init_seqcommit) {
 2. Internally the compiler can lower `State`/`State[]` into any representation; this doc only fixes the user-facing API.
 3. Existing `readInputState`/`validateOutputState` remain the codegen backbone; `validateOutputStateWithTemplate` is available for manual cross-template routing, not declaration lowering.
 4. `N:M` lowering keeps one transition group per transaction.
+
+## Homogeneous-template assumption
+
+Stateful covenant declarations assume that every selected input and every
+continuation output in the active covenant-ID group uses this contract's exact
+program template and implicit `State` layout. In particular:
+
+1. generated prior-state reconstruction uses raw `readInputState` with this
+   contract's field offsets and types;
+2. generated continuation checks use same-template `validateOutputState`;
+3. a shared covenant ID is therefore treated by this abstraction as one
+   homogeneous contract family, even though the underlying covenant mechanism
+   can represent more general arrangements.
+
+Reading an input with another layout can misinterpret its bytes, and a
+continuation with another template will fail same-template validation. A
+heterogeneous covenant family must use handwritten validation with the
+templated state builtins, authenticate each participating template and layout,
+and must not rely on covenant-declaration state wrappers for that route.

--- a/docs/DECL.md
+++ b/docs/DECL.md
@@ -83,6 +83,10 @@ Rules:
     annotation accepts no properties. A delegate body is rejected unless the
     contract also has at least one `binding = cov` declaration.
 
+Covenant declaration policies and delegate bodies are compiler-invoked hooks
+and cannot be called directly from source. Extract shared logic into an
+unannotated helper function instead.
+
 `name` and `delegate_name` values are identifiers, not strings. Generated
 public names undergo the same duplicate-function and reserved-name validation
 as handwritten names.

--- a/docs/kcc20-book/src/scenarios.md
+++ b/docs/kcc20-book/src/scenarios.md
@@ -1408,14 +1408,18 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
     let covenant_id_auxiliary_outpoint = TransactionOutpoint { transaction_id: TransactionId::from_bytes([3; 32]), index: 0 };
 
     {
-        let covenant_id_wrong_witness_tx = build_spend_tx(
+        let covenant_id_wrong_covenant_entries = vec![
+            covenant_id_spend_entries[0].clone(),
+            UtxoEntry::new(500, pay_to_script_hash_script(&[0x51]), 0, false, Some(COV_B)),
+        ];
+        let covenant_id_wrong_covenant_tx = build_spend_tx(
             1,
             Some(covenant_id_auxiliary_outpoint),
-            build_kcc20_sigscript(&split_states[1], covenant_spend_destination_owner_bytes.clone(), 600, 0),
+            build_kcc20_sigscript(&split_states[1], covenant_spend_destination_owner_bytes.clone(), 600, 1),
             covenant_id_spend_outputs.clone(),
         );
-        let err = execute_input_with_covenants(covenant_id_wrong_witness_tx, covenant_id_spend_entries.clone(), 0)
-            .expect_err("KCC20 covenant-id-owned tokens should reject the wrong witness index");
+        let err = execute_input_with_covenants(covenant_id_wrong_covenant_tx, covenant_id_wrong_covenant_entries, 0)
+            .expect_err("KCC20 covenant-id-owned tokens should reject a different covenant ID");
         assert_verify_like_error(err);
     }
 
@@ -1462,9 +1466,9 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
 
 This example explores the two non-pubkey ownership modes in KCC20.
 
-It first creates one script-hash-owned branch and one covenant-ID-owned branch. It then checks, for each mode:
+It first creates one script-hash-owned branch and one covenant-ID-owned branch. It then checks the relevant failure modes for each:
 
-- the wrong witness input is rejected
+- a mismatched witness or covenant ID is rejected
 - a missing matching input is rejected
 - the wrong kind of owner input is rejected
 - the correct matching input is accepted
@@ -1479,7 +1483,7 @@ script-hash-owned branch:
   matching script    -> accept
 
 covenant-ID-owned branch:
-  wrong witness      -> reject
+  wrong covenant ID  -> reject
   missing covenant   -> reject
   wrong owner kind   -> reject
   matching covenant  -> accept

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -10,7 +10,7 @@ use kaspa_txscript::EngineFlags;
 use kaspa_txscript::opcodes::codes::*;
 use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::serialize_i64;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 mod analysis;
 mod const_eval;
@@ -240,7 +240,7 @@ fn build_compiled_contract<'i>(
     lowered_contract: &ContractAst<'i>,
     covenant_lowered_contract: &ContractAst<'i>,
     function_abi_entries: Vec<FunctionAbiEntry>,
-    cov_decl_to_abi: &HashMap<String, FunctionAbiEntry>,
+    cov_decl_to_abi: &BTreeMap<String, FunctionAbiEntry>,
     delegate_entry_abi: Option<&FunctionAbiEntry>,
     bytecode: Vec<u8>,
     state_layout: CompiledStateLayout,

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -52,6 +52,7 @@ pub(super) fn compile_contract_impl<'i>(
     let inferred_lowered_contract = lower_inferred_array_sizes(contract, &constants)?;
     static_check_contract(&inferred_lowered_contract, constructor_args, options)?;
     let covenant_lowered_contract = lower_covenant_declarations(&inferred_lowered_contract, &constants)?;
+    validate_declaration_names(&covenant_lowered_contract)?;
     let ternary_lowered_contract = lower_ternaries(&covenant_lowered_contract, &constants)?;
     let read_input_state_lowered_contract = lower_read_input_state_calls(&ternary_lowered_contract)?;
     let inline_lowered_contract = lower_inline_functions(&read_input_state_lowered_contract, &mut debug_recorder)?;

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -51,7 +51,7 @@ pub(super) fn compile_contract_impl<'i>(
     let mut debug_recorder = DebugRecorder::new(options, contract)?;
     let inferred_lowered_contract = lower_inferred_array_sizes(contract, &constants)?;
     static_check_contract(&inferred_lowered_contract, constructor_args, options)?;
-    let covenant_lowered_contract = lower_covenant_declarations(&inferred_lowered_contract, &constants)?;
+    let (covenant_lowered_contract, covenant_abi_names) = lower_covenant_declarations(&inferred_lowered_contract, &constants)?;
     validate_declaration_names(&covenant_lowered_contract)?;
     let ternary_lowered_contract = lower_ternaries(&covenant_lowered_contract, &constants)?;
     let read_input_state_lowered_contract = lower_read_input_state_calls(&ternary_lowered_contract)?;
@@ -69,12 +69,11 @@ pub(super) fn compile_contract_impl<'i>(
     let mut lowered_constants = flatten_constructor_args_env(&covenant_lowered_contract.params, constructor_args, &structs)?;
     lowered_constants.extend(lowered_contract.constants.iter().map(|constant| (constant.name.clone(), constant.expr.clone())));
 
-    let entrypoint_functions: Vec<&FunctionAst<'i>> = lowered_contract.functions.iter().filter(|func| func.entrypoint).collect();
-    if entrypoint_functions.is_empty() {
+    let (function_abi_entries, cov_decl_to_abi, delegate_entry_abi) =
+        build_abi(&covenant_lowered_contract, &constants, &covenant_abi_names)?;
+    if function_abi_entries.is_empty() {
         return Err(CompilerError::Unsupported("contract has no entries".to_string()));
     }
-
-    let function_abi_entries = build_function_abi_entries(&covenant_lowered_contract, &constants)?;
 
     // dispatch tag: verify no collisions and insert tags to global state
     let mut entrypoints_by_tag = HashMap::<DispatchTag, &str>::new();
@@ -108,6 +107,8 @@ pub(super) fn compile_contract_impl<'i>(
                 &lowered_contract,
                 &covenant_lowered_contract,
                 function_abi_entries.clone(),
+                &cov_decl_to_abi,
+                delegate_entry_abi.as_ref(),
                 bytecode,
                 state_layout,
                 debug_info,
@@ -120,6 +121,8 @@ pub(super) fn compile_contract_impl<'i>(
                 &lowered_contract,
                 &covenant_lowered_contract,
                 function_abi_entries.clone(),
+                &cov_decl_to_abi,
+                delegate_entry_abi.as_ref(),
                 bytecode,
                 state_layout,
                 debug_info,
@@ -237,6 +240,8 @@ fn build_compiled_contract<'i>(
     lowered_contract: &ContractAst<'i>,
     covenant_lowered_contract: &ContractAst<'i>,
     function_abi_entries: Vec<FunctionAbiEntry>,
+    cov_decl_to_abi: &HashMap<String, FunctionAbiEntry>,
+    delegate_entry_abi: Option<&FunctionAbiEntry>,
     bytecode: Vec<u8>,
     state_layout: CompiledStateLayout,
     debug_info: Option<DebugInfo<'i>>,
@@ -247,6 +252,8 @@ fn build_compiled_contract<'i>(
         bytecode,
         ast: covenant_lowered_contract.clone(),
         abi: function_abi_entries,
+        cov_decl_to_abi: cov_decl_to_abi.clone(),
+        delegate_entry_abi: delegate_entry_abi.cloned(),
         state_layout,
         debug_info,
     }

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -69,7 +69,7 @@ pub(super) fn compile_contract_impl<'i>(
     let mut lowered_constants = flatten_constructor_args_env(&covenant_lowered_contract.params, constructor_args, &structs)?;
     lowered_constants.extend(lowered_contract.constants.iter().map(|constant| (constant.name.clone(), constant.expr.clone())));
 
-    let (function_abi_entries, cov_decl_to_abi, delegate_entry_abi) =
+    let BuiltAbi { function_abi_entries, cov_decl_to_abi, delegate_entry_abi } =
         build_abi(&covenant_lowered_contract, &constants, &covenant_abi_names)?;
     if function_abi_entries.is_empty() {
         return Err(CompilerError::Unsupported("contract has no entries".to_string()));

--- a/silverscript-lang/src/compiler/compile/helpers.rs
+++ b/silverscript-lang/src/compiler/compile/helpers.rs
@@ -1,6 +1,12 @@
 use super::*;
 use crate::compiler::covenant_declarations::CovenantDeclarationAbiNames;
 
+pub(super) struct BuiltAbi {
+    pub(super) function_abi_entries: Vec<FunctionAbiEntry>,
+    pub(super) cov_decl_to_abi: HashMap<String, FunctionAbiEntry>,
+    pub(super) delegate_entry_abi: Option<FunctionAbiEntry>,
+}
+
 pub(super) fn compile_contract_fields<'i>(
     fields: &[ContractFieldAst<'i>],
     base_constants: &HashMap<String, Expr<'i>>,
@@ -52,14 +58,14 @@ pub(super) fn build_abi<'i>(
     contract: &ContractAst<'i>,
     constants: &HashMap<String, Expr<'i>>,
     covenant_abi_names: &CovenantDeclarationAbiNames,
-) -> Result<(Vec<FunctionAbiEntry>, HashMap<String, FunctionAbiEntry>, Option<FunctionAbiEntry>), CompilerError> {
+) -> Result<BuiltAbi, CompilerError> {
     let source_name_by_entrypoint = covenant_abi_names
         .entrypoints
         .iter()
         .map(|(source_name, entrypoint_name)| (entrypoint_name.as_str(), source_name.as_str()))
         .collect::<HashMap<_, _>>();
     let delegate_entrypoint = covenant_abi_names.delegate_entrypoint.as_deref();
-    let mut entries = Vec::new();
+    let mut function_abi_entries = Vec::new();
     let mut cov_decl_to_abi = HashMap::new();
     let mut delegate_entry_abi = None;
 
@@ -98,7 +104,7 @@ pub(super) fn build_abi<'i>(
         if delegate_entrypoint == Some(func.name.as_str()) {
             delegate_entry_abi = Some(entry.clone());
         }
-        entries.push(entry);
+        function_abi_entries.push(entry);
     }
 
     if let Some((source_name, entrypoint_name)) =
@@ -114,7 +120,7 @@ pub(super) fn build_abi<'i>(
         )));
     }
 
-    Ok((entries, cov_decl_to_abi, delegate_entry_abi))
+    Ok(BuiltAbi { function_abi_entries, cov_decl_to_abi, delegate_entry_abi })
 }
 
 pub(super) fn array_element_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<i64> {

--- a/silverscript-lang/src/compiler/compile/helpers.rs
+++ b/silverscript-lang/src/compiler/compile/helpers.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::compiler::covenant_declarations::CovenantDeclarationAbiNames;
 
 pub(super) fn compile_contract_fields<'i>(
     fields: &[ContractFieldAst<'i>],
@@ -47,44 +48,73 @@ pub(super) fn infer_expr_type<'i>(
     type_check::check_expr(expr, None, &ctx)
 }
 
-pub(super) fn build_function_abi_entries<'i>(
+pub(super) fn build_abi<'i>(
     contract: &ContractAst<'i>,
     constants: &HashMap<String, Expr<'i>>,
-) -> Result<Vec<FunctionAbiEntry>, CompilerError> {
-    contract
-        .functions
+    covenant_abi_names: &CovenantDeclarationAbiNames,
+) -> Result<(Vec<FunctionAbiEntry>, HashMap<String, FunctionAbiEntry>, Option<FunctionAbiEntry>), CompilerError> {
+    let source_name_by_entrypoint = covenant_abi_names
+        .entrypoints
         .iter()
-        .filter(|func| func.entrypoint)
-        .map(|func| {
-            let inputs = func
-                .params
-                .iter()
-                .map(|param| {
-                    let mut type_ref = param.type_ref.clone();
-                    for dimension in &mut type_ref.array_dims {
-                        if matches!(dimension, ArrayDim::Inferred) {
-                            return Err(CompilerError::NonCanonicalEntrypointParameter {
-                                function: func.name.clone(),
-                                param: param.name.clone(),
-                            });
-                        }
-                        if let ArrayDim::Constant(name) = dimension {
-                            let value = constants
-                                .get(name)
-                                .ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))
-                                .and_then(|expr| eval_const_int(expr, constants))?;
-                            let size = usize::try_from(value).map_err(|_| {
-                                CompilerError::Unsupported(format!("array size constant '{name}' must be a non-negative integer"))
-                            })?;
-                            *dimension = ArrayDim::Fixed(size);
-                        }
+        .map(|(source_name, entrypoint_name)| (entrypoint_name.as_str(), source_name.as_str()))
+        .collect::<HashMap<_, _>>();
+    let delegate_entrypoint = covenant_abi_names.delegate_entrypoint.as_deref();
+    let mut entries = Vec::new();
+    let mut cov_decl_to_abi = HashMap::new();
+    let mut delegate_entry_abi = None;
+
+    for func in contract.functions.iter().filter(|func| func.entrypoint) {
+        let inputs = func
+            .params
+            .iter()
+            .map(|param| {
+                let mut type_ref = param.type_ref.clone();
+                for dimension in &mut type_ref.array_dims {
+                    if matches!(dimension, ArrayDim::Inferred) {
+                        return Err(CompilerError::NonCanonicalEntrypointParameter {
+                            function: func.name.clone(),
+                            param: param.name.clone(),
+                        });
                     }
-                    Ok(FunctionInputAbi { name: param.name.clone(), type_name: type_ref.type_name() })
-                })
-                .collect::<Result<Vec<_>, CompilerError>>()?;
-            Ok(FunctionAbiEntry { name: func.name.clone(), inputs })
-        })
-        .collect()
+                    if let ArrayDim::Constant(name) = dimension {
+                        let value = constants
+                            .get(name)
+                            .ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))
+                            .and_then(|expr| eval_const_int(expr, constants))?;
+                        let size = usize::try_from(value).map_err(|_| {
+                            CompilerError::Unsupported(format!("array size constant '{name}' must be a non-negative integer"))
+                        })?;
+                        *dimension = ArrayDim::Fixed(size);
+                    }
+                }
+                Ok(FunctionInputAbi { name: param.name.clone(), type_name: type_ref.type_name() })
+            })
+            .collect::<Result<Vec<_>, CompilerError>>()?;
+        let entry = FunctionAbiEntry { name: func.name.clone(), inputs };
+
+        if let Some(source_name) = source_name_by_entrypoint.get(func.name.as_str()) {
+            cov_decl_to_abi.insert((*source_name).to_string(), entry.clone());
+        }
+        if delegate_entrypoint == Some(func.name.as_str()) {
+            delegate_entry_abi = Some(entry.clone());
+        }
+        entries.push(entry);
+    }
+
+    if let Some((source_name, entrypoint_name)) =
+        covenant_abi_names.entrypoints.iter().find(|(source_name, _)| !cov_decl_to_abi.contains_key(*source_name))
+    {
+        return Err(CompilerError::Unsupported(format!(
+            "generated covenant entrypoint '{entrypoint_name}' for declaration '{source_name}' is missing from the ABI"
+        )));
+    }
+    if let Some(entrypoint_name) = delegate_entrypoint.filter(|_| delegate_entry_abi.is_none()) {
+        return Err(CompilerError::Unsupported(format!(
+            "generated covenant delegate entrypoint '{entrypoint_name}' is missing from the ABI"
+        )));
+    }
+
+    Ok((entries, cov_decl_to_abi, delegate_entry_abi))
 }
 
 pub(super) fn array_element_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<i64> {

--- a/silverscript-lang/src/compiler/compile/helpers.rs
+++ b/silverscript-lang/src/compiler/compile/helpers.rs
@@ -3,7 +3,7 @@ use crate::compiler::covenant_declarations::CovenantDeclarationAbiNames;
 
 pub(super) struct BuiltAbi {
     pub(super) function_abi_entries: Vec<FunctionAbiEntry>,
-    pub(super) cov_decl_to_abi: HashMap<String, FunctionAbiEntry>,
+    pub(super) cov_decl_to_abi: BTreeMap<String, FunctionAbiEntry>,
     pub(super) delegate_entry_abi: Option<FunctionAbiEntry>,
 }
 
@@ -66,7 +66,7 @@ pub(super) fn build_abi<'i>(
         .collect::<HashMap<_, _>>();
     let delegate_entrypoint = covenant_abi_names.delegate_entrypoint.as_deref();
     let mut function_abi_entries = Vec::new();
-    let mut cov_decl_to_abi = HashMap::new();
+    let mut cov_decl_to_abi = BTreeMap::new();
     let mut delegate_entry_abi = None;
 
     for func in contract.functions.iter().filter(|func| func.entrypoint) {

--- a/silverscript-lang/src/compiler/covenant_declarations.rs
+++ b/silverscript-lang/src/compiler/covenant_declarations.rs
@@ -41,7 +41,7 @@ struct CovenantDeclaration<'i> {
 }
 
 pub(super) struct CovenantDeclarationAbiNames {
-    pub entrypoints: HashMap<String, String>,
+    pub entrypoints: BTreeMap<String, String>,
     pub delegate_entrypoint: Option<String>,
 }
 
@@ -50,7 +50,7 @@ pub(super) fn lower_covenant_declarations<'i>(
     constants: &HashMap<String, Expr<'i>>,
 ) -> Result<(ContractAst<'i>, CovenantDeclarationAbiNames), CompilerError> {
     let mut lowered = Vec::new();
-    let mut covenant_entrypoints = HashMap::new();
+    let mut covenant_entrypoints = BTreeMap::new();
     let mut cov_declaration = None;
     let mut shared_delegate_source = None;
     let mut shared_delegate_entrypoint = None;

--- a/silverscript-lang/src/compiler/covenant_declarations.rs
+++ b/silverscript-lang/src/compiler/covenant_declarations.rs
@@ -34,6 +34,8 @@ struct CovenantDeclaration<'i> {
     groups: CovenantGroups,
     singleton: bool,
     termination: CovenantTermination,
+    entrypoint_name: Option<String>,
+    delegate_entrypoint_name: Option<String>,
     from_expr: Expr<'i>,
     to_expr: Expr<'i>,
 }
@@ -45,10 +47,31 @@ pub(super) fn lower_covenant_declarations<'i>(
     let mut lowered = Vec::new();
     let mut cov_declaration = None;
     let mut shared_delegate_source = None;
+    let mut shared_delegate_entrypoint = None;
+    let mut delegate_policy: Option<FunctionAst<'i>> = None;
+    let mut delegate_body_name = None;
     let mut auth_declaration = None;
     let mut manual_entrypoint = None;
 
     for function in &contract.functions {
+        if is_covenant_delegate_body(function) {
+            validate_covenant_delegate_body(function)?;
+            if let Some(existing) = &delegate_body_name {
+                return Err(CompilerError::Unsupported(format!(
+                    "contract '{}' declares more than one #[covenant.delegate] body ('{}' and '{}')",
+                    contract.name, existing, function.name
+                )));
+            }
+
+            let mut policy = function.clone();
+            policy.name = generated_covenant_delegate_policy_name(&function.name);
+            policy.attributes.clear();
+            delegate_body_name = Some(function.name.clone());
+            delegate_policy = Some(policy.clone());
+            lowered.push(policy);
+            continue;
+        }
+
         if allows_manual_entrypoint_in_leader_contract(function)? {
             let mut lowered_function = function.clone();
             lowered_function.attributes.clear();
@@ -78,27 +101,46 @@ pub(super) fn lower_covenant_declarations<'i>(
         match declaration.binding {
             CovenantBinding::Auth => {
                 auth_declaration.get_or_insert_with(|| function.name.clone());
-                let entrypoint_name = generated_covenant_auth_entrypoint_name(&function.name);
+                let entrypoint_name =
+                    declaration.entrypoint_name.clone().unwrap_or_else(|| generated_covenant_auth_entrypoint_name(&function.name));
                 let mut wrapper = build_auth_wrapper(&policy, &policy_name, declaration.clone(), entrypoint_name, &contract.fields)?;
                 wrapper.params = preserved_entrypoint_params(function, declaration, true, &contract.fields);
                 lowered.push(wrapper);
             }
             CovenantBinding::Cov => {
                 cov_declaration.get_or_insert_with(|| function.name.clone());
-                let leader_name = generated_covenant_leader_entrypoint_name(&function.name);
+                let leader_name =
+                    declaration.entrypoint_name.clone().unwrap_or_else(|| generated_covenant_leader_entrypoint_name(&function.name));
                 let mut leader_wrapper =
                     build_cov_leader_wrapper(&policy, &policy_name, declaration.clone(), leader_name, &contract.fields)?;
                 leader_wrapper.params = preserved_entrypoint_params(function, declaration.clone(), true, &contract.fields);
                 lowered.push(leader_wrapper);
 
                 shared_delegate_source.get_or_insert(policy);
+                let delegate_entrypoint_name =
+                    declaration.delegate_entrypoint_name.clone().unwrap_or_else(generated_covenant_delegate_entrypoint_name);
+                if let Some((existing_name, existing_declaration)) = &shared_delegate_entrypoint {
+                    if existing_name != &delegate_entrypoint_name {
+                        return Err(CompilerError::Unsupported(format!(
+                            "covenant declarations '{}' and '{}' select conflicting shared delegate entrypoint names '{}' and '{}'",
+                            existing_declaration, function.name, existing_name, delegate_entrypoint_name
+                        )));
+                    }
+                } else {
+                    shared_delegate_entrypoint = Some((delegate_entrypoint_name, function.name.clone()));
+                }
             }
         }
     }
 
     if let Some(policy) = shared_delegate_source {
-        let delegate_name = generated_covenant_delegate_entrypoint_name();
-        lowered.push(build_cov_delegate_wrapper(&policy, delegate_name));
+        let delegate_name = shared_delegate_entrypoint.expect("a cov-bound declaration always selects a delegate entrypoint").0;
+        lowered.push(build_cov_delegate_wrapper(&policy, delegate_policy.as_ref(), delegate_name));
+    } else if delegate_policy.is_some() {
+        return Err(CompilerError::Unsupported(format!(
+            "#[covenant.delegate] body '{}' requires at least one binding=cov covenant declaration",
+            delegate_body_name.expect("a delegate policy preserves its source name")
+        )));
     }
 
     if let Some(cov_declaration) = cov_declaration {
@@ -119,6 +161,32 @@ pub(super) fn lower_covenant_declarations<'i>(
     let mut lowered_contract = contract.clone();
     lowered_contract.functions = lowered;
     Ok(lowered_contract)
+}
+
+fn is_covenant_delegate_body(function: &FunctionAst<'_>) -> bool {
+    function
+        .attributes
+        .iter()
+        .any(|attribute| matches!(attribute.path.as_slice(), [head, tail] if head == "covenant" && tail == "delegate"))
+}
+
+fn validate_covenant_delegate_body(function: &FunctionAst<'_>) -> Result<(), CompilerError> {
+    if function.attributes.len() != 1 {
+        return Err(CompilerError::Unsupported("#[covenant.delegate] must be the only attribute on the delegate body".to_string()));
+    }
+    if function.entrypoint {
+        return Err(CompilerError::Unsupported("#[covenant.delegate] must be applied to a function, not an entrypoint".to_string()));
+    }
+    if !function.attributes[0].args.is_empty() {
+        return Err(CompilerError::Unsupported("#[covenant.delegate] does not accept arguments".to_string()));
+    }
+    if !function.return_types.is_empty() {
+        return Err(CompilerError::Unsupported(format!(
+            "#[covenant.delegate] body '{}' must be verification-only and return no values",
+            function.name
+        )));
+    }
+    Ok(())
 }
 
 fn allows_manual_entrypoint_in_leader_contract(function: &FunctionAst<'_>) -> Result<bool, CompilerError> {
@@ -195,7 +263,8 @@ fn parse_covenant_declaration<'i>(
         }
     }
 
-    let allowed_keys: HashSet<&str> = ["binding", "from", "to", "mode", "groups", "termination"].into_iter().collect();
+    let allowed_keys: HashSet<&str> =
+        ["binding", "from", "to", "mode", "groups", "termination", "name", "delegate_name"].into_iter().collect();
     for arg in &attribute.args {
         if !allowed_keys.contains(arg.name.as_str()) {
             return Err(CompilerError::Unsupported(format!("unknown covenant attribute argument '{}'", arg.name)));
@@ -321,6 +390,15 @@ fn parse_covenant_declaration<'i>(
     if binding == CovenantBinding::Cov && groups == CovenantGroups::Multiple {
         return Err(CompilerError::Unsupported("binding=cov with groups=multiple is not supported yet".to_string()));
     }
+    if binding == CovenantBinding::Auth && args_by_name.contains_key("delegate_name") {
+        return Err(CompilerError::Unsupported(
+            "covenant attribute argument 'delegate_name' is valid only with binding=cov".to_string(),
+        ));
+    }
+
+    let entrypoint_name = args_by_name.get("name").map(|expr| parse_attr_ident_arg("name", Some(expr))).transpose()?;
+    let delegate_entrypoint_name =
+        args_by_name.get("delegate_name").map(|expr| parse_attr_ident_arg("delegate_name", Some(expr))).transpose()?;
 
     if mode == CovenantMode::Verification && !function.return_types.is_empty() {
         return Err(CompilerError::Unsupported("verification mode policy functions must not declare return values".to_string()));
@@ -352,6 +430,8 @@ fn parse_covenant_declaration<'i>(
         groups,
         singleton: syntax == CovenantSyntax::Singleton,
         termination,
+        entrypoint_name,
+        delegate_entrypoint_name,
         from_expr: from_expr.clone(),
         to_expr: to_expr.clone(),
     })
@@ -742,10 +822,14 @@ fn build_cov_leader_wrapper<'i>(
     Ok(generated_entrypoint(policy, entrypoint_name, leader_params, body))
 }
 
-fn build_cov_delegate_wrapper<'i>(policy: &FunctionAst<'i>, entrypoint_name: String) -> FunctionAst<'i> {
+fn build_cov_delegate_wrapper<'i>(
+    leader_policy: &FunctionAst<'i>,
+    delegate_policy: Option<&FunctionAst<'i>>,
+    entrypoint_name: String,
+) -> FunctionAst<'i> {
     let active_input = active_input_index_expr();
     let cov_id_name = "__cov_id";
-    let body = vec![
+    let mut body = vec![
         var_def_statement(bytes32_type(), cov_id_name, Expr::call("OpInputCovenantId", vec![active_input.clone()])),
         require_statement(binary_expr(
             BinaryOp::Ne,
@@ -753,7 +837,16 @@ fn build_cov_delegate_wrapper<'i>(policy: &FunctionAst<'i>, entrypoint_name: Str
             active_input,
         )),
     ];
-    generated_entrypoint(policy, entrypoint_name, Vec::new(), body)
+    let (source, params) = if let Some(delegate_policy) = delegate_policy {
+        body.push(call_statement(
+            &delegate_policy.name,
+            delegate_policy.params.iter().map(|param| identifier_expr(&param.name)).collect(),
+        ));
+        (delegate_policy, delegate_policy.params.clone())
+    } else {
+        (leader_policy, Vec::new())
+    };
+    generated_entrypoint(source, entrypoint_name, params, body)
 }
 
 fn generated_entrypoint<'i>(

--- a/silverscript-lang/src/compiler/covenant_declarations.rs
+++ b/silverscript-lang/src/compiler/covenant_declarations.rs
@@ -40,11 +40,17 @@ struct CovenantDeclaration<'i> {
     to_expr: Expr<'i>,
 }
 
+pub(super) struct CovenantDeclarationAbiNames {
+    pub entrypoints: HashMap<String, String>,
+    pub delegate_entrypoint: Option<String>,
+}
+
 pub(super) fn lower_covenant_declarations<'i>(
     contract: &ContractAst<'i>,
     constants: &HashMap<String, Expr<'i>>,
-) -> Result<ContractAst<'i>, CompilerError> {
+) -> Result<(ContractAst<'i>, CovenantDeclarationAbiNames), CompilerError> {
     let mut lowered = Vec::new();
+    let mut covenant_entrypoints = HashMap::new();
     let mut cov_declaration = None;
     let mut shared_delegate_source = None;
     let mut shared_delegate_entrypoint = None;
@@ -103,6 +109,7 @@ pub(super) fn lower_covenant_declarations<'i>(
                 auth_declaration.get_or_insert_with(|| function.name.clone());
                 let entrypoint_name =
                     declaration.entrypoint_name.clone().unwrap_or_else(|| generated_covenant_auth_entrypoint_name(&function.name));
+                covenant_entrypoints.insert(function.name.clone(), entrypoint_name.clone());
                 let mut wrapper = build_auth_wrapper(&policy, &policy_name, declaration.clone(), entrypoint_name, &contract.fields)?;
                 wrapper.params = preserved_entrypoint_params(function, declaration, true, &contract.fields);
                 lowered.push(wrapper);
@@ -111,6 +118,7 @@ pub(super) fn lower_covenant_declarations<'i>(
                 cov_declaration.get_or_insert_with(|| function.name.clone());
                 let leader_name =
                     declaration.entrypoint_name.clone().unwrap_or_else(|| generated_covenant_leader_entrypoint_name(&function.name));
+                covenant_entrypoints.insert(function.name.clone(), leader_name.clone());
                 let mut leader_wrapper =
                     build_cov_leader_wrapper(&policy, &policy_name, declaration.clone(), leader_name, &contract.fields)?;
                 leader_wrapper.params = preserved_entrypoint_params(function, declaration.clone(), true, &contract.fields);
@@ -133,15 +141,18 @@ pub(super) fn lower_covenant_declarations<'i>(
         }
     }
 
-    if let Some(policy) = shared_delegate_source {
+    let delegate_entrypoint = if let Some(policy) = shared_delegate_source {
         let delegate_name = shared_delegate_entrypoint.expect("a cov-bound declaration always selects a delegate entrypoint").0;
-        lowered.push(build_cov_delegate_wrapper(&policy, delegate_policy.as_ref(), delegate_name));
+        lowered.push(build_cov_delegate_wrapper(&policy, delegate_policy.as_ref(), delegate_name.clone()));
+        Some(delegate_name)
     } else if delegate_policy.is_some() {
         return Err(CompilerError::Unsupported(format!(
             "#[covenant.delegate] body '{}' requires at least one binding=cov covenant declaration",
             delegate_body_name.expect("a delegate policy preserves its source name")
         )));
-    }
+    } else {
+        None
+    };
 
     if let Some(cov_declaration) = cov_declaration {
         if let Some(auth_declaration) = auth_declaration {
@@ -160,7 +171,7 @@ pub(super) fn lower_covenant_declarations<'i>(
 
     let mut lowered_contract = contract.clone();
     lowered_contract.functions = lowered;
-    Ok(lowered_contract)
+    Ok((lowered_contract, CovenantDeclarationAbiNames { entrypoints: covenant_entrypoints, delegate_entrypoint }))
 }
 
 fn is_covenant_delegate_body(function: &FunctionAst<'_>) -> bool {

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -51,6 +51,7 @@ use validate_output_state::lower_validate_output_state;
 pub const SYNTHETIC_ARG_PREFIX: &str = "__arg";
 pub const COMPILER_VERSION: &str = "0.1.0";
 const COVENANT_POLICY_PREFIX: &str = "__covenant_policy";
+const COVENANT_DELEGATE_POLICY_PREFIX: &str = "__covenant_delegate_policy";
 pub const COVENANT_ENTRYPOINT_AUTH_PREFIX: &str = "__covenant_entrypoint_auth";
 pub(super) type TypeMap = HashMap<String, TypeRef>;
 
@@ -61,6 +62,10 @@ pub struct CovenantDeclCallOptions {
 
 fn generated_covenant_policy_name(function_name: &str) -> String {
     format!("{COVENANT_POLICY_PREFIX}_{function_name}")
+}
+
+fn generated_covenant_delegate_policy_name(function_name: &str) -> String {
+    format!("{COVENANT_DELEGATE_POLICY_PREFIX}_{function_name}")
 }
 
 pub fn generated_covenant_auth_entrypoint_name(function_name: &str) -> String {
@@ -260,19 +265,54 @@ impl<'i> CompiledContract<'i> {
         args: Vec<Expr<'i>>,
         options: CovenantDeclCallOptions,
     ) -> Result<Vec<u8>, CompilerError> {
-        let auth_entrypoint = generated_covenant_auth_entrypoint_name(function_name);
-        if self.entry_by_name(&auth_entrypoint).is_some() {
-            return self.build_sig_script(&auth_entrypoint, args);
-        }
-
-        let leader_entrypoint = generated_covenant_leader_entrypoint_name(function_name);
-        if self.entry_by_name(&leader_entrypoint).is_some() {
-            let entrypoint = if options.is_leader { leader_entrypoint } else { generated_covenant_delegate_entrypoint_name() };
-            return self.build_sig_script(&entrypoint, args);
-        }
-
-        Err(CompilerError::Unsupported(format!("covenant declaration '{}' not found", function_name)))
+        let entrypoint = self
+            .covenant_decl_entrypoint_name(function_name, options.is_leader)
+            .ok_or_else(|| CompilerError::Unsupported(format!("covenant declaration '{}' not found", function_name)))?;
+        self.build_sig_script(entrypoint, args)
     }
+
+    /// Resolves a source covenant declaration to its final public ABI entrypoint.
+    /// For cov-bound declarations, `is_leader` selects the leader or shared
+    /// delegate wrapper. Auth-bound declarations resolve to the same wrapper in
+    /// either case.
+    pub fn covenant_decl_entrypoint_name(&self, function_name: &str, is_leader: bool) -> Option<&str> {
+        let policy_name = generated_covenant_policy_name(function_name);
+        let wrapper =
+            self.ast.functions.iter().find(|function| function.entrypoint && function_directly_calls(function, &policy_name))?;
+
+        let cov_bound = function_defines_local(wrapper, "__cov_in_count");
+        if !cov_bound || is_leader {
+            return Some(wrapper.name.as_str());
+        }
+
+        self.ast
+            .functions
+            .iter()
+            .find(|function| function.entrypoint && is_generated_covenant_delegate(function))
+            .map(|function| function.name.as_str())
+    }
+}
+
+fn function_directly_calls(function: &FunctionAst<'_>, callee: &str) -> bool {
+    function.body.iter().any(|statement| match statement {
+        Statement::FunctionCall { name, .. } | Statement::FunctionCallAssign { name, .. } => name == callee,
+        _ => false,
+    })
+}
+
+fn function_defines_local(function: &FunctionAst<'_>, local: &str) -> bool {
+    function.body.iter().any(|statement| matches!(statement, Statement::VariableDefinition { name, .. } if name == local))
+}
+
+fn is_generated_covenant_delegate(function: &FunctionAst<'_>) -> bool {
+    matches!(
+        function.body.as_slice(),
+        [
+            Statement::VariableDefinition { name, .. },
+            Statement::Require { .. },
+            ..
+        ] if name == "__cov_id" && !function_defines_local(function, "__cov_in_count")
+    )
 }
 
 fn push_typed_sigscript_arg<'i>(

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -124,6 +124,10 @@ pub struct CompiledContract<'i> {
     pub bytecode: Vec<u8>,
     pub ast: ContractAst<'i>,
     pub abi: Vec<FunctionAbiEntry>,
+    /// Public leader/auth ABI entries keyed by their pre-lowering covenant declaration names.
+    pub cov_decl_to_abi: HashMap<String, FunctionAbiEntry>,
+    /// The shared delegate ABI entry generated for a cov-bound contract.
+    pub delegate_entry_abi: Option<FunctionAbiEntry>,
     pub state_layout: CompiledStateLayout,
     pub debug_info: Option<DebugInfo<'i>>,
 }
@@ -276,43 +280,13 @@ impl<'i> CompiledContract<'i> {
     /// delegate wrapper. Auth-bound declarations resolve to the same wrapper in
     /// either case.
     pub fn covenant_decl_entrypoint_name(&self, function_name: &str, is_leader: bool) -> Option<&str> {
-        let policy_name = generated_covenant_policy_name(function_name);
-        let wrapper =
-            self.ast.functions.iter().find(|function| function.entrypoint && function_directly_calls(function, &policy_name))?;
-
-        let cov_bound = function_defines_local(wrapper, "__cov_in_count");
-        if !cov_bound || is_leader {
-            return Some(wrapper.name.as_str());
+        let entry = self.cov_decl_to_abi.get(function_name)?;
+        if is_leader || self.delegate_entry_abi.is_none() {
+            return Some(entry.name.as_str());
         }
 
-        self.ast
-            .functions
-            .iter()
-            .find(|function| function.entrypoint && is_generated_covenant_delegate(function))
-            .map(|function| function.name.as_str())
+        self.delegate_entry_abi.as_ref().map(|entry| entry.name.as_str())
     }
-}
-
-fn function_directly_calls(function: &FunctionAst<'_>, callee: &str) -> bool {
-    function.body.iter().any(|statement| match statement {
-        Statement::FunctionCall { name, .. } | Statement::FunctionCallAssign { name, .. } => name == callee,
-        _ => false,
-    })
-}
-
-fn function_defines_local(function: &FunctionAst<'_>, local: &str) -> bool {
-    function.body.iter().any(|statement| matches!(statement, Statement::VariableDefinition { name, .. } if name == local))
-}
-
-fn is_generated_covenant_delegate(function: &FunctionAst<'_>) -> bool {
-    matches!(
-        function.body.as_slice(),
-        [
-            Statement::VariableDefinition { name, .. },
-            Statement::Require { .. },
-            ..
-        ] if name == "__cov_id" && !function_defines_local(function, "__cov_in_count")
-    )
 }
 
 fn push_typed_sigscript_arg<'i>(

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use kaspa_txscript::EngineFlags;
 use kaspa_txscript::script_builder::ScriptBuilder;
@@ -125,8 +125,10 @@ pub struct CompiledContract<'i> {
     pub ast: ContractAst<'i>,
     pub abi: Vec<FunctionAbiEntry>,
     /// Public leader/auth ABI entries keyed by their pre-lowering covenant declaration names.
-    pub cov_decl_to_abi: HashMap<String, FunctionAbiEntry>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub cov_decl_to_abi: BTreeMap<String, FunctionAbiEntry>,
     /// The shared delegate ABI entry generated for a cov-bound contract.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delegate_entry_abi: Option<FunctionAbiEntry>,
     pub state_layout: CompiledStateLayout,
     pub debug_info: Option<DebugInfo<'i>>,
@@ -269,9 +271,14 @@ impl<'i> CompiledContract<'i> {
         args: Vec<Expr<'i>>,
         options: CovenantDeclCallOptions,
     ) -> Result<Vec<u8>, CompilerError> {
-        let entrypoint = self
-            .covenant_decl_entrypoint_name(function_name, options.is_leader)
-            .ok_or_else(|| CompilerError::Unsupported(format!("covenant declaration '{}' not found", function_name)))?;
+        let entrypoint = self.covenant_decl_entrypoint_name(function_name, options.is_leader).ok_or_else(|| {
+            let metadata_hint = if self.cov_decl_to_abi.is_empty() {
+                "; the compiled artifact may use an outdated schema without covenant declaration ABI metadata"
+            } else {
+                ""
+            };
+            CompilerError::Unsupported(format!("covenant declaration '{function_name}' not found{metadata_hint}"))
+        })?;
         self.build_sig_script(entrypoint, args)
     }
 

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -4,10 +4,16 @@ use semver::{Comparator, Op, Version, VersionReq};
 use std::collections::{HashMap, HashSet};
 
 pub(super) fn validate_declaration_names(contract: &ContractAst<'_>) -> Result<(), CompilerError> {
+    let mut function_names = HashSet::new();
     for function in &contract.functions {
         if is_builtin_name(&function.name) {
             return Err(CompilerError::Unsupported(format!("function name '{}' is reserved for a builtin", function.name))
                 .with_span(&function.name_span));
+        }
+        if !function_names.insert(function.name.as_str()) {
+            return Err(
+                CompilerError::Unsupported(format!("duplicate function name '{}'", function.name)).with_span(&function.name_span)
+            );
         }
     }
 

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -270,6 +270,11 @@ pub(super) fn check_call<'i>(
         return Ok(Some(cast_type));
     }
     if let Some(function) = ctx.functions.get(name).copied() {
+        if function.attributes.iter().any(|attribute| attribute.path.first().is_some_and(|head| head == "covenant")) {
+            return Err(CompilerError::Unsupported(format!(
+                "covenant-annotated function '{name}' cannot be called directly; extract shared logic into an unannotated helper function"
+            )));
+        }
         if function.entrypoint {
             return Err(CompilerError::Unsupported(format!("entry '{name}' cannot be called")));
         }

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -829,6 +829,50 @@ fn delegate_and_leader_internal_policy_names_use_disjoint_namespaces() {
 }
 
 #[test]
+fn rejects_direct_calls_to_the_delegate_body() {
+    let source = r#"
+        contract Decls() {
+            #[covenant(binding = cov, from = 2, to = 2)]
+            function transfer(byte[] witness) {
+                authorizeDelegate(witness);
+            }
+
+            #[covenant.delegate]
+            function authorizeDelegate(byte[] witness) {
+                require(witness.length > 0);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("delegate bodies are compiler hooks");
+    let message = err.to_string();
+    assert!(message.contains("covenant-annotated function 'authorizeDelegate' cannot be called directly"));
+    assert!(message.contains("extract shared logic into an unannotated helper function"));
+}
+
+#[test]
+fn rejects_direct_calls_to_a_covenant_policy() {
+    let source = r#"
+        contract Decls() {
+            #[covenant(binding = cov, from = 2, to = 2)]
+            function transferPolicy(int amount) {
+                require(amount >= 0);
+            }
+
+            #[covenant.allow(rule = manual_entrypoint_in_leader_contract)]
+            entry recover(int amount) {
+                transferPolicy(amount);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("covenant policies are compiler hooks");
+    let message = err.to_string();
+    assert!(message.contains("covenant-annotated function 'transferPolicy' cannot be called directly"));
+    assert!(message.contains("extract shared logic into an unannotated helper function"));
+}
+
+#[test]
 fn rejects_conflicting_shared_delegate_names() {
     let source = r#"
         contract Decls() {

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -892,6 +892,34 @@ fn rejects_generated_public_name_collision() {
 }
 
 #[test]
+fn rejects_generated_public_name_collisions_with_helpers() {
+    let cases = [
+        r#"
+            contract Decls() {
+                function spend() {}
+
+                #[covenant.singleton(name = spend)]
+                function transfer(int nonce) { require(nonce >= 0); }
+            }
+        "#,
+        r#"
+            contract Decls() {
+                function spend() {}
+
+                #[covenant(binding = cov, from = 2, to = 2, delegate_name = spend)]
+                function transfer(int nonce) { require(nonce >= 0); }
+            }
+        "#,
+    ];
+
+    for source in cases {
+        let err = compile_contract(source, &[], CompileOptions::default())
+            .expect_err("generated public names must not collide with helper functions");
+        assert!(err.to_string().contains("duplicate function name 'spend'"), "unexpected error: {err}");
+    }
+}
+
+#[test]
 fn rejects_per_leader_delegate_policy_selection() {
     let source = r#"
         contract Decls() {

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -688,6 +688,9 @@ fn allows_multiple_cov_covenant_declarations() {
         .expect("multiple cov-bound declarations compile");
     let abi_names: Vec<&str> = compiled.abi.iter().map(|entry| entry.name.as_str()).collect();
     assert_eq!(abi_names, vec!["__leader_merge", "__leader_rebalance", "__delegate"]);
+    assert_eq!(compiled.cov_decl_to_abi.get("merge"), compiled.entry_by_name("__leader_merge"));
+    assert_eq!(compiled.cov_decl_to_abi.get("rebalance"), compiled.entry_by_name("__leader_rebalance"));
+    assert_eq!(compiled.delegate_entry_abi.as_ref(), compiled.entry_by_name("__delegate"));
 
     let merge_delegate =
         compiled.build_sig_script_for_covenant_decl("merge", vec![], Default::default()).expect("merge routes to the shared delegate");
@@ -752,6 +755,8 @@ fn lowers_kcc20_shaped_public_names_and_shared_delegate_body() {
         .expect("declaration helper resolves the overridden delegate name");
     let direct = compiled.build_sig_script("transfer_delegator", delegate_args).expect("public delegate sigscript builds");
     assert_eq!(routed, direct);
+    assert_eq!(compiled.cov_decl_to_abi.get("transferPolicy"), compiled.entry_by_name("transfer"));
+    assert_eq!(compiled.delegate_entry_abi.as_ref(), compiled.entry_by_name("transfer_delegator"));
     assert_eq!(compiled.covenant_decl_entrypoint_name("transferPolicy", true), Some("transfer"));
     assert_eq!(compiled.covenant_decl_entrypoint_name("transferPolicy", false), Some("transfer_delegator"));
 }
@@ -769,6 +774,8 @@ fn supports_public_name_override_for_auth_bound_declaration() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     assert_eq!(compiled.abi[0].name, "spend");
+    assert_eq!(compiled.cov_decl_to_abi.get("spendPolicy"), compiled.entry_by_name("spend"));
+    assert_eq!(compiled.delegate_entry_abi, None);
     assert_eq!(compiled.covenant_decl_entrypoint_name("spendPolicy", false), Some("spend"));
 }
 

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -698,3 +698,213 @@ fn allows_multiple_cov_covenant_declarations() {
     assert_eq!(merge_delegate, shared_delegate);
     assert_eq!(rebalance_delegate, shared_delegate);
 }
+
+#[test]
+fn lowers_kcc20_shaped_public_names_and_shared_delegate_body() {
+    let source = r#"
+        contract Token(byte[1] initial_owner, int initial_amount) {
+            byte[1] owner = initial_owner;
+            int amount = initial_amount;
+
+            function verifyOwner(byte[1] expected_owner, byte[] witness) {
+                require(witness.length == 1);
+                require(expected_owner == byte[1](witness));
+            }
+
+            #[covenant(
+                binding = cov,
+                from = 2,
+                to = 2,
+                mode = verification,
+                name = transfer,
+                delegate_name = transfer_delegator
+            )]
+            function transferPolicy(State[] prev_states, State[] next_states, byte[] witness) {
+                require(prev_states.length == 2);
+                require(next_states.length == 2);
+                verifyOwner(owner, witness);
+            }
+
+            #[covenant.delegate]
+            function authorizeDelegate(byte[] witness) {
+                verifyOwner(owner, witness);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[Expr::bytes(vec![7]), Expr::int(10)], CompileOptions::default())
+        .expect("KCC20-shaped declaration compiles");
+
+    let abi = compiled
+        .abi
+        .iter()
+        .map(|entry| (entry.name.as_str(), entry.inputs.iter().map(|input| input.type_name.as_str()).collect::<Vec<_>>()))
+        .collect::<Vec<_>>();
+    assert_eq!(abi, vec![("transfer", vec!["State[]", "byte[]"]), ("transfer_delegator", vec!["byte[]"]),]);
+
+    let transfer = compiled.entry_by_name("transfer").expect("public transfer exists");
+    let expected_hash = blake3::hash(b"transfer(State[],byte[])");
+    assert_eq!(transfer.dispatch_tag(), expected_hash.as_bytes()[..4]);
+
+    let delegate_args = vec![Expr::dynamic_bytes(vec![7])];
+    let routed = compiled
+        .build_sig_script_for_covenant_decl("transferPolicy", delegate_args.clone(), Default::default())
+        .expect("declaration helper resolves the overridden delegate name");
+    let direct = compiled.build_sig_script("transfer_delegator", delegate_args).expect("public delegate sigscript builds");
+    assert_eq!(routed, direct);
+    assert_eq!(compiled.covenant_decl_entrypoint_name("transferPolicy", true), Some("transfer"));
+    assert_eq!(compiled.covenant_decl_entrypoint_name("transferPolicy", false), Some("transfer_delegator"));
+}
+
+#[test]
+fn supports_public_name_override_for_auth_bound_declaration() {
+    let source = r#"
+        contract Decls() {
+            #[covenant.singleton(name = spend)]
+            function spendPolicy(int amount) {
+                require(amount >= 0);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    assert_eq!(compiled.abi[0].name, "spend");
+    assert_eq!(compiled.covenant_decl_entrypoint_name("spendPolicy", false), Some("spend"));
+}
+
+#[test]
+fn rejects_duplicate_delegate_bodies() {
+    let source = r#"
+        contract Decls() {
+            #[covenant(binding = cov, from = 2, to = 2)]
+            function merge(int nonce) { require(nonce >= 0); }
+
+            #[covenant.delegate]
+            function authorizeA(byte[] witness) { require(witness.length >= 0); }
+
+            #[covenant.delegate]
+            function authorizeB(byte[] witness) { require(witness.length >= 0); }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("duplicate delegate bodies must fail");
+    assert!(err.to_string().contains("more than one #[covenant.delegate] body"), "unexpected error: {err}");
+}
+
+#[test]
+fn rejects_delegate_body_without_cov_bound_declaration() {
+    let source = r#"
+        contract Decls() {
+            #[covenant.delegate]
+            function authorize(byte[] witness) { require(witness.length >= 0); }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("unused delegate body must fail");
+    assert!(err.to_string().contains("requires at least one binding=cov"), "unexpected error: {err}");
+}
+
+#[test]
+fn delegate_and_leader_internal_policy_names_use_disjoint_namespaces() {
+    let source = r#"
+        contract Decls() {
+            #[covenant(binding = cov, from = 2, to = 2)]
+            function delegate_authorize(int nonce) { require(nonce >= 0); }
+
+            #[covenant.delegate]
+            function authorize(byte[] witness) { require(witness.length >= 0); }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("internal policy names do not collide");
+    assert!(compiled.ast.functions.iter().any(|function| function.name == "__covenant_policy_delegate_authorize"));
+    assert!(compiled.ast.functions.iter().any(|function| function.name == "__covenant_delegate_policy_authorize"));
+}
+
+#[test]
+fn rejects_conflicting_shared_delegate_names() {
+    let source = r#"
+        contract Decls() {
+            #[covenant(binding = cov, from = 2, to = 2, delegate_name = merge_delegator)]
+            function merge(int nonce) { require(nonce >= 0); }
+
+            #[covenant(binding = cov, from = 2, to = 2, delegate_name = rebalance_delegator)]
+            function rebalance(int nonce) { require(nonce >= 0); }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("delegate names must agree");
+    assert!(err.to_string().contains("conflicting shared delegate entrypoint names"), "unexpected error: {err}");
+}
+
+#[test]
+fn rejects_invalid_delegate_body_signatures() {
+    let cases = [
+        r#"
+            contract Decls() {
+                #[covenant(binding = cov, from = 2, to = 2)]
+                function merge(int nonce) { require(nonce >= 0); }
+                #[covenant.delegate]
+                entry authorize(byte[] witness) { require(witness.length >= 0); }
+            }
+        "#,
+        r#"
+            contract Decls() {
+                #[covenant(binding = cov, from = 2, to = 2)]
+                function merge(int nonce) { require(nonce >= 0); }
+                #[covenant.delegate]
+                function authorize(byte[] witness) : (int) { return(witness.length); }
+            }
+        "#,
+        r#"
+            contract Decls() {
+                #[covenant(binding = cov, from = 2, to = 2)]
+                function merge(int nonce) { require(nonce >= 0); }
+                #[covenant.delegate(name = delegated)]
+                function authorize(byte[] witness) { require(witness.length >= 0); }
+            }
+        "#,
+    ];
+
+    for source in cases {
+        let err = compile_contract(source, &[], CompileOptions::default()).expect_err("invalid delegate signature must fail");
+        assert!(err.to_string().contains("#[covenant.delegate]"), "unexpected error: {err}");
+    }
+}
+
+#[test]
+fn rejects_generated_public_name_collision() {
+    let source = r#"
+        contract Decls() {
+            #[covenant(binding = cov, from = 2, to = 2, name = transfer)]
+            function transferPolicy(int nonce) { require(nonce >= 0); }
+
+            #[covenant.allow(rule = manual_entrypoint_in_leader_contract)]
+            entry transfer() {
+                byte[32] cov_id = OpInputCovenantId(this.activeInputIndex);
+                require(OpCovInputCount(cov_id) == 1);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("generated public name collision must fail");
+    assert!(err.to_string().contains("duplicate function name 'transfer'"), "unexpected error: {err}");
+}
+
+#[test]
+fn rejects_per_leader_delegate_policy_selection() {
+    let source = r#"
+        contract Decls() {
+            function weak(byte[] witness) { require(witness.length >= 0); }
+
+            #[covenant(binding = cov, from = 2, to = 2, delegate_policy = weak)]
+            function merge(int nonce) { require(nonce >= 0); }
+
+            #[covenant.delegate]
+            function strong(byte[] witness) { require(witness.length > 0); }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("leaders cannot select delegate policies");
+    assert!(err.to_string().contains("unknown covenant attribute argument 'delegate_policy'"), "unexpected error: {err}");
+}

--- a/silverscript-lang/tests/covenant_declaration_security_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_security_tests.rs
@@ -98,6 +98,37 @@ const COV_N_TO_M_DIFFERENT_SCRIPT_SOURCE: &str = r#"
     }
 "#;
 
+const KCC20_SHAPED_SOURCE: &str = r#"
+    contract Token(byte[1] initial_owner, int initial_amount) {
+        byte[1] owner = initial_owner;
+        int amount = initial_amount;
+
+        function verifyOwner(byte[1] expected_owner, byte[] witness) {
+            require(witness.length == 1);
+            require(expected_owner == byte[1](witness));
+        }
+
+        #[covenant(
+            binding = cov,
+            from = 2,
+            to = 2,
+            name = transfer,
+            delegate_name = transfer_delegator
+        )]
+        function transferPolicy(State[] prev_states, State[] next_states, byte[] witness) {
+            require(prev_states.length == 2);
+            require(next_states.length == 2);
+            require(prev_states[0].amount + prev_states[1].amount == next_states[0].amount + next_states[1].amount);
+            verifyOwner(owner, witness);
+        }
+
+        #[covenant.delegate]
+        function authorizeDelegate(byte[] witness) {
+            verifyOwner(owner, witness);
+        }
+    }
+"#;
+
 const AUTH_SINGLETON_ARRAY_RUNTIME_SOURCE: &str = r#"
     contract Counter(int init_value) {
         int value = init_value;
@@ -147,6 +178,15 @@ fn state_array_arg(values: Vec<i64>) -> Expr<'static> {
 
 fn state_arg(value: i64) -> Expr<'static> {
     struct_object("State", vec![("value", Expr::int(value))])
+}
+
+fn compile_kcc20_state(owner: u8, amount: i64) -> CompiledContract<'static> {
+    compile_contract(KCC20_SHAPED_SOURCE, &[Expr::bytes(vec![owner]), Expr::int(amount)], CompileOptions::default())
+        .expect("KCC20-shaped contract compiles")
+}
+
+fn kcc20_state_arg(owner: u8, amount: i64) -> Expr<'static> {
+    struct_object("State", vec![("owner", Expr::bytes(vec![owner])), ("amount", Expr::int(amount))])
 }
 
 fn cov_decl_nm_leader_sigscript(compiled: &CompiledContract<'_>, next_values: Vec<i64>) -> Vec<u8> {
@@ -405,6 +445,46 @@ fn many_to_many_happy_path_succeeds() {
 
     execute_input_with_covenants(tx.clone(), entries.clone(), 0).expect("leader path should accept valid many-to-many transition");
     execute_input_with_covenants(tx, entries, 1).expect("delegate path should accept valid many-to-many transition");
+}
+
+#[test]
+fn shared_delegate_body_authenticates_each_inputs_local_state() {
+    let in0 = compile_kcc20_state(1, 10);
+    let in1 = compile_kcc20_state(2, 7);
+    let out0 = compile_kcc20_state(3, 8);
+    let out1 = compile_kcc20_state(4, 9);
+    let next_states =
+        Expr::array(parse_type_ref("State[]").expect("State[] parses"), vec![kcc20_state_arg(3, 8), kcc20_state_arg(4, 9)]);
+
+    let leader_sigscript = covenant_decl_sigscript(&in0, "transferPolicy", vec![next_states, Expr::dynamic_bytes(vec![1])], true);
+    let delegate_sigscript = covenant_decl_sigscript(&in1, "transferPolicy", vec![Expr::dynamic_bytes(vec![2])], false);
+    let outputs = vec![covenant_output(&out0, 0, COV_A), covenant_output(&out1, 1, COV_A)];
+    let tx = Transaction::new(
+        1,
+        vec![tx_input(0, leader_sigscript), tx_input(1, delegate_sigscript)],
+        outputs.clone(),
+        0,
+        Default::default(),
+        0,
+        vec![],
+    );
+    let entries = vec![covenant_utxo(&in0, COV_A), covenant_utxo(&in1, COV_A)];
+
+    execute_input_with_covenants(tx.clone(), entries.clone(), 0).expect("leader authenticates its local owner");
+    execute_input_with_covenants(tx, entries.clone(), 1).expect("delegate authenticates its own local owner");
+
+    let wrong_delegate_sigscript = covenant_decl_sigscript(&in1, "transferPolicy", vec![Expr::dynamic_bytes(vec![1])], false);
+    let wrong_tx = Transaction::new(
+        1,
+        vec![tx_input(0, redeem_only_sigscript(&in0)), tx_input(1, wrong_delegate_sigscript)],
+        outputs,
+        0,
+        Default::default(),
+        0,
+        vec![],
+    );
+    let err = execute_input_with_covenants(wrong_tx, entries, 1).expect_err("delegate must reject another input's owner witness");
+    assert_verify_like_error(err);
 }
 
 #[test]

--- a/silverscript-lang/tests/examples/kcc20.sil
+++ b/silverscript-lang/tests/examples/kcc20.sil
@@ -8,18 +8,16 @@ contract KCC20(byte[32] genesisPk, int genesisAmount, byte genesisIdentifierType
     int amount = genesisAmount;
     bool isMinter = genesisIsMinter;
 
-    function checkSigs(State[] prevStates, sig[] sigs, byte[] witnesses) {
-        for(i, 0, prevStates.length, maxCovIns) {
-            if(prevStates[i].identifierType == IDENTIFIER_PUBKEY){
-                require(checkSig(sigs[i], pubkey(prevStates[i].ownerIdentifier)));
-            } else if(prevStates[i].identifierType == IDENTIFIER_SCRIPT_HASH){
-                byte[] spk = byte[](new ScriptPubKeyP2SH(prevStates[i].ownerIdentifier));
-                require(tx.inputs[unsigned(witnesses[i])].scriptPubKey == spk);
-            } else if(prevStates[i].identifierType == IDENTIFIER_COVENANT_ID){
-                require(OpInputCovenantId(unsigned(witnesses[i])) == prevStates[i].ownerIdentifier);
-            } else {
-                require(false);
-            }
+    function checkInputSig(sig s, byte witness) {
+        if(identifierType == IDENTIFIER_PUBKEY){
+            require(checkSig(s, pubkey(ownerIdentifier)));
+        } else if(identifierType == IDENTIFIER_SCRIPT_HASH){
+            byte[] spk = byte[](new ScriptPubKeyP2SH(ownerIdentifier));
+            require(tx.inputs[unsigned(witness)].scriptPubKey == spk);
+        } else if(identifierType == IDENTIFIER_COVENANT_ID){
+            require(OpInputCovenantId(unsigned(witness)) == ownerIdentifier);
+        } else {
+            require(false);
         }
     }
 
@@ -48,9 +46,14 @@ contract KCC20(byte[32] genesisPk, int genesisAmount, byte genesisIdentifierType
     }
 
     #[covenant(binding = cov, from = maxCovIns, to = maxCovOuts)]
-    function transfer(State[] prevStates, State[] newStates, sig[] sigs, byte[] witnesses) {
-        checkSigs(prevStates, sigs, witnesses);
+    function transfer(State[] prevStates, State[] newStates, sig s, byte witness) {
+        checkInputSig(s, witness);
         checkAmounts(prevStates, newStates);
         checkMintingTransfer(newStates);
+    }
+
+    #[covenant.delegate]
+    function authorizeDelegate(sig s, byte witness) {
+        checkInputSig(s, witness);
     }
 }

--- a/silverscript-lang/tests/examples/kcc20.sil
+++ b/silverscript-lang/tests/examples/kcc20.sil
@@ -15,7 +15,7 @@ contract KCC20(byte[32] genesisPk, int genesisAmount, byte genesisIdentifierType
             byte[] spk = byte[](new ScriptPubKeyP2SH(ownerIdentifier));
             require(tx.inputs[unsigned(witness)].scriptPubKey == spk);
         } else if(identifierType == IDENTIFIER_COVENANT_ID){
-            require(OpInputCovenantId(unsigned(witness)) == ownerIdentifier);
+            require(OpCovInputCount(ownerIdentifier) > 0);
         } else {
             require(false);
         }

--- a/silverscript-lang/tests/examples/p2pkh_ecdsa.sil
+++ b/silverscript-lang/tests/examples/p2pkh_ecdsa.sil
@@ -1,0 +1,8 @@
+pragma silverscript ^0.1.0;
+
+contract P2PKHEcdsa(byte[32] pkh) {
+    entry spend(byte[33] pk, sig s) {
+        require(blake2b(byte[](pk)) == pkh);
+        require(checkSigEcdsa(s, pk));
+    }
+}

--- a/silverscript-lang/tests/examples_tests.rs
+++ b/silverscript-lang/tests/examples_tests.rs
@@ -1,5 +1,5 @@
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
-use kaspa_consensus_core::hashing::sighash::calc_schnorr_signature_hash;
+use kaspa_consensus_core::hashing::sighash::{calc_ecdsa_signature_hash, calc_schnorr_signature_hash};
 use kaspa_consensus_core::hashing::sighash_type::SIG_HASH_ALL;
 use kaspa_consensus_core::mass::units::SigopCount;
 use kaspa_consensus_core::tx::{
@@ -888,30 +888,89 @@ fn compiles_p2pkh_example_and_verifies() {
 
     let reused_values = SigHashReusedValuesUnsync::new();
     let sig_hash = calc_schnorr_signature_hash(&tx.as_verifiable(), 0, SIG_HASH_ALL, &reused_values);
-    let msg = secp256k1::Message::from_digest_slice(sig_hash.as_bytes().as_slice()).unwrap();
+    let msg = secp256k1::Message::from_digest(sig_hash.into());
     let sig = owner.sign_schnorr(msg);
     let mut signature = Vec::new();
     signature.extend_from_slice(sig.as_ref().as_slice());
     signature.push(SIG_HASH_ALL.to_u8());
 
-    // Test spend() function call (build sigscript for spend()).
-    let sigscript =
-        compiled.build_sig_script("spend", vec![pubkey_bytes.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
-    tx.tx.inputs[0].signature_script = sigscript;
+    let mut run = |signature: Vec<u8>| {
+        tx.tx.inputs[0].signature_script =
+            compiled.build_sig_script("spend", vec![pubkey_bytes.to_vec().into(), signature.into()]).expect("sigscript builds");
 
-    let tx = tx.as_verifiable();
-    let sig_cache = Cache::new(10_000);
-    let mut vm = TxScriptEngine::from_transaction_input(
-        &tx,
-        &tx.inputs()[0],
-        0,
-        &utxo_entry,
-        EngineCtx::new(&sig_cache).with_reused(&reused_values),
-        EngineFlags { covenants_enabled: true, ..Default::default() },
-    );
+        let verifiable_tx = tx.as_verifiable();
+        let sig_cache = Cache::new(100);
+        let mut vm = TxScriptEngine::from_transaction_input(
+            &verifiable_tx,
+            &verifiable_tx.inputs()[0],
+            0,
+            &utxo_entry,
+            EngineCtx::new(&sig_cache).with_reused(&reused_values),
+            EngineFlags { covenants_enabled: true, ..Default::default() },
+        );
+        vm.execute()
+    };
 
-    let result = vm.execute();
-    assert!(result.is_ok(), "p2pkh example failed: {}", result.unwrap_err());
+    assert!(run(signature.clone()).is_ok(), "valid p2pkh Schnorr signature should pass");
+    signature[0] ^= 0x01;
+    assert!(run(signature).is_err(), "forged p2pkh Schnorr signature should fail");
+}
+
+#[test]
+fn compiles_p2pkh_ecdsa_example_and_verifies() {
+    let source = load_example_source("p2pkh_ecdsa.sil");
+
+    let owner = random_keypair();
+    let pubkey_bytes = owner.public_key().serialize();
+    let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
+    let constructor_args = [pkh.into()];
+
+    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+
+    let input = TransactionInput {
+        previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([5u8; 32]), index: 0 },
+        signature_script: vec![],
+        sequence: 0,
+        compute_commit: SigopCount(1).into(),
+    };
+    let output = TransactionOutput {
+        value: 7000,
+        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        covenant: None,
+    };
+
+    let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
+    let utxo_entry =
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+    let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
+
+    let reused_values = SigHashReusedValuesUnsync::new();
+    let sig_hash = calc_ecdsa_signature_hash(&tx.as_verifiable(), 0, SIG_HASH_ALL, &reused_values);
+    let msg = secp256k1::Message::from_digest(sig_hash.into());
+    let sig = owner.secret_key().sign_ecdsa(msg);
+    let mut signature = sig.serialize_compact().to_vec();
+    signature.push(SIG_HASH_ALL.to_u8());
+
+    let mut run = |signature: Vec<u8>| {
+        tx.tx.inputs[0].signature_script =
+            compiled.build_sig_script("spend", vec![pubkey_bytes.to_vec().into(), signature.into()]).expect("sigscript builds");
+
+        let verifiable_tx = tx.as_verifiable();
+        let sig_cache = Cache::new(100);
+        let mut vm = TxScriptEngine::from_transaction_input(
+            &verifiable_tx,
+            &verifiable_tx.inputs()[0],
+            0,
+            &utxo_entry,
+            EngineCtx::new(&sig_cache).with_reused(&reused_values),
+            EngineFlags { covenants_enabled: true, ..Default::default() },
+        );
+        vm.execute()
+    };
+
+    assert!(run(signature.clone()).is_ok(), "valid p2pkh ECDSA signature should pass");
+    signature[0] ^= 0x01;
+    assert!(run(signature).is_err(), "forged p2pkh ECDSA signature should fail");
 }
 
 #[test]

--- a/silverscript-lang/tests/kcc20_tests.rs
+++ b/silverscript-lang/tests/kcc20_tests.rs
@@ -71,14 +71,6 @@ fn kcc20_state_array_arg_with_minter<'i>(values: Vec<(Vec<u8>, i64, bool)>) -> E
     )
 }
 
-fn sig_array_arg<'i>(values: Vec<Vec<u8>>) -> Expr<'i> {
-    Expr::array(parse_type_ref("sig[]").unwrap(), values.into_iter().map(Expr::bytes).collect())
-}
-
-fn witness_array_arg<'i>(values: Vec<u8>) -> Expr<'i> {
-    Expr::dynamic_bytes(values)
-}
-
 fn kcc20_state_arg<'i>(owner_identifier: Vec<u8>, identifier_type: u8, amount: i64, is_minter: bool) -> Expr<'i> {
     struct_object(
         "KCC20State",
@@ -196,11 +188,7 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
     let handoff_sigscript = covenant_decl_sigscript(
         &genesis,
         "transfer",
-        vec![
-            kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]),
-            sig_array_arg(vec![handoff_sig]),
-            witness_array_arg(vec![0]),
-        ],
+        vec![kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]), Expr::bytes(handoff_sig), Expr::byte(0)],
         true,
     );
     let handoff_tx = Transaction::new(
@@ -252,8 +240,8 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
         "transfer",
         vec![
             kcc20_state_array_arg(vec![(split_owner_a_bytes.clone(), 400), (split_owner_b_bytes.clone(), 600)]),
-            sig_array_arg(vec![split_sig]),
-            witness_array_arg(vec![0]),
+            Expr::bytes(split_sig),
+            Expr::byte(0),
         ],
         true,
     );
@@ -292,18 +280,14 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
         vec![],
     );
     let merge_sig_a = sign_tx_input(merge_unsigned_tx.clone(), merge_entries.clone(), 0, &split_owner_a);
-    let merge_sig_b = sign_tx_input(merge_unsigned_tx, merge_entries.clone(), 0, &split_owner_b);
+    let merge_sig_b = sign_tx_input(merge_unsigned_tx, merge_entries.clone(), 1, &split_owner_b);
     let merge_leader_sigscript = covenant_decl_sigscript(
         &split_a,
         "transfer",
-        vec![
-            kcc20_state_array_arg(vec![(merged_owner_bytes, 1_000)]),
-            sig_array_arg(vec![merge_sig_a, merge_sig_b]),
-            witness_array_arg(vec![0, 1]),
-        ],
+        vec![kcc20_state_array_arg(vec![(merged_owner_bytes, 1_000)]), Expr::bytes(merge_sig_a), Expr::byte(0)],
         true,
     );
-    let merge_delegate_sigscript = covenant_decl_sigscript(&split_b, "transfer", vec![], false);
+    let merge_delegate_sigscript = covenant_decl_sigscript(&split_b, "transfer", vec![Expr::bytes(merge_sig_b), Expr::byte(1)], false);
     let merge_tx = Transaction::new(
         1,
         vec![
@@ -363,11 +347,7 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
     let handoff_sigscript = covenant_decl_sigscript(
         &genesis,
         "transfer",
-        vec![
-            kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]),
-            sig_array_arg(vec![handoff_sig]),
-            witness_array_arg(vec![0]),
-        ],
+        vec![kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]), Expr::bytes(handoff_sig), Expr::byte(0)],
         true,
     );
     let handoff_tx = Transaction::new(
@@ -419,8 +399,8 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
         "transfer",
         vec![
             kcc20_state_array_arg(vec![(split_owner_a_bytes.clone(), 400), (split_owner_b_bytes.clone(), 600)]),
-            sig_array_arg(vec![split_sig]),
-            witness_array_arg(vec![0]),
+            Expr::bytes(split_sig),
+            Expr::byte(0),
         ],
         true,
     );
@@ -458,18 +438,14 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
         vec![],
     );
     let merge_sig_a = sign_tx_input(merge_unsigned_tx.clone(), merge_entries.clone(), 0, &split_owner_a);
-    let wrong_sig_b = sign_tx_input(merge_unsigned_tx, merge_entries.clone(), 0, &wrong_signer);
+    let wrong_sig_b = sign_tx_input(merge_unsigned_tx, merge_entries.clone(), 1, &wrong_signer);
     let merge_leader_sigscript = covenant_decl_sigscript(
         &split_a,
         "transfer",
-        vec![
-            kcc20_state_array_arg(vec![(merged_owner_bytes, 1_000)]),
-            sig_array_arg(vec![merge_sig_a, wrong_sig_b]),
-            witness_array_arg(vec![0, 1]),
-        ],
+        vec![kcc20_state_array_arg(vec![(merged_owner_bytes, 1_000)]), Expr::bytes(merge_sig_a), Expr::byte(0)],
         true,
     );
-    let merge_delegate_sigscript = covenant_decl_sigscript(&split_b, "transfer", vec![], false);
+    let merge_delegate_sigscript = covenant_decl_sigscript(&split_b, "transfer", vec![Expr::bytes(wrong_sig_b), Expr::byte(1)], false);
     let merge_tx = Transaction::new(
         1,
         vec![
@@ -483,7 +459,9 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
         vec![],
     );
 
-    let err = execute_input_with_covenants(merge_tx, merge_entries, 0)
+    execute_input_with_covenants(merge_tx.clone(), merge_entries.clone(), 0)
+        .expect("KCC20 merge leader should accept its valid local signature");
+    let err = execute_input_with_covenants(merge_tx, merge_entries, 1)
         .expect_err("KCC20 merge should reject when one signature does not match the previous owner");
     assert_verify_like_error(err);
 }
@@ -526,11 +504,7 @@ fn kcc20_rejects_split_when_amounts_do_not_match() {
     let handoff_sigscript = covenant_decl_sigscript(
         &genesis,
         "transfer",
-        vec![
-            kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]),
-            sig_array_arg(vec![handoff_sig]),
-            witness_array_arg(vec![0]),
-        ],
+        vec![kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]), Expr::bytes(handoff_sig), Expr::byte(0)],
         true,
     );
     let handoff_tx = Transaction::new(
@@ -582,8 +556,8 @@ fn kcc20_rejects_split_when_amounts_do_not_match() {
         "transfer",
         vec![
             kcc20_state_array_arg(vec![(split_owner_a_bytes, 400), (split_owner_b_bytes, 500)]),
-            sig_array_arg(vec![split_sig]),
-            witness_array_arg(vec![0]),
+            Expr::bytes(split_sig),
+            Expr::byte(0),
         ],
         true,
     );
@@ -648,8 +622,8 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
         "transfer",
         vec![
             kcc20_state_array_arg_with_minter(vec![(minter_owner_bytes.clone(), 400, true), (other_owner_bytes.clone(), 600, false)]),
-            sig_array_arg(vec![split_sig]),
-            witness_array_arg(vec![0]),
+            Expr::bytes(split_sig),
+            Expr::byte(0),
         ],
         true,
     );
@@ -691,8 +665,8 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
         "transfer",
         vec![
             kcc20_state_array_arg_with_minter(vec![(other_owner_bytes.clone(), 700, false)]),
-            sig_array_arg(vec![forged_other_sig]),
-            witness_array_arg(vec![0]),
+            Expr::bytes(forged_other_sig),
+            Expr::byte(0),
         ],
         true,
     );
@@ -733,8 +707,8 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
         "transfer",
         vec![
             kcc20_state_array_arg_with_minter(vec![(other_owner_bytes.clone(), 600, true)]),
-            sig_array_arg(vec![forged_other_minter_sig]),
-            witness_array_arg(vec![0]),
+            Expr::bytes(forged_other_minter_sig),
+            Expr::byte(0),
         ],
         true,
     );
@@ -775,11 +749,7 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let mint_sigscript = covenant_decl_sigscript(
         &split_minter,
         "transfer",
-        vec![
-            kcc20_state_array_arg_with_minter(vec![(minter_owner_bytes.clone(), 900, true)]),
-            sig_array_arg(vec![mint_sig]),
-            witness_array_arg(vec![0]),
-        ],
+        vec![kcc20_state_array_arg_with_minter(vec![(minter_owner_bytes.clone(), 900, true)]), Expr::bytes(mint_sig), Expr::byte(0)],
         true,
     );
     let mint_tx = Transaction::new(
@@ -814,11 +784,7 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let burn_sigscript = covenant_decl_sigscript(
         &minted_minter,
         "transfer",
-        vec![
-            kcc20_state_array_arg_with_minter(vec![(minter_owner_bytes, 500, true)]),
-            sig_array_arg(vec![burn_sig]),
-            witness_array_arg(vec![0]),
-        ],
+        vec![kcc20_state_array_arg_with_minter(vec![(minter_owner_bytes, 500, true)]), Expr::bytes(burn_sig), Expr::byte(0)],
         true,
     );
     let burn_tx = Transaction::new(
@@ -863,11 +829,7 @@ fn kcc20_minter_can_mint_in_single_transaction() {
     let mint_sigscript = covenant_decl_sigscript(
         &genesis,
         "transfer",
-        vec![
-            kcc20_state_array_arg_with_minter(vec![(genesis_owner_bytes, 1_500, true)]),
-            sig_array_arg(vec![mint_sig]),
-            witness_array_arg(vec![0]),
-        ],
+        vec![kcc20_state_array_arg_with_minter(vec![(genesis_owner_bytes, 1_500, true)]), Expr::bytes(mint_sig), Expr::byte(0)],
         true,
     );
     let mint_tx = Transaction::new(
@@ -1043,8 +1005,8 @@ fn kcc20_covenant_minter() {
                     (minter_cov_id.as_bytes().to_vec(), IDENTIFIER_COVENANT_ID, 0, true),
                     (owner_bytes.clone(), 0, minted_amount, false),
                 ]),
-                sig_array_arg(vec![]),
-                witness_array_arg(vec![1]),
+                Expr::bytes(vec![0; 65]),
+                Expr::byte(1),
             ],
             true,
         );
@@ -1142,8 +1104,8 @@ fn kcc20_covenant_minter() {
         "transfer",
         vec![
             kcc20_state_array_arg(vec![(alternate_owner_bytes.clone(), FIRST_MINTED_AMOUNT)]),
-            sig_array_arg(vec![recipient_transfer_sig]),
-            witness_array_arg(vec![0]),
+            Expr::bytes(recipient_transfer_sig),
+            Expr::byte(0),
         ],
         true,
     );
@@ -1291,8 +1253,8 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
                 (multisig_script_hash.clone(), IDENTIFIER_SCRIPT_HASH, 400, false),
                 (covenant_owner_bytes.clone(), IDENTIFIER_COVENANT_ID, 600, false),
             ]),
-            sig_array_arg(vec![split_sig]),
-            witness_array_arg(vec![0]),
+            Expr::bytes(split_sig),
+            Expr::byte(0),
         ],
         true,
     );
@@ -1331,7 +1293,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
         covenant_decl_sigscript(
             state,
             "transfer",
-            vec![kcc20_state_array_arg(vec![(destination_owner, amount)]), sig_array_arg(vec![]), witness_array_arg(vec![witness])],
+            vec![kcc20_state_array_arg(vec![(destination_owner, amount)]), Expr::bytes(vec![0; 65]), Expr::byte(witness)],
             true,
         )
     };

--- a/silverscript-lang/tests/kcc20_tests.rs
+++ b/silverscript-lang/tests/kcc20_tests.rs
@@ -20,7 +20,7 @@ use std::fs;
 mod common;
 
 use common::{
-    COV_A, assert_verify_like_error, compiled_template_parts_and_hash, covenant_decl_sigscript, covenant_output, covenant_utxo,
+    COV_A, COV_B, assert_verify_like_error, compiled_template_parts_and_hash, covenant_decl_sigscript, covenant_output, covenant_utxo,
     execute_input_with_covenants,
 };
 
@@ -1369,16 +1369,19 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
     ];
     let covenant_id_auxiliary_outpoint = TransactionOutpoint { transaction_id: TransactionId::from_bytes([3; 32]), index: 0 };
 
-    // Wrong witness: the KCC20 input points at itself instead of the attached covenant-owned input.
+    // Wrong covenant ID: an auxiliary covenant input is attached, but it does not
+    // match the covenant ID that owns this KCC20 branch.
     {
-        let covenant_id_wrong_witness_tx = build_spend_tx(
+        let covenant_id_wrong_covenant_entries =
+            vec![covenant_id_spend_entries[0].clone(), UtxoEntry::new(500, pay_to_script_hash_script(&[0x51]), 0, false, Some(COV_B))];
+        let covenant_id_wrong_covenant_tx = build_spend_tx(
             1,
             Some(covenant_id_auxiliary_outpoint),
-            build_kcc20_sigscript(&split_states[1], covenant_spend_destination_owner_bytes.clone(), 600, 0),
+            build_kcc20_sigscript(&split_states[1], covenant_spend_destination_owner_bytes.clone(), 600, 1),
             covenant_id_spend_outputs.clone(),
         );
-        let err = execute_input_with_covenants(covenant_id_wrong_witness_tx, covenant_id_spend_entries.clone(), 0)
-            .expect_err("KCC20 covenant-id-owned tokens should reject the wrong witness index");
+        let err = execute_input_with_covenants(covenant_id_wrong_covenant_tx, covenant_id_wrong_covenant_entries, 0)
+            .expect_err("KCC20 covenant-id-owned tokens should reject a different covenant ID");
         assert_verify_like_error(err);
     }
 

--- a/silverscript-lang/tests/silverc_tests.rs
+++ b/silverscript-lang/tests/silverc_tests.rs
@@ -80,6 +80,9 @@ fn silverc_defaults_output_path_and_empty_ctor_args() {
 
     let out_path = dir.join("basic.json");
     let json = fs::read_to_string(&out_path).expect("read output");
+    let artifact: serde_json::Value = serde_json::from_str(&json).expect("parse compiled artifact JSON");
+    assert!(artifact.get("cov_decl_to_abi").is_none());
+    assert!(artifact.get("delegate_entry_abi").is_none());
     let compiled: CompiledContract = serde_json::from_str(&json).expect("parse compiled contract");
     assert_eq!(compiled.contract_name, "Basic");
     assert_eq!(compiled.compiler_version, COMPILER_VERSION);


### PR DESCRIPTION
## Summary

Extend covenant declarations with:

- one contract-wide `#[covenant.delegate]` policy body;
- `name` for controlling the generated leader/auth entrypoint name; and
- `delegate_name` for controlling the shared delegate entrypoint name.

This supports the KCC1 leader/delegator model directly. The leader validates the complete shared transition, while every non-leader input can execute the same local delegate policy.

For example, KCC20 can expose its specified ABI:

```silverscript
#[covenant(
    binding = cov,
    from = max_token_inputs,
    to = max_token_outputs,
    name = transfer,
    delegate_name = transfer_delegator
)]
function transferPolicy(
    State[] prev_states,
    State[] next_states,
    byte[] witness
) {
    // Validate the complete transition and the leader's authorization.
}

#[covenant.delegate]
function authorizeDelegate(byte[] witness) {
    // Authenticate this delegator's local owner.
    // Current contract fields are available directly.
}
```

This produces:

```text
transfer(State[],byte[])
transfer_delegator(byte[])
```

Dispatch tags are calculated from these final public names and parameter types.

## Delegate semantics

A contract may define at most one delegate body. The compiler-generated delegate wrapper:

1. derives the active input's Covenant ID;
2. rejects the leader position;
3. invokes the shared delegate body with its public arguments.

The delegate policy is intentionally contract-wide rather than selected by individual leader declarations. A delegator cannot determine which leader entrypoint input zero selected, so per-leader delegate policies could expose a weaker selectable authorization path.

All cov-bound declarations therefore share the same delegate entrypoint and must agree on `delegate_name`.

Contracts without `#[covenant.delegate]` retain the existing inert delegate behavior for source compatibility.

## Other changes

- Covenant sigscript helpers and debugger routing now resolve final overridden ABI names.
- The debugger maps execution inside the lowered delegate policy back to its source function name.
- Generated public-name collisions are rejected.
- Documentation now states the existing homogeneous-template assumption of covenant declarations. Supporting heterogeneous contracts under one Covenant ID remains outside this change.

## Unrelated test coverage

The branch also adds an end-to-end `checkSigEcdsa` P2PKH example covering valid and forged signatures, and adds a forged-signature case to the existing Schnorr P2PKH test.