### PR TITLE
feat(compiler/abi): dispatch tag in entries

### DIFF
--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use kaspa_txscript::EngineFlags;
 use kaspa_txscript::script_builder::ScriptBuilder;
+use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
 
 use crate::ast::{
@@ -86,7 +87,7 @@ pub struct FunctionInputAbi {
     pub type_name: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub struct FunctionAbiEntry {
     pub name: String,
     pub inputs: Vec<FunctionInputAbi>,
@@ -102,6 +103,19 @@ impl FunctionAbiEntry {
         let mut tag = [0u8; 4];
         tag.copy_from_slice(&hash.as_bytes()[..4]);
         tag
+    }
+}
+
+impl Serialize for FunctionAbiEntry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut entry = serializer.serialize_struct("FunctionAbiEntry", 3)?;
+        entry.serialize_field("name", &self.name)?;
+        entry.serialize_field("inputs", &self.inputs)?;
+        entry.serialize_field("dispatch_tag", &faster_hex::hex_string(&self.dispatch_tag()))?;
+        entry.end()
     }
 }
 

--- a/silverscript-lang/tests/silverc_tests.rs
+++ b/silverscript-lang/tests/silverc_tests.rs
@@ -80,9 +80,11 @@ fn silverc_defaults_output_path_and_empty_ctor_args() {
 
     let out_path = dir.join("basic.json");
     let json = fs::read_to_string(&out_path).expect("read output");
+    let artifact: serde_json::Value = serde_json::from_str(&json).expect("parse compiled contract JSON");
     let compiled: CompiledContract = serde_json::from_str(&json).expect("parse compiled contract");
     assert_eq!(compiled.contract_name, "Basic");
     assert_eq!(compiled.compiler_version, COMPILER_VERSION);
+    assert_eq!(artifact["abi"][0]["dispatch_tag"], faster_hex::hex_string(&compiled.abi[0].dispatch_tag()));
 }
 
 #[test]


### PR DESCRIPTION
Now emits `dispatch_tag` in ABI as `hex` representation:
```json
"abi": [
    {
      "name": "merge",
      "inputs": [
        {
          "name": "nonce",
          "type_name": "int"
        }
      ],
      "dispatch_tag": "126491f7"
    }
  ]
```