### PR TITLE
Compiler hardening: validate dynamic struct-array ABI cardinality

### DIFF
--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -57,6 +57,7 @@ pub(super) fn compile_contract_impl<'i>(
     let inline_lowered_contract = lower_inline_functions(&read_input_state_lowered_contract, &mut debug_recorder)?;
     let structs = build_struct_registry(&inline_lowered_contract)?;
     let validate_output_state_lowered_contract = lower_validate_output_state(&inline_lowered_contract, &structs, &constants)?;
+    let struct_array_param_groups = dynamic_struct_array_param_groups(&validate_output_state_lowered_contract, &structs)?;
     let struct_lowered_contract = lower_structs_contract(&validate_output_state_lowered_contract, &structs, &constants)?;
     let append_lowered_contract = lower_array_appends(&struct_lowered_contract, &constants)?;
     let for_lowered_contract = lower_for_loops(&append_lowered_contract, &constants)?;
@@ -96,6 +97,7 @@ pub(super) fn compile_contract_impl<'i>(
             bytecode_size,
             &function_abi_entries,
             &structs,
+            &struct_array_param_groups,
             &mut debug_recorder,
         )?;
 
@@ -134,6 +136,7 @@ fn compile_contract_bytecode_iteration<'i>(
     bytecode_size: Option<i64>,
     function_abi_entries: &[FunctionAbiEntry],
     structs: &StructRegistry,
+    struct_array_param_groups: &StructArrayParamGroups,
     debug_recorder: &mut DebugRecorder<'i>,
 ) -> Result<(Vec<u8>, CompiledStateLayout), CompilerError> {
     let (_contract_fields, state_push_bytecode) = compile_contract_fields(&lowered_contract.fields, lowered_constants, bytecode_size)?;
@@ -145,8 +148,15 @@ fn compile_contract_bytecode_iteration<'i>(
     };
     let state_end = state_start + state_push_bytecode.len();
     let state_layout = CompiledStateLayout { start: state_start, len: state_push_bytecode.len() };
-    let compiled_entrypoints =
-        compile_entrypoint_bytecodes(lowered_contract, state_end, lowered_constants, structs, bytecode_size, debug_recorder)?;
+    let compiled_entrypoints = compile_entrypoint_bytecodes(
+        lowered_contract,
+        state_end,
+        lowered_constants,
+        structs,
+        struct_array_param_groups,
+        bytecode_size,
+        debug_recorder,
+    )?;
     let bytecode = build_contract_bytecode(debug_recorder, &state_push_bytecode, &compiled_entrypoints, function_abi_entries)?;
     Ok((bytecode, state_layout))
 }
@@ -156,6 +166,7 @@ fn compile_entrypoint_bytecodes<'i>(
     state_end: usize,
     lowered_constants: &HashMap<String, Expr<'i>>,
     structs: &StructRegistry,
+    struct_array_param_groups: &StructArrayParamGroups,
     bytecode_size: Option<i64>,
     debug_recorder: &mut DebugRecorder<'i>,
 ) -> Result<Vec<(String, Vec<u8>)>, CompilerError> {
@@ -171,6 +182,7 @@ fn compile_entrypoint_bytecodes<'i>(
                 lowered_constants,
                 structs,
                 bytecode_size,
+                struct_array_param_groups.get(&func.name).map(Vec::as_slice).unwrap_or_default(),
                 debug_recorder,
             )?;
             compiled_entrypoints.push(compiled);

--- a/silverscript-lang/src/compiler/compile/statement.rs
+++ b/silverscript-lang/src/compiler/compile/statement.rs
@@ -104,6 +104,8 @@ fn compile_param_size_validations<'i>(
     let grouped_leaf_names = struct_array_param_groups.iter().flatten().map(String::as_str).collect::<HashSet<_>>();
 
     for param in &function.params {
+        // Grouped leaves are always dynamic arrays. Their OP_MOD shape check
+        // is fused with the cardinality check below so OP_SIZE can be reused.
         if grouped_leaf_names.contains(param.name.as_str()) {
             continue;
         }

--- a/silverscript-lang/src/compiler/compile/statement.rs
+++ b/silverscript-lang/src/compiler/compile/statement.rs
@@ -11,6 +11,7 @@ pub(super) fn compile_entrypoint_function<'i>(
     constants: &HashMap<String, Expr<'i>>,
     structs: &StructRegistry,
     bytecode_size: Option<i64>,
+    struct_array_param_groups: &[Vec<String>],
     debug_recorder: &mut DebugRecorder<'i>,
 ) -> Result<(String, Vec<u8>), CompilerError> {
     debug_recorder.begin_entrypoint(function, contract_fields, structs)?;
@@ -43,7 +44,7 @@ pub(super) fn compile_entrypoint_function<'i>(
         types.insert(field.name.clone(), field.type_ref.clone());
     }
     let mut builder = script_builder();
-    compile_param_size_validations(function, constants, &stack_bindings, &mut builder)?;
+    compile_param_size_validations(function, constants, struct_array_param_groups, &stack_bindings, &mut builder)?;
     let mut return_exprs: Vec<Expr> = Vec::new();
 
     let body_len = function.body.len();
@@ -96,6 +97,7 @@ pub(super) fn compile_entrypoint_function<'i>(
 fn compile_param_size_validations<'i>(
     function: &FunctionAst<'i>,
     constants: &HashMap<String, Expr<'i>>,
+    struct_array_param_groups: &[Vec<String>],
     stack_bindings: &StackBindings,
     builder: &mut ScriptBuilder,
 ) -> Result<(), CompilerError> {
@@ -142,6 +144,51 @@ fn compile_param_size_validations<'i>(
         builder.add_op(OpDrop)?;
     }
 
+    for leaf_names in struct_array_param_groups {
+        let Some((first, rest)) = leaf_names.split_first() else {
+            continue;
+        };
+        let mut transient_stack_depth = 0;
+        emit_dynamic_array_length(function, first, constants, stack_bindings, &mut transient_stack_depth, builder)?;
+        for leaf_name in rest {
+            builder.add_op(OpDup)?;
+            transient_stack_depth += 1;
+            emit_dynamic_array_length(function, leaf_name, constants, stack_bindings, &mut transient_stack_depth, builder)?;
+            builder.add_op(OpNumEqualVerify)?;
+            transient_stack_depth -= 2;
+        }
+        debug_assert_eq!(transient_stack_depth, 1);
+        builder.add_op(OpDrop)?;
+    }
+
+    Ok(())
+}
+
+fn emit_dynamic_array_length<'i>(
+    function: &FunctionAst<'i>,
+    param_name: &str,
+    constants: &HashMap<String, Expr<'i>>,
+    stack_bindings: &StackBindings,
+    stack_depth: &mut i64,
+    builder: &mut ScriptBuilder,
+) -> Result<(), CompilerError> {
+    let param = function
+        .params
+        .iter()
+        .find(|param| param.name == param_name)
+        .expect("struct lowering must retain every grouped leaf parameter");
+    let element_size =
+        array_element_size(&param.type_ref, constants).expect("type checking must validate dynamic struct-array leaf element sizes");
+
+    let copied = stack_bindings.emit_copy_binding_to_top(param_name, stack_depth, builder)?;
+    debug_assert!(copied, "entrypoint parameter must have a stack binding");
+    builder.add_op(OpSize)?;
+    builder.add_op(OpSwap)?;
+    builder.add_op(OpDrop)?;
+    if element_size != 1 {
+        builder.add_i64(element_size)?;
+        builder.add_op(OpDiv)?;
+    }
     Ok(())
 }
 

--- a/silverscript-lang/src/compiler/compile/statement.rs
+++ b/silverscript-lang/src/compiler/compile/statement.rs
@@ -101,7 +101,13 @@ fn compile_param_size_validations<'i>(
     stack_bindings: &StackBindings,
     builder: &mut ScriptBuilder,
 ) -> Result<(), CompilerError> {
+    let grouped_leaf_names = struct_array_param_groups.iter().flatten().map(String::as_str).collect::<HashSet<_>>();
+
     for param in &function.params {
+        if grouped_leaf_names.contains(param.name.as_str()) {
+            continue;
+        }
+
         let exact_size = if param.type_ref.is_array() {
             fixed_type_size(&param.type_ref, constants)
         } else if param.type_ref.is_byte() {
@@ -149,11 +155,11 @@ fn compile_param_size_validations<'i>(
             continue;
         };
         let mut transient_stack_depth = 0;
-        emit_dynamic_array_length(function, first, constants, stack_bindings, &mut transient_stack_depth, builder)?;
+        emit_checked_dynamic_array_length(function, first, constants, stack_bindings, &mut transient_stack_depth, builder)?;
         for leaf_name in rest {
             builder.add_op(OpDup)?;
             transient_stack_depth += 1;
-            emit_dynamic_array_length(function, leaf_name, constants, stack_bindings, &mut transient_stack_depth, builder)?;
+            emit_checked_dynamic_array_length(function, leaf_name, constants, stack_bindings, &mut transient_stack_depth, builder)?;
             builder.add_op(OpNumEqualVerify)?;
             transient_stack_depth -= 2;
         }
@@ -164,7 +170,11 @@ fn compile_param_size_validations<'i>(
     Ok(())
 }
 
-fn emit_dynamic_array_length<'i>(
+/// Copies a dynamic-array parameter, verifies that its encoded byte size is
+/// divisible by its fixed element stride, and leaves the resulting element
+/// count on top of the stack. On success, `stack_depth` therefore increases
+/// by exactly one.
+fn emit_checked_dynamic_array_length<'i>(
     function: &FunctionAst<'i>,
     param_name: &str,
     constants: &HashMap<String, Expr<'i>>,
@@ -183,6 +193,11 @@ fn emit_dynamic_array_length<'i>(
     let copied = stack_bindings.emit_copy_binding_to_top(param_name, stack_depth, builder)?;
     debug_assert!(copied, "entrypoint parameter must have a stack binding");
     builder.add_op(OpSize)?;
+    builder.add_op(OpDup)?;
+    builder.add_i64(element_size)?;
+    builder.add_op(OpMod)?;
+    builder.add_i64(0)?;
+    builder.add_op(OpNumEqualVerify)?;
     builder.add_op(OpSwap)?;
     builder.add_op(OpDrop)?;
     if element_size != 1 {

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -40,8 +40,9 @@ use read_input_state::lower_read_input_state_calls;
 use static_check::validate_expr_matches_type;
 pub use structs::flattened_struct_name;
 pub(super) use structs::{
-    StructRegistry, build_struct_registry, ensure_known_struct_or_builtin_type, flatten_constructor_args_env, flatten_type_leaves,
-    flattened_struct_field_specs_for_type, is_struct, is_struct_array, lower_structs_contract, struct_name, validate_struct_graph,
+    StructArrayParamGroups, StructRegistry, build_struct_registry, dynamic_struct_array_param_groups,
+    ensure_known_struct_or_builtin_type, flatten_constructor_args_env, flatten_type_leaves, flattened_struct_field_specs_for_type,
+    is_struct, is_struct_array, lower_structs_contract, struct_name, validate_struct_graph,
 };
 pub(super) use type_system::{append_type, array_size as array_type_size, concat_types, fixed_type_size, type_refs_equal};
 use validate_output_state::lower_validate_output_state;

--- a/silverscript-lang/src/compiler/structs.rs
+++ b/silverscript-lang/src/compiler/structs.rs
@@ -3,8 +3,8 @@ use std::collections::{HashMap, HashSet};
 use super::compile::read_input_state_field_expr_symbolic;
 use super::*;
 use crate::ast::{
-    ConstantAst, ContractAst, ContractFieldAst, Expr, ExprKind, FunctionAst, ParamAst, STATE_TYPE_NAME, Statement, StructBindingAst,
-    TypeBase, TypeRef,
+    ArrayDim, ConstantAst, ContractAst, ContractFieldAst, Expr, ExprKind, FunctionAst, ParamAst, STATE_TYPE_NAME, Statement,
+    StructBindingAst, TypeBase, TypeRef,
 };
 use crate::span;
 
@@ -22,7 +22,7 @@ mod statement;
 use assignment::lower_assignment;
 pub(crate) use context::LoweringScope;
 use context::StructLowerer;
-pub(crate) use contract::{flatten_constructor_args_env, lower_structs_contract};
+pub(crate) use contract::{dynamic_struct_array_param_groups, flatten_constructor_args_env, lower_structs_contract};
 use declaration::lower_variable_definition;
 use destructure::lower_struct_destructure_statement;
 use expr_lowering::{
@@ -40,3 +40,5 @@ pub(crate) use schema::{
     struct_name, validate_struct_graph,
 };
 use statement::lower_statements;
+
+pub(crate) type StructArrayParamGroups = HashMap<String, Vec<Vec<String>>>;

--- a/silverscript-lang/src/compiler/structs/contract.rs
+++ b/silverscript-lang/src/compiler/structs/contract.rs
@@ -21,6 +21,33 @@ fn flatten_param<'i>(param: &ParamAst<'i>, structs: &StructRegistry) -> Result<V
         .collect())
 }
 
+pub(crate) fn dynamic_struct_array_param_groups(
+    contract: &ContractAst<'_>,
+    structs: &StructRegistry,
+) -> Result<StructArrayParamGroups, CompilerError> {
+    let mut groups_by_entrypoint = HashMap::new();
+
+    for function in contract.functions.iter().filter(|function| function.entrypoint) {
+        let mut groups = Vec::new();
+        for param in &function.params {
+            if !is_struct_array(&param.type_ref, structs) || !matches!(param.type_ref.array_dims.as_slice(), [ArrayDim::Dynamic]) {
+                continue;
+            }
+
+            let leaf_names = flatten_param(param, structs)?.into_iter().map(|leaf| leaf.name).collect::<Vec<_>>();
+            if leaf_names.len() > 1 {
+                groups.push(leaf_names);
+            }
+        }
+
+        if !groups.is_empty() {
+            groups_by_entrypoint.insert(function.name.clone(), groups);
+        }
+    }
+
+    Ok(groups_by_entrypoint)
+}
+
 pub(crate) fn flatten_constructor_args_env<'i>(
     params: &[ParamAst<'i>],
     constructor_args: &[Expr<'i>],

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -3538,6 +3538,27 @@ fn runtime_rejects_mismatched_dynamic_struct_array_leaf_counts_before_append() {
 }
 
 #[test]
+fn codegen_reuses_dynamic_struct_array_leaf_sizes_for_cardinality_validation() {
+    let source = r#"
+        contract C() {
+            struct Item {
+                int number;
+                byte[2] tag;
+            }
+
+            entry main(Item[] items) {
+                require(true);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+
+    assert_eq!(opcodes.matches("OpSize").count(), 2, "each flattened struct-array leaf should be sized once: {opcodes}");
+}
+
+#[test]
 fn runtime_validates_cardinality_for_deeply_nested_struct_array_leaves() {
     let source = r#"
         contract C() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -3494,6 +3494,133 @@ fn runtime_supports_direct_struct_array_entrypoint_signature() {
 }
 
 #[test]
+fn runtime_rejects_mismatched_dynamic_struct_array_leaf_counts_before_append() {
+    let source = r#"
+        contract C() {
+            struct Item {
+                int number;
+                byte[2] tag;
+            }
+
+            entry main(Item[] items, byte[2] appendedTag, byte[2] expectedTag) {
+                require(appendedTag != expectedTag);
+                int len = items.length;
+                Item[] result = items.append(Item {number: 8, tag: appendedTag});
+                require(result[len].number == 8);
+                require(result[len].tag == expectedTag);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+
+    // This cannot encode an Item[]: the number leaf contains one element,
+    // while the tag leaf contains two. Without a cardinality guard, append
+    // makes result[1] combine the appended number with the attacker's second
+    // tag and all source-level requirements succeed.
+    let number_leaf = [7, 0, 0, 0, 0, 0, 0, 0];
+    let tag_leaf = [0x01, 0x02, 0x05, 0x06];
+    let sigscript = script_builder()
+        .add_data(&number_leaf)
+        .unwrap()
+        .add_data(&tag_leaf)
+        .unwrap()
+        .add_data(&[0x03, 0x04])
+        .unwrap()
+        .add_data(&[0x05, 0x06])
+        .unwrap()
+        .add_data(&dispatch_tag_for(&compiled, "main"))
+        .unwrap()
+        .drain();
+
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    assert!(result.is_err(), "mismatched struct-array leaf counts must fail before the entrypoint body");
+}
+
+#[test]
+fn runtime_validates_cardinality_for_deeply_nested_struct_array_leaves() {
+    let source = r#"
+        contract C() {
+            struct Leaf {
+                int[2][3] matrix;
+                byte[4] code;
+            }
+            struct Middle {
+                Leaf leaf;
+                bool[4][2] flags;
+            }
+            struct Item {
+                Middle middle;
+                int[2] totals;
+            }
+
+            entry main(Item[] items) {
+                require(items.length == 1);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let dispatch_tag = dispatch_tag_for(&compiled, "main");
+    let build_sigscript = |code_leaf_len: usize| {
+        script_builder()
+            // One outer Item for each leaf. Their respective strides are
+            // 48 (int[2][3]), 4 (byte[4]), 8 (bool[4][2]), and 16 (int[2]).
+            .add_data(&[0; 48])
+            .unwrap()
+            .add_data(&vec![0; code_leaf_len])
+            .unwrap()
+            .add_data(&[0; 8])
+            .unwrap()
+            .add_data(&[0; 16])
+            .unwrap()
+            .add_data(&dispatch_tag)
+            .unwrap()
+            .drain()
+    };
+
+    let valid = run_bytecode_with_sigscript(compiled.bytecode.clone(), build_sigscript(4));
+    assert!(valid.is_ok(), "equal leaf cardinalities across nested fixed-width layouts should execute: {valid:?}");
+
+    let malformed = run_bytecode_with_sigscript(compiled.bytecode, build_sigscript(8));
+    assert!(malformed.is_err(), "a surplus element in a deeply nested leaf must be rejected");
+}
+
+#[test]
+fn runtime_keeps_cardinality_groups_separate_for_multiple_struct_array_params() {
+    let source = r#"
+        contract C() {
+            struct Item {
+                int number;
+                byte[2] tag;
+            }
+
+            entry main(Item[] first, Item[] second) {
+                require(first.length == 1);
+                require(second.length == 2);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let first = Expr::array(
+        parse_type_ref("Item[]").unwrap(),
+        vec![struct_object("Item", vec![("number", Expr::int(1)), ("tag", Expr::bytes(vec![1, 2]))])],
+    );
+    let second = Expr::array(
+        parse_type_ref("Item[]").unwrap(),
+        vec![
+            struct_object("Item", vec![("number", Expr::int(2)), ("tag", Expr::bytes(vec![3, 4]))]),
+            struct_object("Item", vec![("number", Expr::int(3)), ("tag", Expr::bytes(vec![5, 6]))]),
+        ],
+    );
+    let sigscript = compiled.build_sig_script("main", vec![first, second]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+
+    assert!(result.is_ok(), "separate struct-array parameters may have different lengths: {result:?}");
+}
+
+#[test]
 fn build_sig_script_enforces_fixed_struct_array_length() {
     let source = r#"
         contract C() {


### PR DESCRIPTION
Dynamic arrays of structs are lowered into one dynamic array per recursively flattened leaf, following the KCC1 record-array ABI.

For example:

```sil
struct Item {
    int number;
    byte[2] tag;
}

entry main(Item[] items) {
}
```

is physically represented by:

```text
int[]     items.number
byte[2][] items.tag
```

Previously, entrypoint validation checked each leaf independently:

```text
byteSize(items.number) % 8 == 0
byteSize(items.tag)    % 2 == 0
```

This proves that each leaf contains whole elements, but does not prove that the leaves contain the same number of elements.

A handcrafted signature script could therefore provide one `number` and two `tag` values. This can violate source-level struct semantics without an explicit out-of-bounds access. For example, because append lowers independently per leaf:

```sil
int len = items.length;
Item[] result = items.append(Item {number: 8, tag: appendedTag});

require(result[len].number == 8);
require(result[len].tag == expectedTag);
```

the appended number can be paired with an attacker-supplied surplus tag. The contract author cannot inspect the individual flattened-leaf cardinalities from sil code.

---

This PR restores the aggregate type invariant at the untrusted entrypoint boundary.

Before struct lowering erases the relationship between a logical `Struct[]` parameter and its physical leaves, the compiler records groups of flattened leaf parameter names:

```text
entrypoint
    └── logical Struct[] parameter
            └── flattened leaf parameters
```

The metadata is generated using the same `flatten_param`/`flatten_named_type` logic as actual struct lowering, ensuring that the recorded names match the lowered function parameters. Groups are kept separate per logical parameter, so two distinct struct arrays may still have different lengths.

The metadata is then carried through bytecode-size stabilization and supplied to each lowered entrypoint. After the existing per-leaf divisibility checks, the entrypoint prologue computes each leaf’s logical element count:

```text
COPY leaf
OP_SIZE
OP_SWAP
OP_DROP
PUSH element_stride
OP_DIV
```

The first leaf’s count is retained as the group reference. Every remaining leaf is compared against it with `OP_NUMEQUALVERIFY`, after which the temporary reference count is dropped. All operations inspect copies, leaving the original argument stack unchanged.

The existing divisibility checks execute first, so the subsequent division is exact rather than truncating malformed byte lengths. Validation also runs before any source-level entrypoint statement, ensuring malformed aggregate values never become observable to the contract.

The new regressions cover:

- The append-based malformed-cardinality exploit using a handcrafted signature script.
- Equal-cardinality validation through deeply nested records and fixed-width leaf arrays.
- Independent lengths for two separate dynamic struct-array parameters.

Fixed struct arrays retain their existing exact-byte-size validation, and single-leaf structs require no additional relational check.