### PR TITLE
Expose spanned standalone function AST traversal

### DIFF
--- a/silverscript-lang/src/ast/mod.rs
+++ b/silverscript-lang/src/ast/mod.rs
@@ -5,7 +5,10 @@ use pest::iterators::Pair;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::errors::CompilerError;
-use crate::parser::{Rule, parse_expression as parse_expression_rule, parse_source_file, parse_type_name as parse_type_name_rule};
+use crate::parser::{
+    Rule, parse_expression as parse_expression_rule, parse_function as parse_function_rule, parse_source_file,
+    parse_type_name as parse_type_name_rule,
+};
 pub use crate::span::{Span, SpanUtils};
 
 pub mod visit;
@@ -1467,6 +1470,17 @@ pub fn parse_contract_ast<'i>(source: &'i str) -> Result<ContractAst<'i>, Compil
     }
 
     contract.ok_or_else(|| CompilerError::Unsupported("no contract definition".to_string()))
+}
+
+/// Parses one standalone function or entrypoint definition.
+pub fn parse_function_ast<'i>(source: &'i str) -> Result<FunctionAst<'i>, CompilerError> {
+    let mut pairs = parse_function_rule(source)?;
+    let source_pair = pairs.next().ok_or_else(|| CompilerError::Unsupported("empty function source".to_string()))?;
+    let function_pair = source_pair
+        .into_inner()
+        .find(|pair| pair.as_rule() == Rule::function_definition)
+        .ok_or_else(|| CompilerError::Unsupported("no function definition".to_string()))?;
+    parse_function_definition(function_pair)
 }
 
 pub fn parse_expression_ast<'i>(source: &'i str) -> Result<Expr<'i>, CompilerError> {

--- a/silverscript-lang/src/ast/visit.rs
+++ b/silverscript-lang/src/ast/visit.rs
@@ -23,7 +23,8 @@ pub enum NameKind {
 }
 
 pub trait AstVisitorMut<'i> {
-    fn visit_name(&mut self, _name: &mut String, _kind: NameKind) {}
+    /// Visits a classified name together with its exact source span.
+    fn visit_name(&mut self, _name: &mut String, _kind: NameKind, _span: Span<'i>) {}
     fn visit_span(&mut self, _span: &mut Span<'i>) {}
 
     fn visit_contract(&mut self, contract: &mut ContractAst<'i>) {
@@ -71,8 +72,12 @@ pub fn visit_contract_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, co
     visitor.visit_contract(contract);
 }
 
+pub fn visit_function_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, function: &mut FunctionAst<'i>) {
+    visitor.visit_function(function);
+}
+
 pub fn walk_contract_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, contract: &mut ContractAst<'i>) {
-    visitor.visit_name(&mut contract.name, NameKind::Contract);
+    visitor.visit_name(&mut contract.name, NameKind::Contract, contract.name_span);
     visitor.visit_span(&mut contract.span);
     visitor.visit_span(&mut contract.name_span);
     for param in &mut contract.params {
@@ -90,7 +95,7 @@ pub fn walk_contract_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, con
 }
 
 pub fn walk_contract_field_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, field: &mut ContractFieldAst<'i>) {
-    visitor.visit_name(&mut field.name, NameKind::ContractField);
+    visitor.visit_name(&mut field.name, NameKind::ContractField, field.name_span);
     visitor.visit_span(&mut field.span);
     visitor.visit_span(&mut field.type_span);
     visitor.visit_span(&mut field.name_span);
@@ -98,7 +103,7 @@ pub fn walk_contract_field_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut 
 }
 
 pub fn walk_constant_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, constant: &mut ConstantAst<'i>) {
-    visitor.visit_name(&mut constant.name, NameKind::Constant);
+    visitor.visit_name(&mut constant.name, NameKind::Constant, constant.name_span);
     visitor.visit_span(&mut constant.span);
     visitor.visit_span(&mut constant.type_span);
     visitor.visit_span(&mut constant.name_span);
@@ -106,7 +111,7 @@ pub fn walk_constant_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, con
 }
 
 pub fn walk_function_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, function: &mut FunctionAst<'i>) {
-    visitor.visit_name(&mut function.name, NameKind::Function);
+    visitor.visit_name(&mut function.name, NameKind::Function, function.name_span);
     visitor.visit_span(&mut function.span);
     visitor.visit_span(&mut function.name_span);
     visitor.visit_span(&mut function.body_span);
@@ -126,11 +131,11 @@ pub fn walk_function_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, fun
 
 pub fn walk_function_attribute_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, attribute: &mut FunctionAttributeAst<'i>) {
     visitor.visit_span(&mut attribute.span);
+    for (segment, span) in attribute.path.iter_mut().zip(attribute.path_spans.iter().copied()) {
+        visitor.visit_name(segment, NameKind::AttributePathSegment, span);
+    }
     for span in &mut attribute.path_spans {
         visitor.visit_span(span);
-    }
-    for segment in &mut attribute.path {
-        visitor.visit_name(segment, NameKind::AttributePathSegment);
     }
     for arg in &mut attribute.args {
         visitor.visit_function_attribute_arg(arg);
@@ -138,22 +143,26 @@ pub fn walk_function_attribute_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &
 }
 
 pub fn walk_function_attribute_arg_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, arg: &mut FunctionAttributeArgAst<'i>) {
-    visitor.visit_name(&mut arg.name, NameKind::AttributeArg);
+    visitor.visit_name(&mut arg.name, NameKind::AttributeArg, arg.name_span);
     visitor.visit_span(&mut arg.span);
     visitor.visit_span(&mut arg.name_span);
     visitor.visit_expr(&mut arg.expr);
 }
 
 pub fn walk_param_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, param: &mut ParamAst<'i>) {
-    visitor.visit_name(&mut param.name, NameKind::Parameter);
+    walk_param_with_kind_mut(visitor, param, NameKind::Parameter);
+}
+
+fn walk_param_with_kind_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, param: &mut ParamAst<'i>, kind: NameKind) {
+    visitor.visit_name(&mut param.name, kind, param.name_span);
     visitor.visit_span(&mut param.span);
     visitor.visit_span(&mut param.type_span);
     visitor.visit_span(&mut param.name_span);
 }
 
 pub fn walk_state_binding_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, binding: &mut StructBindingAst<'i>) {
-    visitor.visit_name(&mut binding.field_name, NameKind::StateField);
-    visitor.visit_name(&mut binding.name, NameKind::StateBinding);
+    visitor.visit_name(&mut binding.field_name, NameKind::StateField, binding.field_span);
+    visitor.visit_name(&mut binding.name, NameKind::StateBinding, binding.name_span);
     visitor.visit_span(&mut binding.span);
     visitor.visit_span(&mut binding.field_span);
     visitor.visit_span(&mut binding.type_span);
@@ -163,13 +172,13 @@ pub fn walk_state_binding_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V
 pub fn walk_statement_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, statement: &mut Statement<'i>) {
     match statement {
         Statement::VariableDefinition { name, expr, span, type_span, modifier_spans, name_span, .. } => {
+            visitor.visit_name(name, NameKind::LocalBinding, *name_span);
             visitor.visit_span(span);
             visitor.visit_span(type_span);
             for span in modifier_spans {
                 visitor.visit_span(span);
             }
             visitor.visit_span(name_span);
-            visitor.visit_name(name, NameKind::LocalBinding);
             if let Some(expr) = expr {
                 visitor.visit_expr(expr);
             }
@@ -185,41 +194,41 @@ pub fn walk_statement_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, st
             right_name_span,
             ..
         } => {
+            visitor.visit_name(left_name, NameKind::LocalBinding, *left_name_span);
+            visitor.visit_name(right_name, NameKind::LocalBinding, *right_name_span);
             visitor.visit_span(span);
             visitor.visit_span(left_type_span);
             visitor.visit_span(left_name_span);
             visitor.visit_span(right_type_span);
             visitor.visit_span(right_name_span);
-            visitor.visit_name(left_name, NameKind::AssignmentTarget);
-            visitor.visit_name(right_name, NameKind::AssignmentTarget);
             visitor.visit_expr(expr);
         }
         Statement::FunctionCall { name, args, span, name_span } => {
+            visitor.visit_name(name, NameKind::CallTarget, *name_span);
             visitor.visit_span(span);
             visitor.visit_span(name_span);
-            visitor.visit_name(name, NameKind::CallTarget);
             for arg in args {
                 visitor.visit_expr(arg);
             }
         }
         Statement::FunctionCallAssign { bindings, name, args, span, name_span } => {
+            visitor.visit_name(name, NameKind::CallTarget, *name_span);
             visitor.visit_span(span);
             visitor.visit_span(name_span);
             for binding in bindings {
-                visitor.visit_param(binding);
+                walk_param_with_kind_mut(visitor, binding, NameKind::LocalBinding);
             }
-            visitor.visit_name(name, NameKind::CallTarget);
             for arg in args {
                 visitor.visit_expr(arg);
             }
         }
         Statement::StateFunctionCallAssign { target_struct: _, bindings, name, args, span, name_span } => {
+            visitor.visit_name(name, NameKind::CallTarget, *name_span);
             visitor.visit_span(span);
             visitor.visit_span(name_span);
             for binding in bindings {
                 visitor.visit_state_binding(binding);
             }
-            visitor.visit_name(name, NameKind::CallTarget);
             for arg in args {
                 visitor.visit_expr(arg);
             }
@@ -232,9 +241,9 @@ pub fn walk_statement_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, st
             visitor.visit_expr(expr);
         }
         Statement::Assign { name, expr, span, name_span } => {
+            visitor.visit_name(name, NameKind::AssignmentTarget, *name_span);
             visitor.visit_span(span);
             visitor.visit_span(name_span);
-            visitor.visit_name(name, NameKind::AssignmentTarget);
             visitor.visit_expr(expr);
         }
         Statement::RequireAgeDaa { expr, span, target_span, message_span, .. }
@@ -277,10 +286,10 @@ pub fn walk_statement_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, st
             }
         }
         Statement::For { ident, start, end, max_iterations, body, span, ident_span, body_span } => {
+            visitor.visit_name(ident, NameKind::LoopBinding, *ident_span);
             visitor.visit_span(span);
             visitor.visit_span(ident_span);
             visitor.visit_span(body_span);
-            visitor.visit_name(ident, NameKind::LoopBinding);
             visitor.visit_expr(start);
             visitor.visit_expr(end);
             visitor.visit_expr(max_iterations);
@@ -304,17 +313,18 @@ pub fn walk_statement_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, st
 }
 
 pub fn walk_expr_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, expr: &mut Expr<'i>) {
+    let expr_span = expr.span;
     visitor.visit_span(&mut expr.span);
     match &mut expr.kind {
-        ExprKind::Identifier(name) => visitor.visit_name(name, NameKind::IdentifierExpr),
+        ExprKind::Identifier(name) => visitor.visit_name(name, NameKind::IdentifierExpr, expr_span),
         ExprKind::Array { values: items, .. } => {
             for item in items {
                 visitor.visit_expr(item);
             }
         }
         ExprKind::Call { name, args, name_span } | ExprKind::New { name, args, name_span } => {
+            visitor.visit_name(name, NameKind::CallTarget, *name_span);
             visitor.visit_span(name_span);
-            visitor.visit_name(name, NameKind::CallTarget);
             for arg in args {
                 visitor.visit_expr(arg);
             }
@@ -364,7 +374,7 @@ pub fn walk_expr_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, expr: &
         ExprKind::StructLiteral { fields, name_span, .. } => {
             visitor.visit_span(name_span);
             for field in fields {
-                visitor.visit_name(&mut field.name, NameKind::StateField);
+                visitor.visit_name(&mut field.name, NameKind::StateField, field.name_span);
                 visitor.visit_span(&mut field.span);
                 visitor.visit_span(&mut field.name_span);
                 visitor.visit_expr(&mut field.expr);
@@ -372,7 +382,7 @@ pub fn walk_expr_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, expr: &
         }
         ExprKind::FieldAccess { source, field, field_span } => {
             visitor.visit_expr(source);
-            visitor.visit_name(field, NameKind::StateField);
+            visitor.visit_name(field, NameKind::StateField, *field_span);
             visitor.visit_span(field_span);
         }
         ExprKind::Int(_)

--- a/silverscript-lang/src/parser.rs
+++ b/silverscript-lang/src/parser.rs
@@ -13,6 +13,11 @@ pub fn parse_source_file(input: &str) -> Result<Pairs<'_, Rule>, ParseDiagnostic
     SilverScriptParser::parse(Rule::source_file, input).map_err(|err| crate::diagnostic::interpret_parse_error(input, &err))
 }
 
+pub fn parse_function(input: &str) -> Result<Pairs<'_, Rule>, ParseDiagnostic> {
+    pest::set_error_detail(true);
+    SilverScriptParser::parse(Rule::function_source, input).map_err(|err| crate::diagnostic::interpret_parse_error(input, &err))
+}
+
 pub fn parse_expression(input: &str) -> Result<Pairs<'_, Rule>, ParseDiagnostic> {
     pest::set_error_detail(true);
     SilverScriptParser::parse(Rule::expression, input).map_err(|err| crate::diagnostic::interpret_parse_error(input, &err))

--- a/silverscript-lang/src/silverscript.pest
+++ b/silverscript-lang/src/silverscript.pest
@@ -1,4 +1,5 @@
 source_file = { SOI ~ pragma_directive? ~ contract_definition ~ EOI }
+function_source = { SOI ~ function_definition ~ EOI }
 
 pragma_directive = { "pragma" ~ pragma_name ~ pragma_value ~ ";" }
 pragma_name = { "silverscript" }

--- a/silverscript-lang/tests/ast_spans_tests.rs
+++ b/silverscript-lang/tests/ast_spans_tests.rs
@@ -1,10 +1,66 @@
-use silverscript_lang::ast::{ExprKind, Statement, parse_contract_ast};
+use silverscript_lang::ast::visit::{AstVisitorMut, NameKind, visit_function_mut};
+use silverscript_lang::ast::{ExprKind, Statement, parse_contract_ast, parse_function_ast};
+use silverscript_lang::span::Span;
 
 fn assert_span_text(source: &str, actual: &str, expected: &str) {
     let start = source.find(expected).expect("expected text must exist in source");
     let end = start + expected.len();
     assert_eq!(actual, expected);
     assert_eq!(&source[start..end], expected);
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct NameOccurrence {
+    name: String,
+    kind: NameKind,
+    source: String,
+}
+
+#[derive(Default)]
+struct NameOccurrenceCollector {
+    occurrences: Vec<NameOccurrence>,
+}
+
+impl<'i> AstVisitorMut<'i> for NameOccurrenceCollector {
+    fn visit_name(&mut self, name: &mut String, kind: NameKind, span: Span<'i>) {
+        self.occurrences.push(NameOccurrence { name: name.clone(), kind, source: span.as_str().to_string() });
+    }
+}
+
+#[test]
+fn parses_standalone_functions_and_visits_name_spans() {
+    let source = r#"function inspect(Turn turn) : int {
+        int value = helper(turn.cycles);
+        int left, int right = pair();
+        (int total) = sum(left, right);
+        value = value + 1;
+        return(total);
+    }"#;
+    let mut function = parse_function_ast(source).expect("standalone function should parse");
+    let mut collector = NameOccurrenceCollector::default();
+    visit_function_mut(&mut collector, &mut function);
+
+    assert_eq!(
+        collector.occurrences,
+        vec![
+            NameOccurrence { name: "inspect".to_string(), kind: NameKind::Function, source: "inspect".to_string() },
+            NameOccurrence { name: "turn".to_string(), kind: NameKind::Parameter, source: "turn".to_string() },
+            NameOccurrence { name: "value".to_string(), kind: NameKind::LocalBinding, source: "value".to_string() },
+            NameOccurrence { name: "helper".to_string(), kind: NameKind::CallTarget, source: "helper".to_string() },
+            NameOccurrence { name: "turn".to_string(), kind: NameKind::IdentifierExpr, source: "turn".to_string() },
+            NameOccurrence { name: "cycles".to_string(), kind: NameKind::StateField, source: "cycles".to_string() },
+            NameOccurrence { name: "left".to_string(), kind: NameKind::LocalBinding, source: "left".to_string() },
+            NameOccurrence { name: "right".to_string(), kind: NameKind::LocalBinding, source: "right".to_string() },
+            NameOccurrence { name: "pair".to_string(), kind: NameKind::CallTarget, source: "pair".to_string() },
+            NameOccurrence { name: "sum".to_string(), kind: NameKind::CallTarget, source: "sum".to_string() },
+            NameOccurrence { name: "total".to_string(), kind: NameKind::LocalBinding, source: "total".to_string() },
+            NameOccurrence { name: "left".to_string(), kind: NameKind::IdentifierExpr, source: "left".to_string() },
+            NameOccurrence { name: "right".to_string(), kind: NameKind::IdentifierExpr, source: "right".to_string() },
+            NameOccurrence { name: "value".to_string(), kind: NameKind::AssignmentTarget, source: "value".to_string() },
+            NameOccurrence { name: "value".to_string(), kind: NameKind::IdentifierExpr, source: "value".to_string() },
+            NameOccurrence { name: "total".to_string(), kind: NameKind::IdentifierExpr, source: "total".to_string() },
+        ]
+    );
 }
 
 #[test]

--- a/silverscript-lang/tests/covenant_declaration_ast_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_ast_tests.rs
@@ -23,7 +23,7 @@ fn canonicalize_generated_name(name: &str) -> String {
 struct GeneratedNameCanonicalizer;
 
 impl<'i> AstVisitorMut<'i> for GeneratedNameCanonicalizer {
-    fn visit_name(&mut self, name: &mut String, _kind: NameKind) {
+    fn visit_name(&mut self, name: &mut String, _kind: NameKind, _span: Span<'i>) {
         *name = canonicalize_generated_name(name);
     }
 


### PR DESCRIPTION
## Context

This change is required by [the Argent global-helper namespace PR](https://github.com/argent-lang/argent/pull/49).

Argent emits each global helper function into several generated Sil contracts. It must rename the helper’s parameters and local bindings so they cannot collide with fields in those contracts.

A token-based identifier scan is not sufficient. Sil has contextual syntax, complete numeric literals, field names, call targets, destructuring, and several forms of typed result declarations. Argent needs Sil’s own syntax classification.

## Need

Argent must answer two questions for every name in a helper:

1. What role does this name have?
2. Where exactly does it appear in the original source?

`NameKind` already answers the first question.

The previous `visit_name` callback did not answer the second. `visit_span` could report spans separately, but it did not associate a specific name with its span. Argent therefore could not safely make source-preserving edits.

Reformatting the complete AST was not appropriate for this use. Argent only needs to insert a generated prefix at selected identifiers while preserving comments, strings, literals, and the surrounding source.

## Change

The AST API now supports parsing and visiting one standalone function:

```rust
let mut function = parse_function_ast(source)?;
visit_function_mut(&mut visitor, &mut function);
```

`AstVisitorMut::visit_name` now receives the exact span of the classified name:

```rust
fn visit_name(
    &mut self,
    name: &mut String,
    kind: NameKind,
    span: Span<'i>,
);
```

Every existing name visit now supplies its corresponding source span.

The parser adds a standalone `function_source` root. It reuses the existing function grammar and AST construction; it does not introduce a second function parser.

## Binding classification fixes

The visitor also corrects two name classifications.

### Tuple results

Names declared by a typed tuple result are local bindings:

```sil
int left, int right = pair();
```

Both names include explicit types and introduce new local variables. They were previously reported as `AssignmentTarget`, which describes assignment to an existing variable.

They are now reported as `LocalBinding`.

### Function-call results

Typed function-call results also introduce local variables:

```sil
(int total) = sum(left, right);
```

These names were previously visited through `visit_param` and reported as `Parameter`. They are not function parameters; they are local result declarations inside the function body.

They are now reported as `LocalBinding`.

These changes affect visitor metadata only. They align the public AST traversal with the meaning already represented by the statement variants and do not change Sil compilation behavior.

## Coverage

Tests verify:

- standalone function parsing
- exact spans for function names and parameters
- local, tuple-result, and function-result bindings
- function call targets
- identifier references
- state fields
- assignment targets
- traversal order

Sil `./check.sh` passes with all 807 tests.