### PR TITLE
feat(compiler): dispatch tag revision

### DIFF
--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -70,7 +70,7 @@ pub(super) fn compile_contract_impl<'i>(
     lowered_constants.extend(lowered_contract.constants.iter().map(|constant| (constant.name.clone(), constant.expr.clone())));
 
     let BuiltAbi { function_abi_entries, cov_decl_to_abi, delegate_entry_abi } =
-        build_abi(&covenant_lowered_contract, &constants, &covenant_abi_names)?;
+        build_abi(&covenant_lowered_contract, &constants, &structs, &covenant_abi_names)?;
     if function_abi_entries.is_empty() {
         return Err(CompilerError::Unsupported("contract has no entries".to_string()));
     }
@@ -78,7 +78,7 @@ pub(super) fn compile_contract_impl<'i>(
     // dispatch tag: verify no collisions and insert tags to global state
     let mut entrypoints_by_tag = HashMap::<DispatchTag, &str>::new();
     for entrypoint in &function_abi_entries {
-        let tag = entrypoint.dispatch_tag();
+        let tag = entrypoint.dispatch_tag;
         if let Some(existing) = entrypoints_by_tag.insert(tag, entrypoint.name.as_str()) {
             return Err(CompilerError::EntrypointDispatchTagCollision { f1: existing.to_string(), f2: entrypoint.name.clone() });
         }
@@ -212,7 +212,7 @@ fn build_contract_bytecode(
     let total = compiled_entrypoints.len();
 
     let dispatch_tag_by_entry_name =
-        function_abi_entries.iter().map(|entry| (entry.name.as_str(), entry.dispatch_tag())).collect::<HashMap<_, _>>();
+        function_abi_entries.iter().map(|entry| (entry.name.as_str(), entry.dispatch_tag)).collect::<HashMap<_, _>>();
 
     for (entrypoint_index, (name, bytecode)) in compiled_entrypoints.iter().enumerate() {
         let dispatch_tag = dispatch_tag_by_entry_name.get(name.as_str()).expect("compiled entrypoint must have an ABI entry");

--- a/silverscript-lang/src/compiler/compile/helpers.rs
+++ b/silverscript-lang/src/compiler/compile/helpers.rs
@@ -54,9 +54,54 @@ pub(super) fn infer_expr_type<'i>(
     type_check::check_expr(expr, None, &ctx)
 }
 
+/// assumption: no inferred dimensions array param on entrypoint parameters before calling this function
+fn write_dispatch_type_name<'i>(
+    type_ref: &TypeRef,
+    structs: &StructRegistry,
+    constants: &HashMap<String, Expr<'i>>,
+    signature: &mut String,
+) -> Result<(), CompilerError> {
+    match &type_ref.base {
+        TypeBase::Custom(name) => {
+            let item = structs
+                .get(name)
+                .ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{name}' in entrypoint dispatch type")))?;
+            signature.push('{');
+            for (index, field) in item.fields.iter().enumerate() {
+                if index != 0 {
+                    signature.push(',');
+                }
+                write_dispatch_type_name(&field.type_ref, structs, constants, signature)?;
+            }
+            signature.push('}');
+        }
+        _ => signature.push_str(&type_ref.base.type_name()),
+    }
+
+    for dimension in &type_ref.array_dims {
+        match dimension {
+            ArrayDim::Dynamic => signature.push_str("[]"),
+            ArrayDim::Fixed(size) => signature.push_str(&format!("[{size}]")),
+            ArrayDim::Constant(name) => {
+                let value = constants
+                    .get(name)
+                    .ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))
+                    .and_then(|expr| eval_const_int(expr, constants))?;
+                let size = usize::try_from(value)
+                    .map_err(|_| CompilerError::Unsupported(format!("array size constant '{name}' must be a non-negative integer")))?;
+                signature.push_str(&format!("[{size}]"));
+            }
+            ArrayDim::Inferred => panic!("inferred array dimensions must be rejected before writing a dispatch type name"),
+        }
+    }
+
+    Ok(())
+}
+
 pub(super) fn build_abi<'i>(
     contract: &ContractAst<'i>,
     constants: &HashMap<String, Expr<'i>>,
+    structs: &StructRegistry,
     covenant_abi_names: &CovenantDeclarationAbiNames,
 ) -> Result<BuiltAbi, CompilerError> {
     let source_name_by_entrypoint = covenant_abi_names
@@ -70,7 +115,7 @@ pub(super) fn build_abi<'i>(
     let mut delegate_entry_abi = None;
 
     for func in contract.functions.iter().filter(|func| func.entrypoint) {
-        let inputs = func
+        let input_specs = func
             .params
             .iter()
             .map(|param| {
@@ -93,10 +138,21 @@ pub(super) fn build_abi<'i>(
                         *dimension = ArrayDim::Fixed(size);
                     }
                 }
-                Ok(FunctionInputAbi { name: param.name.clone(), type_name: type_ref.type_name() })
+                let type_name = type_ref.type_name();
+                let mut signature_type = String::new();
+                write_dispatch_type_name(&type_ref, structs, constants, &mut signature_type)?;
+                Ok((FunctionInputAbi { name: param.name.clone(), type_name }, signature_type))
             })
             .collect::<Result<Vec<_>, CompilerError>>()?;
-        let entry = FunctionAbiEntry { name: func.name.clone(), inputs };
+        let (inputs, signature_types): (Vec<_>, Vec<_>) = input_specs.into_iter().unzip();
+
+        // dispatch tag creation
+        let signature = format!("{}({})", func.name, signature_types.join(","));
+        let hash = blake3::hash(signature.as_bytes());
+        let mut dispatch_tag = [0u8; 4];
+        dispatch_tag.copy_from_slice(&hash.as_bytes()[..4]);
+
+        let entry = FunctionAbiEntry { name: func.name.clone(), inputs, dispatch_tag };
 
         if let Some(source_name) = source_name_by_entrypoint.get(func.name.as_str()) {
             cov_decl_to_abi.insert((*source_name).to_string(), entry.clone());

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -96,24 +96,10 @@ pub struct FunctionInputAbi {
 pub struct FunctionAbiEntry {
     pub name: String,
     pub inputs: Vec<FunctionInputAbi>,
-    #[serde(serialize_with = "faster_hex::nopfx_lowercase::serialize", deserialize_with = "deserialize_dispatch_tag")]
     pub dispatch_tag: DispatchTag,
 }
 
 pub type DispatchTag = [u8; 4];
-
-fn deserialize_dispatch_tag<'de, D>(deserializer: D) -> Result<DispatchTag, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let encoded = String::deserialize(deserializer)?;
-    if encoded.len() != 8 {
-        return Err(serde::de::Error::custom("dispatch tag must contain exactly 8 hexadecimal characters"));
-    }
-    let mut dispatch_tag = [0u8; 4];
-    faster_hex::hex_decode(encoded.as_bytes(), &mut dispatch_tag).map_err(serde::de::Error::custom)?;
-    Ok(dispatch_tag)
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CompiledStateLayout {

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -96,19 +96,23 @@ pub struct FunctionInputAbi {
 pub struct FunctionAbiEntry {
     pub name: String,
     pub inputs: Vec<FunctionInputAbi>,
+    #[serde(serialize_with = "faster_hex::nopfx_lowercase::serialize", deserialize_with = "deserialize_dispatch_tag")]
+    pub dispatch_tag: DispatchTag,
 }
 
 pub type DispatchTag = [u8; 4];
 
-impl FunctionAbiEntry {
-    pub fn dispatch_tag(&self) -> DispatchTag {
-        let type_names = self.inputs.iter().map(|input| input.type_name.as_str()).collect::<Vec<_>>().join(",");
-        let signature = format!("{}({type_names})", self.name);
-        let hash = blake3::hash(signature.as_bytes());
-        let mut tag = [0u8; 4];
-        tag.copy_from_slice(&hash.as_bytes()[..4]);
-        tag
+fn deserialize_dispatch_tag<'de, D>(deserializer: D) -> Result<DispatchTag, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let encoded = String::deserialize(deserializer)?;
+    if encoded.len() != 8 {
+        return Err(serde::de::Error::custom("dispatch tag must contain exactly 8 hexadecimal characters"));
     }
+    let mut dispatch_tag = [0u8; 4];
+    faster_hex::hex_decode(encoded.as_bytes(), &mut dispatch_tag).map_err(serde::de::Error::custom)?;
+    Ok(dispatch_tag)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -260,7 +264,7 @@ impl<'i> CompiledContract<'i> {
             })?;
         }
 
-        builder.add_data(&function.dispatch_tag())?;
+        builder.add_data(&function.dispatch_tag)?;
 
         Ok(builder.drain())
     }

--- a/silverscript-lang/tests/cashc_valid_examples_tests.rs
+++ b/silverscript-lang/tests/cashc_valid_examples_tests.rs
@@ -128,7 +128,7 @@ fn build_sigscript(args: &[ArgValue], dispatch_tag: DispatchTag) -> Vec<u8> {
 }
 
 fn dispatch_tag_for_compiled(compiled: &CompiledContract<'_>, function_name: &str) -> DispatchTag {
-    compiled.entry_by_name(function_name).expect("entrypoint resolved").dispatch_tag()
+    compiled.entry_by_name(function_name).expect("entrypoint resolved").dispatch_tag
 }
 
 fn build_p2pk_script(pubkey: &[u8]) -> Vec<u8> {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -6841,6 +6841,33 @@ fn record_dispatch_tag_matches_kcc1_structural_type_vector() {
 }
 
 #[test]
+fn dispatch_tag_hashes_exact_utf8_signature_bytes() {
+    // KCC identifiers are currently ASCII-only. Mutating parsed ASTs still pins the
+    // UTF-8 hashing semantics if that restriction is relaxed in the future.
+    let cases = [
+        ("café", true, b"caf\xc3\xa9(int)".as_slice(), [0x76, 0xbb, 0x38, 0x88]),
+        ("轉帳", false, b"\xe8\xbd\x89\xe5\xb8\xb3()".as_slice(), [0x9a, 0x67, 0x99, 0xc5]),
+        ("🚀", true, b"\xf0\x9f\x9a\x80(int)".as_slice(), [0xfa, 0x79, 0x41, 0x20]),
+        ("café", false, b"caf\xc3\xa9()".as_slice(), [0xde, 0x33, 0x57, 0x99]),
+        ("cafe\u{301}", false, b"cafe\xcc\x81()".as_slice(), [0x3f, 0x0c, 0x9d, 0xa1]),
+    ];
+
+    for (name, has_input, utf8_signature, expected_tag) in cases {
+        let source = if has_input {
+            "contract Test() { entry placeholder(int value) { require(true); } }"
+        } else {
+            "contract Test() { entry placeholder() { require(true); } }"
+        };
+        let mut contract = parse_contract_ast(source).expect("contract parses");
+        contract.functions[0].name = name.to_string();
+
+        let compiled = compile_contract_ast(&contract, &[], CompileOptions::default()).expect("contract compiles");
+        assert_eq!(&blake3::hash(utf8_signature).as_bytes()[..4], expected_tag);
+        assert_eq!(compiled.entry_by_name(name).expect("entrypoint exists").dispatch_tag, expected_tag);
+    }
+}
+
+#[test]
 fn rejects_colliding_kcc1_dispatch_tags() {
     let source = r#"
         contract Test() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -2562,7 +2562,7 @@ fn build_sig_script_appends_dispatch_tag_for_single_entrypoint() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = compiled.build_sig_script("spend", vec![1.into(), vec![2u8; 4].into()]).expect("sigscript builds");
-    let dispatch_tag = compiled.entry_by_name("spend").expect("entrypoint resolved").dispatch_tag();
+    let dispatch_tag = compiled.entry_by_name("spend").expect("entrypoint resolved").dispatch_tag;
 
     let expected =
         script_builder().add_i64(1).unwrap().add_data_with_push_opcode(&[2u8; 4]).unwrap().add_data(&dispatch_tag).unwrap().drain();
@@ -2761,16 +2761,19 @@ fn replace_compiled_interface<'i>(
     entrypoint_name: &str,
     inputs: &[(&str, &str)],
 ) {
-    let old_dispatch_tag = compiled.abi[0].dispatch_tag();
+    let old_dispatch_tag = compiled.abi[0].dispatch_tag;
     compiled.ast = parse_contract_ast(source).expect("interface parses");
+    // Do not rely on the dispatch tag in tests using this synthetic interface.
+    let dispatch_tag = [0u8; 4];
     compiled.abi = vec![FunctionAbiEntry {
         name: entrypoint_name.to_string(),
         inputs: inputs
             .iter()
             .map(|(name, type_name)| FunctionInputAbi { name: (*name).to_string(), type_name: (*type_name).to_string() })
             .collect(),
+        dispatch_tag,
     }];
-    let new_dispatch_tag = compiled.abi[0].dispatch_tag();
+    let new_dispatch_tag = compiled.abi[0].dispatch_tag;
     let tag_offset = compiled
         .bytecode
         .windows(old_dispatch_tag.len())
@@ -6605,7 +6608,7 @@ fn build_covenant_opcode_tx(sigscript: Vec<u8>, covenant_id_a: Hash, covenant_id
 }
 
 fn dispatch_tag_for(compiled: &CompiledContract<'_>, function_name: &str) -> DispatchTag {
-    compiled.entry_by_name(function_name).expect("entrypoint resolved").dispatch_tag()
+    compiled.entry_by_name(function_name).expect("entrypoint resolved").dispatch_tag
 }
 
 fn wrap_with_single_dispatch(compiled: &CompiledContract<'_>, body: Vec<u8>) -> Vec<u8> {
@@ -6616,7 +6619,7 @@ fn wrap_with_single_dispatch_and_state(compiled: &CompiledContract<'_>, state: &
     let [entrypoint] = compiled.abi.as_slice() else {
         panic!("single-dispatch wrapper requires exactly one ABI entrypoint");
     };
-    let dispatch_tag = entrypoint.dispatch_tag();
+    let dispatch_tag = entrypoint.dispatch_tag;
     let mut builder = script_builder();
     if !state.is_empty() {
         builder.add_op(OpToAltStack).unwrap();
@@ -6706,8 +6709,8 @@ fn compiles_stateless_multiple_entrypoints_with_kcc1_dispatch_tags() {
 
     let contract = parse_contract_ast(source).expect("ast parsed");
     let compiled = compile_contract_ast(&contract, &[], CompileOptions::default()).expect("compile succeeds");
-    let dispatch_tag_a = compiled.entry_by_name("a").expect("entrypoint resolved").dispatch_tag();
-    let dispatch_tag_b = compiled.entry_by_name("b").expect("entrypoint resolved").dispatch_tag();
+    let dispatch_tag_a = compiled.entry_by_name("a").expect("entrypoint resolved").dispatch_tag;
+    let dispatch_tag_b = compiled.entry_by_name("b").expect("entrypoint resolved").dispatch_tag;
 
     let body_a = script_builder()
         .add_i64(1)
@@ -6801,7 +6804,7 @@ fn dispatch_tag_and_argument_encoding_match_kcc1_vector() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let step = compiled.entry_by_name("step").expect("step entrypoint exists");
     assert_eq!(step.inputs[1].type_name, "byte[4]");
-    assert_eq!(step.dispatch_tag(), [0x2c, 0x49, 0xed, 0x65]);
+    assert_eq!(step.dispatch_tag, [0x2c, 0x49, 0xed, 0x65]);
 
     let sigscript = compiled
         .build_sig_script("step", vec![Expr::int(17), Expr::bytes(vec![1, 2, 3, 4]), Expr::bool(true), Expr::byte(1)])
@@ -6811,43 +6814,30 @@ fn dispatch_tag_and_argument_encoding_match_kcc1_vector() {
 }
 
 #[test]
-fn dispatch_tag_hashes_exact_utf8_signature_bytes() {
-    // KCC identifiers are currently ASCII-only. These manually constructed ABI entries
-    // still pin the UTF-8 hashing semantics if that restriction is relaxed in the future.
-    let cases = [
-        (
-            FunctionAbiEntry {
-                name: "café".to_string(),
-                inputs: vec![FunctionInputAbi { name: "value".to_string(), type_name: "int".to_string() }],
-            },
-            b"caf\xc3\xa9(int)".as_slice(),
-            [0x76, 0xbb, 0x38, 0x88],
-        ),
-        (
-            FunctionAbiEntry { name: "轉帳".to_string(), inputs: vec![] },
-            b"\xe8\xbd\x89\xe5\xb8\xb3()".as_slice(),
-            [0x9a, 0x67, 0x99, 0xc5],
-        ),
-        (
-            FunctionAbiEntry {
-                name: "🚀".to_string(),
-                inputs: vec![FunctionInputAbi { name: "value".to_string(), type_name: "int".to_string() }],
-            },
-            b"\xf0\x9f\x9a\x80(int)".as_slice(),
-            [0xfa, 0x79, 0x41, 0x20],
-        ),
-    ];
+fn record_dispatch_tag_matches_kcc1_structural_type_vector() {
+    let source = r#"
+        contract CoffeeMachine() {
+            int constant RECIPE_CODE_LEN = 4;
 
-    for (entrypoint, utf8_signature, expected_tag) in cases {
-        assert_eq!(&blake3::hash(utf8_signature).as_bytes()[..4], expected_tag);
-        assert_eq!(entrypoint.dispatch_tag(), expected_tag);
-    }
+            struct CoffeeOrder {
+                byte[RECIPE_CODE_LEN] recipe_code;
+                byte sugar_level;
+                bool with_milk;
+            }
 
-    let composed = FunctionAbiEntry { name: "café".to_string(), inputs: vec![] };
-    let decomposed = FunctionAbiEntry { name: "cafe\u{301}".to_string(), inputs: vec![] };
-    assert_eq!(composed.dispatch_tag(), [0xde, 0x33, 0x57, 0x99]);
-    assert_eq!(decomposed.dispatch_tag(), [0x3f, 0x0c, 0x9d, 0xa1]);
-    assert_ne!(composed.dispatch_tag(), decomposed.dispatch_tag(), "dispatch signatures must not normalize Unicode");
+            entry dispense(CoffeeOrder[] orders) {
+                require(orders.length >= 0);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let dispense = compiled.entry_by_name("dispense").expect("dispense entrypoint exists");
+    assert_eq!(dispense.inputs[0].type_name, "CoffeeOrder[]");
+    assert_eq!(dispense.dispatch_tag, [0x67, 0x6b, 0x1a, 0x86]);
+
+    let json = serde_json::to_string(dispense).expect("ABI entry serializes");
+    assert_eq!(serde_json::from_str::<serde_json::Value>(&json).unwrap()["dispatch_tag"], "676b1a86");
 }
 
 #[test]

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -6887,6 +6887,11 @@ fn dispatch_tag_for(compiled: &CompiledContract<'_>, function_name: &str) -> Dis
     compiled.entry_by_name(function_name).expect("entrypoint resolved").dispatch_tag
 }
 
+fn dispatch_tag_for_preimage(preimage: &str) -> DispatchTag {
+    let hash = blake3::hash(preimage.as_bytes());
+    hash.as_bytes()[..4].try_into().expect("a BLAKE3 hash contains a four-byte dispatch tag")
+}
+
 fn wrap_with_single_dispatch(compiled: &CompiledContract<'_>, body: Vec<u8>) -> Vec<u8> {
     wrap_with_single_dispatch_and_state(compiled, &[], &body)
 }
@@ -7114,6 +7119,40 @@ fn record_dispatch_tag_matches_kcc1_structural_type_vector() {
 
     let json = serde_json::to_string(dispense).expect("ABI entry serializes");
     assert_eq!(serde_json::from_str::<serde_json::Value>(&json).unwrap()["dispatch_tag"], serde_json::json!([103, 107, 26, 134]));
+}
+
+#[test]
+fn nested_record_dispatch_tags_hash_structural_type_preimages() {
+    let source = r#"
+        contract Test() {
+            int constant N = 3;
+
+            struct Inner {
+                int value;
+                byte[N] payload;
+            }
+
+            struct Outer {
+                Inner child;
+                bool[2] flags;
+            }
+
+            entry scalar(Outer value) { require(true); }
+            entry dynamic(Outer[] values) { require(values.length >= 0); }
+            entry fixed(Outer[2] values) { require(values.length == 2); }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let vectors = [
+        ("scalar", "scalar({{int,byte[3]},bool[2]})"),
+        ("dynamic", "dynamic({{int,byte[3]},bool[2]}[])"),
+        ("fixed", "fixed({{int,byte[3]},bool[2]}[2])"),
+    ];
+
+    for (entrypoint, preimage) in vectors {
+        assert_eq!(dispatch_tag_for(&compiled, entrypoint), dispatch_tag_for_preimage(preimage), "preimage: {preimage}");
+    }
 }
 
 #[test]

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -6837,7 +6837,7 @@ fn record_dispatch_tag_matches_kcc1_structural_type_vector() {
     assert_eq!(dispense.dispatch_tag, [0x67, 0x6b, 0x1a, 0x86]);
 
     let json = serde_json::to_string(dispense).expect("ABI entry serializes");
-    assert_eq!(serde_json::from_str::<serde_json::Value>(&json).unwrap()["dispatch_tag"], "676b1a86");
+    assert_eq!(serde_json::from_str::<serde_json::Value>(&json).unwrap()["dispatch_tag"], serde_json::json!([103, 107, 26, 134]));
 }
 
 #[test]

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -746,8 +746,8 @@ fn lowers_kcc20_shaped_public_names_and_shared_delegate_body() {
     assert_eq!(abi, vec![("transfer", vec!["State[]", "byte[]"]), ("transfer_delegator", vec!["byte[]"]),]);
 
     let transfer = compiled.entry_by_name("transfer").expect("public transfer exists");
-    let expected_hash = blake3::hash(b"transfer(State[],byte[])");
-    assert_eq!(transfer.dispatch_tag(), expected_hash.as_bytes()[..4]);
+    let expected_hash = blake3::hash(b"transfer({byte[1],int}[],byte[])");
+    assert_eq!(transfer.dispatch_tag, expected_hash.as_bytes()[..4]);
 
     let delegate_args = vec![Expr::dynamic_bytes(vec![7])];
     let routed = compiled

--- a/silverscript-lang/tests/silverc_tests.rs
+++ b/silverscript-lang/tests/silverc_tests.rs
@@ -86,6 +86,7 @@ fn silverc_defaults_output_path_and_empty_ctor_args() {
     let compiled: CompiledContract = serde_json::from_str(&json).expect("parse compiled contract");
     assert_eq!(compiled.contract_name, "Basic");
     assert_eq!(compiled.compiler_version, COMPILER_VERSION);
+    assert_eq!(artifact["abi"][0]["dispatch_tag"], faster_hex::hex_string(&compiled.abi[0].dispatch_tag));
 }
 
 #[test]
@@ -126,7 +127,7 @@ fn silverc_accepts_constructor_args_and_output_flag() {
     let compiled: CompiledContract = serde_json::from_str(&json).expect("parse compiled contract");
     assert_eq!(compiled.contract_name, "WithCtor");
     assert_eq!(compiled.compiler_version, COMPILER_VERSION);
-    let selector = compiled.entry_by_name("main").expect("entrypoint resolved").dispatch_tag();
+    let selector = compiled.entry_by_name("main").expect("entrypoint resolved").dispatch_tag;
     assert!(run_bytecode_with_selector(compiled.bytecode, selector).is_ok());
 }
 

--- a/silverscript-lang/tests/silverc_tests.rs
+++ b/silverscript-lang/tests/silverc_tests.rs
@@ -86,7 +86,7 @@ fn silverc_defaults_output_path_and_empty_ctor_args() {
     let compiled: CompiledContract = serde_json::from_str(&json).expect("parse compiled contract");
     assert_eq!(compiled.contract_name, "Basic");
     assert_eq!(compiled.compiler_version, COMPILER_VERSION);
-    assert_eq!(artifact["abi"][0]["dispatch_tag"], faster_hex::hex_string(&compiled.abi[0].dispatch_tag));
+    assert_eq!(artifact["abi"][0]["dispatch_tag"], serde_json::json!(compiled.abi[0].dispatch_tag));
 }
 
 #[test]


### PR DESCRIPTION
KCC-01 dispatch-tag revision PR: https://github.com/kaspanet/kccs/pull/19

supersede #220 

`FunctionAbiEntry` now has `dispatch_tag` as field.