### PR TITLE
  Harden type, ABI, and artifact validation

### DIFF
--- a/debugger/cli/src/main.rs
+++ b/debugger/cli/src/main.rs
@@ -24,7 +24,7 @@ use kaspa_txscript::covenants::CovenantsContext;
 use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::{EngineCtx, EngineFlags, pay_to_script_hash_script};
 use silverscript_lang::ast::{
-    ArrayDim, ContractAst, Expr, ExprKind, STATE_TYPE_NAME, StateFieldExpr, TypeBase, TypeRef, parse_contract_ast, parse_type_ref,
+    ContractAst, Expr, ExprKind, STATE_TYPE_NAME, StateFieldExpr, TypeBase, TypeRef, parse_contract_ast, parse_type_ref,
 };
 use silverscript_lang::compiler::{CompileOptions, CompiledContract, compile_contract, compile_contract_ast};
 
@@ -154,7 +154,8 @@ fn is_state_type(type_ref: &TypeRef) -> bool {
 
 fn is_state_array_type(type_ref: &TypeRef) -> bool {
     matches!(&type_ref.base, TypeBase::Custom(name) if name == "State")
-        && matches!(type_ref.array_dims.as_slice(), [ArrayDim::Dynamic])
+        && type_ref.array_dims.len() == 1
+        && type_ref.is_dynamic_array()
 }
 
 fn synthesized_covenant_prefix_args(
@@ -1025,6 +1026,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use silverscript_lang::ast::ArrayDim;
 
     #[test]
     fn state_array_type_requires_one_dynamic_dimension() {

--- a/debugger/session/src/args.rs
+++ b/debugger/session/src/args.rs
@@ -101,7 +101,7 @@ fn validate_array_len(type_ref: &TypeRef, len: usize) -> Result<(), String> {
 fn parse_byte_array_arg(type_ref: &TypeRef, raw: &str) -> Result<Expr<'static>, String> {
     let bytes = parse_hex_bytes(raw)?;
     validate_byte_array_len(type_ref, bytes.len())?;
-    if matches!(type_ref.array_size(), Some(ArrayDim::Dynamic)) { Ok(Expr::dynamic_bytes(bytes)) } else { Ok(bytes_expr(bytes)) }
+    if type_ref.is_dynamic_array() { Ok(Expr::dynamic_bytes(bytes)) } else { Ok(bytes_expr(bytes)) }
 }
 
 fn parse_scalar_arg(type_ref: &TypeRef, raw: &str) -> Result<Expr<'static>, String> {

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1173,36 +1173,36 @@ Covenants are contracts that enforce conditions on how funds can be spent. They 
 
 ### Creating ScriptPubKey
 
-**`new ScriptPubKeyP2PK(pubkey pk): byte[34]`**
+**`new ScriptPubKeyP2PK(pubkey pk): byte[36]`**
 
 Create a Pay-to-Public-Key scriptPubKey:
 
 ```javascript
 entry checkOutput(pubkey recipientPubkey) {
-    byte[34] outputScriptPubKey = new ScriptPubKeyP2PK(recipientPubkey);
+    byte[36] outputScriptPubKey = new ScriptPubKeyP2PK(recipientPubkey);
     require(tx.outputs[0].scriptPubKey == byte[](outputScriptPubKey));
 }
 ```
 
-**`new ScriptPubKeyP2SH(byte[32] scriptHash): byte[35]`**
+**`new ScriptPubKeyP2SH(byte[32] scriptHash): byte[37]`**
 
 Create a Pay-to-Script-Hash scriptPubKey:
 
 ```javascript
 entry checkOutput(byte[] redeemScript) {
     byte[32] redeemScriptHash = blake2b(redeemScript);
-    byte[35] outputScriptPubKey = new ScriptPubKeyP2SH(redeemScriptHash);
+    byte[37] outputScriptPubKey = new ScriptPubKeyP2SH(redeemScriptHash);
     require(tx.outputs[0].scriptPubKey == byte[](outputScriptPubKey));
 }
 ```
 
-**`new ScriptPubKeyP2SHFromRedeemScript(byte[] redeemScript): byte[35]`**
+**`new ScriptPubKeyP2SHFromRedeemScript(byte[] redeemScript): byte[37]`**
 
 Create a P2SH scriptPubKey directly from a redeem script:
 
 ```javascript
 entry build(byte[] redeemScript) {
-    byte[35] outputScriptPubKey = new ScriptPubKeyP2SHFromRedeemScript(redeemScript);
+    byte[37] outputScriptPubKey = new ScriptPubKeyP2SHFromRedeemScript(redeemScript);
     require(outputScriptPubKey == outputScriptPubKey);
 }
 ```
@@ -1299,7 +1299,7 @@ pragma silverscript ^0.1.0;
 contract SimpleCovenant(pubkey recipient) {
     entry spend() {
         // First output must go to the recipient
-        byte[34] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
+        byte[36] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
         require(tx.outputs[0].scriptPubKey == byte[](recipientScriptPubKey));
     }
 }
@@ -1316,7 +1316,7 @@ contract RecurringPayment(pubkey recipient, int paymentAmount, int period) {
         require(this.ageDaa >= period);
         
         // First output must pay the recipient
-        byte[34] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
+        byte[36] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
         require(tx.outputs[0].scriptPubKey == byte[](recipientScriptPubKey));
         require(tx.outputs[0].value >= paymentAmount);
         
@@ -1503,7 +1503,7 @@ contract Mecenas(pubkey recipient, byte[32] funder, int pledge, int period) {
         require(this.ageDaa >= period);
 
         // Check that the first output sends to the recipient
-        byte[34] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
+        byte[36] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
         require(tx.outputs[0].scriptPubKey == byte[](recipientScriptPubKey));
 
         // Calculate the value that's left

--- a/silverscript-lang/src/ast/mod.rs
+++ b/silverscript-lang/src/ast/mod.rs
@@ -4,6 +4,7 @@ use chrono::NaiveDateTime;
 use pest::iterators::Pair;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::checked_arithmetic::{checked_mul, checked_pow};
 use crate::errors::CompilerError;
 use crate::parser::{
     Rule, parse_expression as parse_expression_rule, parse_function as parse_function_rule, parse_source_file,
@@ -341,6 +342,11 @@ impl TypeRef {
 
     pub fn is_array(&self) -> bool {
         !self.array_dims.is_empty()
+    }
+
+    /// Returns whether the outermost array dimension has a runtime-defined length.
+    pub fn is_dynamic_array(&self) -> bool {
+        matches!(self.array_size(), Some(ArrayDim::Dynamic))
     }
 
     // This returns the type of the array elements, or None if this is not an array type.
@@ -2397,8 +2403,8 @@ fn parse_number(raw: &str) -> Result<i64, CompilerError> {
 
         // rejects negative exponent
         let exp = exp_clean.parse::<u32>().map_err(|_| CompilerError::InvalidLiteral(format!("invalid number literal '{raw}'")))?;
-        let pow = 10i128.checked_pow(exp).ok_or_else(|| CompilerError::InvalidLiteral(format!("number literal overflow '{raw}'")))?;
-        value = value.checked_mul(pow).ok_or_else(|| CompilerError::InvalidLiteral(format!("number literal overflow '{raw}'")))?;
+        let pow = checked_pow(10i128, exp)?;
+        value = checked_mul(value, pow)?;
     }
 
     if value < i64::MIN as i128 || value > i64::MAX as i128 {
@@ -2612,9 +2618,7 @@ fn apply_number_unit<'i>(expr: Expr<'i>, unit: &str) -> Result<Expr<'i>, Compile
         "kas" => 100_000_000,
         _ => return Err(CompilerError::Unsupported(format!("number unit '{unit}' not supported"))),
     };
-    let scaled = value
-        .checked_mul(multiplier)
-        .ok_or_else(|| CompilerError::InvalidLiteral(format!("number literal overflow for unit '{unit}'")))?;
+    let scaled = checked_mul(value, multiplier)?;
     let kind = if is_temporal_unit(unit) { ExprKind::Temporal(scaled) } else { ExprKind::Int(scaled) };
     Ok(Expr::new(kind, span))
 }

--- a/silverscript-lang/src/checked_arithmetic.rs
+++ b/silverscript-lang/src/checked_arithmetic.rs
@@ -1,0 +1,67 @@
+use std::fmt::Display;
+
+use crate::errors::CompilerError;
+
+pub(crate) trait CheckedArithmetic: Copy + Display {
+    fn checked_add_value(self, right: Self) -> Option<Self>;
+    fn checked_sub_value(self, right: Self) -> Option<Self>;
+    fn checked_mul_value(self, right: Self) -> Option<Self>;
+    fn checked_div_value(self, right: Self) -> Option<Self>;
+    fn checked_rem_value(self, right: Self) -> Option<Self>;
+    fn checked_pow_value(self, exponent: u32) -> Option<Self>;
+}
+
+macro_rules! impl_checked_arithmetic {
+    ($($type:ty),+ $(,)?) => {
+        $(
+            impl CheckedArithmetic for $type {
+                fn checked_add_value(self, right: Self) -> Option<Self> { self.checked_add(right) }
+                fn checked_sub_value(self, right: Self) -> Option<Self> { self.checked_sub(right) }
+                fn checked_mul_value(self, right: Self) -> Option<Self> { self.checked_mul(right) }
+                fn checked_div_value(self, right: Self) -> Option<Self> { self.checked_div(right) }
+                fn checked_rem_value(self, right: Self) -> Option<Self> { self.checked_rem(right) }
+                fn checked_pow_value(self, exponent: u32) -> Option<Self> { self.checked_pow(exponent) }
+            }
+        )+
+    };
+}
+
+impl_checked_arithmetic!(i64, i128, usize);
+
+pub(crate) trait CheckedNeg: Copy + Display {
+    fn checked_neg_value(self) -> Option<Self>;
+}
+
+impl CheckedNeg for i64 {
+    fn checked_neg_value(self) -> Option<Self> {
+        self.checked_neg()
+    }
+}
+
+pub(crate) fn checked_add<T: CheckedArithmetic>(left: T, right: T) -> Result<T, CompilerError> {
+    left.checked_add_value(right).ok_or_else(|| CompilerError::ArithmeticOverflow(format!("{left} + {right}")))
+}
+
+pub(crate) fn checked_sub<T: CheckedArithmetic>(left: T, right: T) -> Result<T, CompilerError> {
+    left.checked_sub_value(right).ok_or_else(|| CompilerError::ArithmeticOverflow(format!("{left} - {right}")))
+}
+
+pub(crate) fn checked_mul<T: CheckedArithmetic>(left: T, right: T) -> Result<T, CompilerError> {
+    left.checked_mul_value(right).ok_or_else(|| CompilerError::ArithmeticOverflow(format!("{left} * {right}")))
+}
+
+pub(crate) fn checked_div<T: CheckedArithmetic>(left: T, right: T) -> Result<T, CompilerError> {
+    left.checked_div_value(right).ok_or_else(|| CompilerError::ArithmeticOverflow(format!("{left} / {right}")))
+}
+
+pub(crate) fn checked_rem<T: CheckedArithmetic>(left: T, right: T) -> Result<T, CompilerError> {
+    left.checked_rem_value(right).ok_or_else(|| CompilerError::ArithmeticOverflow(format!("{left} % {right}")))
+}
+
+pub(crate) fn checked_pow<T: CheckedArithmetic>(base: T, exponent: u32) -> Result<T, CompilerError> {
+    base.checked_pow_value(exponent).ok_or_else(|| CompilerError::ArithmeticOverflow(format!("{base}^{exponent}")))
+}
+
+pub(crate) fn checked_neg<T: CheckedNeg>(value: T) -> Result<T, CompilerError> {
+    value.checked_neg_value().ok_or_else(|| CompilerError::ArithmeticOverflow(format!("-({value})")))
+}

--- a/silverscript-lang/src/compiler/array_append.rs
+++ b/silverscript-lang/src/compiler/array_append.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::ast::{ConstantAst, ContractAst, ContractFieldAst, Expr, ExprKind, FunctionAst, StateFieldExpr, Statement};
-use crate::compiler::infer_array::infer_expr_type;
 
 pub(super) fn lower_array_appends<'i>(
     contract: &ContractAst<'i>,
@@ -260,8 +259,11 @@ fn lower_expr<'i>(
     let span = expr.span;
     match &expr.kind {
         ExprKind::Append { source, args, .. } => {
-            let source_type = infer_expr_type(source, types, constants, functions)?
-                .ok_or_else(|| CompilerError::Unsupported("cannot determine append source type".to_string()))?;
+            // Input-state calls and structs have already been lowered, so type inference no longer needs contract-field metadata
+            // or struct definitions.
+            let structs = StructRegistry::new();
+            let type_context = type_check::TypeCheckContext { types, structs: &structs, constants, functions, contract_fields: &[] };
+            let source_type = type_check::infer_expr_type(source, &type_context)?;
             let mut appended_type = source_type
                 .array_element_type()
                 .ok_or_else(|| CompilerError::Unsupported("append target must be an array".to_string()))?;

--- a/silverscript-lang/src/compiler/array_append.rs
+++ b/silverscript-lang/src/compiler/array_append.rs
@@ -260,7 +260,7 @@ fn lower_expr<'i>(
     let span = expr.span;
     match &expr.kind {
         ExprKind::Append { source, args, .. } => {
-            let source_type = infer_expr_type(source, types, constants, functions)
+            let source_type = infer_expr_type(source, types, constants, functions)?
                 .ok_or_else(|| CompilerError::Unsupported("cannot determine append source type".to_string()))?;
             let mut appended_type = source_type
                 .array_element_type()

--- a/silverscript-lang/src/compiler/builtin_types.rs
+++ b/silverscript-lang/src/compiler/builtin_types.rs
@@ -116,8 +116,8 @@ pub(super) fn builtin_return_type(name: &str) -> Option<TypeRef> {
 
 pub(super) fn constructor_return_type(name: &str) -> Option<TypeRef> {
     Some(match name {
-        "ScriptPubKeyP2PK" => byte_array(ArrayDim::Fixed(34)),
-        "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript" => byte_array(ArrayDim::Fixed(35)),
+        "ScriptPubKeyP2PK" => byte_array(ArrayDim::Fixed(36)),
+        "ScriptPubKeyP2SH" | "ScriptPubKeyP2SHFromRedeemScript" => byte_array(ArrayDim::Fixed(37)),
         _ => return None,
     })
 }

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -21,7 +21,7 @@ mod state;
 mod statement;
 
 use analysis::*;
-pub(crate) use const_eval::{eval_const_int, resolve_constant_references};
+pub(crate) use const_eval::{eval_const_int, eval_optional_const_int, resolve_constant_references};
 use emitter::*;
 use expression::*;
 pub(super) use helpers::encode_array_literal;

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -241,35 +241,6 @@ fn maximum_canonical_data_push_size(payload_size: usize) -> Result<usize, Compil
     checked_add(payload_size, prefix_size)
 }
 
-#[cfg(test)]
-mod signature_script_limit_tests {
-    use super::*;
-
-    #[test]
-    fn conservative_argument_sizes_use_maximum_scalar_widths_and_one_dynamic_element() {
-        let constants = HashMap::new();
-        let cases = [
-            ("int", 9),
-            ("temporal", 9),
-            ("bool", 1),
-            ("byte", 2),
-            ("string", 2),
-            ("byte[1]", 2),
-            ("byte[]", 2),
-            ("int[]", 9),
-            ("byte[2][]", 3),
-            ("pubkey[]", 33),
-        ];
-
-        for (type_name, expected_size) in cases {
-            let type_ref = parse_type_ref(type_name).unwrap_or_else(|err| panic!("{type_name} should parse: {err}"));
-            let actual = conservative_sigscript_argument_size(&type_ref, &constants)
-                .unwrap_or_else(|err| panic!("{type_name} should have a conservative size: {err}"));
-            assert_eq!(actual, expected_size, "unexpected conservative size for {type_name}");
-        }
-    }
-}
-
 fn compile_contract_bytecode_iteration<'i>(
     lowered_contract: &ContractAst<'i>,
     lowered_constants: &HashMap<String, Expr<'i>>,
@@ -409,4 +380,33 @@ pub fn compile_debug_expr<'i>(
     let mut emitter = ScriptEmitter::new(&mut builder, 0);
     compile_expr(&expr, Some(&type_ref), &env, &mut emitter)?;
     Ok((builder.drain(), type_ref.type_name()))
+}
+
+#[cfg(test)]
+mod signature_script_limit_tests {
+    use super::*;
+
+    #[test]
+    fn conservative_argument_sizes_use_maximum_scalar_widths_and_one_dynamic_element() {
+        let constants = HashMap::new();
+        let cases = [
+            ("int", 9),
+            ("temporal", 9),
+            ("bool", 1),
+            ("byte", 2),
+            ("string", 2),
+            ("byte[1]", 2),
+            ("byte[]", 2),
+            ("int[]", 9),
+            ("byte[2][]", 3),
+            ("pubkey[]", 33),
+        ];
+
+        for (type_name, expected_size) in cases {
+            let type_ref = parse_type_ref(type_name).unwrap_or_else(|err| panic!("{type_name} should parse: {err}"));
+            let actual = conservative_sigscript_argument_size(&type_ref, &constants)
+                .unwrap_or_else(|err| panic!("{type_name} should have a conservative size: {err}"));
+            assert_eq!(actual, expected_size, "unexpected conservative size for {type_name}");
+        }
+    }
 }

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -141,12 +141,12 @@ fn compile_contract_bytecode_iteration<'i>(
 ) -> Result<(Vec<u8>, CompiledStateLayout), CompilerError> {
     let (_contract_fields, state_push_bytecode) = compile_contract_fields(&lowered_contract.fields, lowered_constants, bytecode_size)?;
 
-    let state_start = if state_push_bytecode.is_empty() {
+    let state_start: usize = if state_push_bytecode.is_empty() {
         0
     } else {
         1 // The 1 accounts for OpToAltStack.
     };
-    let state_end = state_start + state_push_bytecode.len();
+    let state_end = checked_add(state_start, state_push_bytecode.len())?;
     let state_layout = CompiledStateLayout { start: state_start, len: state_push_bytecode.len() };
     let compiled_entrypoints = compile_entrypoint_bytecodes(
         lowered_contract,

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -74,6 +74,7 @@ pub(super) fn compile_contract_impl<'i>(
     }
 
     let function_abi_entries = build_function_abi_entries(&covenant_lowered_contract, &constants)?;
+    let artifact_contract = resolve_artifact_struct_type_refs(&covenant_lowered_contract, &constants)?;
 
     // dispatch tag: verify no collisions and insert tags to global state
     let mut entrypoints_by_tag = HashMap::<DispatchTag, &str>::new();
@@ -105,7 +106,7 @@ pub(super) fn compile_contract_impl<'i>(
         if !uses_bytecode_size {
             return Ok(build_compiled_contract(
                 &lowered_contract,
-                &covenant_lowered_contract,
+                &artifact_contract,
                 function_abi_entries.clone(),
                 bytecode,
                 state_layout,
@@ -117,7 +118,7 @@ pub(super) fn compile_contract_impl<'i>(
         if Some(actual_size) == bytecode_size {
             return Ok(build_compiled_contract(
                 &lowered_contract,
-                &covenant_lowered_contract,
+                &artifact_contract,
                 function_abi_entries.clone(),
                 bytecode,
                 state_layout,

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -6,10 +6,11 @@ use super::stack_bindings::StackBindings;
 use super::static_check::{static_check_contract, validate_concrete_constructor_argument, validate_declaration_names};
 use super::ternary::lower_ternaries;
 use super::*;
-use kaspa_txscript::EngineFlags;
+use kaspa_consensus_core::config::params::MAINNET_PARAMS;
 use kaspa_txscript::opcodes::codes::*;
 use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::serialize_i64;
+use kaspa_txscript::{EngineFlags, MAX_STACK_SIZE};
 use std::collections::{HashMap, HashSet};
 
 mod analysis;
@@ -80,6 +81,7 @@ pub(super) fn compile_contract_impl<'i>(
     if entrypoint_functions.is_empty() {
         return Err(CompilerError::Unsupported("contract has no entries".to_string()));
     }
+    validate_entrypoint_stack_limits(&entrypoint_functions)?;
 
     let function_abi_entries = build_function_abi_entries(&covenant_lowered_contract, &constants)?;
     let artifact_contract = resolve_artifact_struct_type_refs(&covenant_lowered_contract, &constants)?;
@@ -139,6 +141,135 @@ pub(super) fn compile_contract_impl<'i>(
     Err(CompilerError::Unsupported("bytecode size did not stabilize".to_string()))
 }
 
+fn validate_entrypoint_stack_limits(entrypoints: &[&FunctionAst<'_>]) -> Result<(), CompilerError> {
+    for entrypoint in entrypoints {
+        // At the end of P2SH signature-script execution, the stack contains
+        // every flattened argument, the dispatch tag, and the redeem script.
+        let initial_stack_items = checked_add(entrypoint.params.len(), 2)?;
+        if initial_stack_items > MAX_STACK_SIZE {
+            return Err(CompilerError::EntrypointStackTooLarge {
+                function: entrypoint.name.clone(),
+                actual: initial_stack_items,
+                maximum: MAX_STACK_SIZE,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_signature_script_limits<'i>(
+    bytecode: &[u8],
+    entrypoints: &[&FunctionAst<'i>],
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<(), CompilerError> {
+    let max_signature_script_len = MAINNET_PARAMS.new_max_signature_script_len;
+    if bytecode.len() > max_signature_script_len {
+        return Err(CompilerError::RedeemScriptTooLarge { actual: bytecode.len(), maximum: max_signature_script_len });
+    }
+
+    let redeem_script_push_size = ScriptBuilder::canonical_data_size(bytecode);
+    let dispatch_tag_push_size = maximum_canonical_data_push_size(std::mem::size_of::<DispatchTag>())?;
+    for entrypoint in entrypoints {
+        let mut estimated_size = checked_add(redeem_script_push_size, dispatch_tag_push_size)?;
+        for param in &entrypoint.params {
+            estimated_size = checked_add(estimated_size, conservative_sigscript_argument_size(&param.type_ref, constants)?)?;
+        }
+        if estimated_size > max_signature_script_len {
+            return Err(CompilerError::EntrypointSignatureScriptTooLarge {
+                function: entrypoint.name.clone(),
+                estimated: estimated_size,
+                maximum: max_signature_script_len,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn conservative_sigscript_argument_size<'i>(
+    type_ref: &TypeRef,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<usize, CompilerError> {
+    if type_ref.is_array() {
+        let payload_size = match fixed_type_size(type_ref, constants)? {
+            Some(payload_size) => payload_size,
+            None => {
+                // Dynamic arrays are estimated with one element. Use the full
+                // fixed-width encoding of that element as a worst-case estimate for the dynamic array's payload size.
+                let element_type = type_ref.array_element_type().expect("array type has an element type");
+                fixed_type_size(&element_type, constants)?.ok_or_else(|| {
+                    CompilerError::Unsupported(format!("cannot determine dynamic ABI element size for {}", type_ref.type_name()))
+                })?
+            }
+        };
+        return maximum_canonical_data_push_size(payload_size);
+    }
+
+    match type_ref.base {
+        // Int-like values can occupy the full eight-byte ScriptNum payload.
+        TypeBase::Int | TypeBase::Temporal => maximum_canonical_data_push_size(8),
+        TypeBase::Bool => Ok(1),
+        TypeBase::Byte => maximum_canonical_data_push_size(1),
+        // Treat strings as containing at least one byte for this conservative
+        // feasibility estimate.
+        TypeBase::String => maximum_canonical_data_push_size(1),
+        TypeBase::Pubkey | TypeBase::Sig | TypeBase::Datasig => {
+            let payload_size = type_ref
+                .base
+                .fixed_byte_sequence_len()
+                .ok_or_else(|| CompilerError::Unsupported(format!("cannot determine ABI size for {}", type_ref.type_name())))?;
+            maximum_canonical_data_push_size(payload_size)
+        }
+        TypeBase::Tuple(_) | TypeBase::Custom(_) => {
+            Err(CompilerError::Unsupported(format!("cannot determine flattened ABI size for {}", type_ref.type_name())))
+        }
+    }
+}
+
+fn maximum_canonical_data_push_size(payload_size: usize) -> Result<usize, CompilerError> {
+    if payload_size == 0 {
+        return Ok(1);
+    }
+    let prefix_size = if payload_size <= OpData75 as usize {
+        1
+    } else if payload_size <= u8::MAX as usize {
+        2
+    } else if payload_size <= u16::MAX as usize {
+        3
+    } else {
+        5
+    };
+    checked_add(payload_size, prefix_size)
+}
+
+#[cfg(test)]
+mod signature_script_limit_tests {
+    use super::*;
+
+    #[test]
+    fn conservative_argument_sizes_use_maximum_scalar_widths_and_one_dynamic_element() {
+        let constants = HashMap::new();
+        let cases = [
+            ("int", 9),
+            ("temporal", 9),
+            ("bool", 1),
+            ("byte", 2),
+            ("string", 2),
+            ("byte[1]", 2),
+            ("byte[]", 2),
+            ("int[]", 9),
+            ("byte[2][]", 3),
+            ("pubkey[]", 33),
+        ];
+
+        for (type_name, expected_size) in cases {
+            let type_ref = parse_type_ref(type_name).unwrap_or_else(|err| panic!("{type_name} should parse: {err}"));
+            let actual = conservative_sigscript_argument_size(&type_ref, &constants)
+                .unwrap_or_else(|err| panic!("{type_name} should have a conservative size: {err}"));
+            assert_eq!(actual, expected_size, "unexpected conservative size for {type_name}");
+        }
+    }
+}
+
 fn compile_contract_bytecode_iteration<'i>(
     lowered_contract: &ContractAst<'i>,
     lowered_constants: &HashMap<String, Expr<'i>>,
@@ -167,6 +298,8 @@ fn compile_contract_bytecode_iteration<'i>(
         debug_recorder,
     )?;
     let bytecode = build_contract_bytecode(debug_recorder, &state_push_bytecode, &compiled_entrypoints, function_abi_entries)?;
+    let entrypoints = lowered_contract.functions.iter().filter(|function| function.entrypoint).collect::<Vec<_>>();
+    validate_signature_script_limits(&bytecode, &entrypoints, lowered_constants)?;
     Ok((bytecode, state_layout))
 }
 

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -3,7 +3,7 @@ use super::covenant_declarations::lower_covenant_declarations;
 use super::infer_array::lower_inferred_array_sizes;
 use super::inline_functions::lower_inline_functions;
 use super::stack_bindings::StackBindings;
-use super::static_check::{static_check_contract, validate_declaration_names};
+use super::static_check::{static_check_contract, validate_concrete_constructor_argument, validate_declaration_names};
 use super::ternary::lower_ternaries;
 use super::*;
 use kaspa_txscript::EngineFlags;
@@ -41,6 +41,14 @@ pub(super) fn compile_contract_impl<'i>(
     source: Option<&'i str>,
 ) -> Result<CompiledContract<'i>, CompilerError> {
     validate_declaration_names(contract)?;
+    // Constructor arguments enter the constant environment below, so reject
+    // evaluatable expression forms before any inference or lowering can use them.
+    if contract.params.len() != constructor_args.len() {
+        return Err(CompilerError::Unsupported("constructor argument count mismatch".to_string()));
+    }
+    for (param, value) in contract.params.iter().zip(constructor_args) {
+        validate_concrete_constructor_argument(param, value)?;
+    }
 
     let mut constants: HashMap<String, Expr<'i>> =
         contract.constants.iter().map(|constant| (constant.name.clone(), constant.expr.clone())).collect();

--- a/silverscript-lang/src/compiler/compile/const_eval.rs
+++ b/silverscript-lang/src/compiler/compile/const_eval.rs
@@ -35,35 +35,27 @@ fn eval_const_int_inner<'i>(
         }
         ExprKind::Unary { op: UnaryOp::Neg, expr } => {
             let value = eval_const_int_inner(expr, constants, visiting, resolved)?;
-            value.checked_neg().ok_or_else(|| CompilerError::InvalidLiteral(format!("constant integer overflow: -({value})")))
+            checked_neg(value)
         }
         ExprKind::Unary { .. } => Err(CompilerError::Unsupported("constant expression must evaluate to an integer".to_string())),
         ExprKind::Binary { op, left, right } => {
             let lhs = eval_const_int_inner(left, constants, visiting, resolved)?;
             let rhs = eval_const_int_inner(right, constants, visiting, resolved)?;
             match op {
-                BinaryOp::Add => lhs
-                    .checked_add(rhs)
-                    .ok_or_else(|| CompilerError::InvalidLiteral(format!("constant integer overflow: {lhs} + {rhs}"))),
-                BinaryOp::Sub => lhs
-                    .checked_sub(rhs)
-                    .ok_or_else(|| CompilerError::InvalidLiteral(format!("constant integer overflow: {lhs} - {rhs}"))),
-                BinaryOp::Mul => lhs
-                    .checked_mul(rhs)
-                    .ok_or_else(|| CompilerError::InvalidLiteral(format!("constant integer overflow: {lhs} * {rhs}"))),
+                BinaryOp::Add => checked_add(lhs, rhs),
+                BinaryOp::Sub => checked_sub(lhs, rhs),
+                BinaryOp::Mul => checked_mul(lhs, rhs),
                 BinaryOp::Div => {
                     if rhs == 0 {
                         return Err(CompilerError::InvalidLiteral("division by zero in constant expression".to_string()));
                     }
-                    lhs.checked_div(rhs)
-                        .ok_or_else(|| CompilerError::InvalidLiteral(format!("constant integer overflow: {lhs} / {rhs}")))
+                    checked_div(lhs, rhs)
                 }
                 BinaryOp::Mod => {
                     if rhs == 0 {
                         return Err(CompilerError::InvalidLiteral("modulo by zero in constant expression".to_string()));
                     }
-                    lhs.checked_rem(rhs)
-                        .ok_or_else(|| CompilerError::InvalidLiteral(format!("constant integer overflow: {lhs} % {rhs}")))
+                    checked_rem(lhs, rhs)
                 }
                 _ => Err(CompilerError::Unsupported("constant expression must evaluate to an integer".to_string())),
             }
@@ -222,14 +214,14 @@ mod tests {
                     ExprKind::Binary { op: BinaryOp::Add, left: Box::new(Expr::int(i64::MAX)), right: Box::new(Expr::int(1)) },
                     Default::default(),
                 ),
-                format!("constant integer overflow: {} + 1", i64::MAX),
+                format!("arithmetic overflow: {} + 1", i64::MAX),
             ),
             (
                 Expr::new(
                     ExprKind::Binary { op: BinaryOp::Sub, left: Box::new(Expr::int(-i64::MAX)), right: Box::new(Expr::int(2)) },
                     Default::default(),
                 ),
-                format!("constant integer overflow: {} - 2", -i64::MAX),
+                format!("arithmetic overflow: {} - 2", -i64::MAX),
             ),
             (
                 Expr::new(
@@ -240,30 +232,31 @@ mod tests {
                     },
                     Default::default(),
                 ),
-                "constant integer overflow: 3037000500 * 3037000500".to_string(),
+                "arithmetic overflow: 3037000500 * 3037000500".to_string(),
             ),
             (
                 Expr::new(ExprKind::Unary { op: UnaryOp::Neg, expr: Box::new(Expr::int(i64::MIN)) }, Default::default()),
-                format!("constant integer overflow: -({})", i64::MIN),
+                format!("arithmetic overflow: -({})", i64::MIN),
             ),
             (
                 Expr::new(
                     ExprKind::Binary { op: BinaryOp::Div, left: Box::new(Expr::int(i64::MIN)), right: Box::new(Expr::int(-1)) },
                     Default::default(),
                 ),
-                format!("constant integer overflow: {} / -1", i64::MIN),
+                format!("arithmetic overflow: {} / -1", i64::MIN),
             ),
             (
                 Expr::new(
                     ExprKind::Binary { op: BinaryOp::Mod, left: Box::new(Expr::int(i64::MIN)), right: Box::new(Expr::int(-1)) },
                     Default::default(),
                 ),
-                format!("constant integer overflow: {} % -1", i64::MIN),
+                format!("arithmetic overflow: {} % -1", i64::MIN),
             ),
         ];
 
         for (expr, expected) in cases {
             let err = eval_const_int(&expr, &constants).expect_err("overflow should be rejected");
+            assert!(matches!(err, CompilerError::ArithmeticOverflow(_)), "unexpected error variant: {err}");
             assert!(err.to_string().contains(&expected), "unexpected error: {err}");
         }
     }

--- a/silverscript-lang/src/compiler/compile/const_eval.rs
+++ b/silverscript-lang/src/compiler/compile/const_eval.rs
@@ -6,6 +6,21 @@ pub(crate) fn eval_const_int<'i>(expr: &Expr<'i>, constants: &HashMap<String, Ex
     eval_const_int_inner(expr, constants, &mut visiting, &mut resolved)
 }
 
+/// Evaluates an integer expression when it is compile-time constant.
+///
+/// A non-constant runtime expression is represented by `None`; failures while evaluating an otherwise constant expression must
+/// remain compiler errors.
+pub(crate) fn eval_optional_const_int<'i>(
+    expr: &Expr<'i>,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<Option<i64>, CompilerError> {
+    match eval_const_int(expr, constants) {
+        Ok(value) => Ok(Some(value)),
+        Err(CompilerError::NonConstantInteger(_)) => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
 fn eval_const_int_inner<'i>(
     expr: &Expr<'i>,
     constants: &HashMap<String, Expr<'i>>,
@@ -23,7 +38,7 @@ fn eval_const_int_inner<'i>(
                 return Ok(*value);
             }
             let value =
-                constants.get(name).ok_or_else(|| CompilerError::Unsupported(format!("'{name}' is not a constant integer")))?;
+                constants.get(name).ok_or_else(|| CompilerError::NonConstantInteger(format!("'{name}' is not a constant integer")))?;
             if !visiting.insert(name.clone()) {
                 return Err(CompilerError::CyclicIdentifier(name.clone()));
             }
@@ -37,7 +52,9 @@ fn eval_const_int_inner<'i>(
             let value = eval_const_int_inner(expr, constants, visiting, resolved)?;
             checked_neg(value)
         }
-        ExprKind::Unary { .. } => Err(CompilerError::Unsupported("constant expression must evaluate to an integer".to_string())),
+        ExprKind::Unary { .. } => {
+            Err(CompilerError::NonConstantInteger("constant expression must evaluate to an integer".to_string()))
+        }
         ExprKind::Binary { op, left, right } => {
             let lhs = eval_const_int_inner(left, constants, visiting, resolved)?;
             let rhs = eval_const_int_inner(right, constants, visiting, resolved)?;
@@ -57,10 +74,10 @@ fn eval_const_int_inner<'i>(
                     }
                     checked_rem(lhs, rhs)
                 }
-                _ => Err(CompilerError::Unsupported("constant expression must evaluate to an integer".to_string())),
+                _ => Err(CompilerError::NonConstantInteger("constant expression must evaluate to an integer".to_string())),
             }
         }
-        _ => Err(CompilerError::Unsupported("constant expression must evaluate to an integer".to_string())),
+        _ => Err(CompilerError::NonConstantInteger("constant expression must evaluate to an integer".to_string())),
     }
 }
 
@@ -259,6 +276,29 @@ mod tests {
             assert!(matches!(err, CompilerError::ArithmeticOverflow(_)), "unexpected error variant: {err}");
             assert!(err.to_string().contains(&expected), "unexpected error: {err}");
         }
+    }
+
+    #[test]
+    fn optional_constant_evaluation_only_uses_none_for_runtime_expressions() {
+        let constants = HashMap::new();
+        let runtime_value = Expr::identifier("runtime_value");
+        let err = eval_const_int(&runtime_value, &constants).expect_err("runtime expression must have a distinct error");
+        assert!(matches!(err, CompilerError::NonConstantInteger(_)), "unexpected error: {err}");
+        assert_eq!(eval_optional_const_int(&runtime_value, &constants).unwrap(), None);
+
+        let overflow = Expr::new(
+            ExprKind::Binary { op: BinaryOp::Add, left: Box::new(Expr::int(i64::MAX)), right: Box::new(Expr::int(1)) },
+            Default::default(),
+        );
+        let err = eval_optional_const_int(&overflow, &constants).expect_err("constant overflow must not become None");
+        assert!(matches!(err, CompilerError::ArithmeticOverflow(_)), "unexpected error: {err}");
+
+        let division_by_zero = Expr::new(
+            ExprKind::Binary { op: BinaryOp::Div, left: Box::new(Expr::int(1)), right: Box::new(Expr::int(0)) },
+            Default::default(),
+        );
+        let err = eval_optional_const_int(&division_by_zero, &constants).expect_err("invalid constant must not become None");
+        assert!(matches!(err, CompilerError::InvalidLiteral(_)), "unexpected error: {err}");
     }
 
     #[test]

--- a/silverscript-lang/src/compiler/compile/expression.rs
+++ b/silverscript-lang/src/compiler/compile/expression.rs
@@ -144,10 +144,15 @@ fn compile_array_expr<'i>(
             .ok_or_else(|| CompilerError::Unsupported("array literal type cannot be inferred".to_string()))?
     };
 
-    // First we try to encode the array literal as a single constant value. If that fails, we fall back to compiling it as a runtime expression.
-    if let Ok(encoded) = encode_array_literal(values, &array_type, ctx.env.constants) {
-        ctx.push_data(&encoded)?;
-        return Ok(());
+    // A non-constant element cannot be encoded ahead of time and uses runtime lowering. Actual encoding failures must not be
+    // mistaken for that expected fallback.
+    match encode_array_literal(values, &array_type, ctx.env.constants) {
+        Ok(encoded) => {
+            ctx.push_data(&encoded)?;
+            return Ok(());
+        }
+        Err(CompilerError::RuntimeEvaluationRequired) => {}
+        Err(err) => return Err(err),
     }
     compile_runtime_array_literal(ctx, values, &array_type)
 }
@@ -198,21 +203,19 @@ fn infer_array_literal_type<'i>(
     types: &TypeMap,
 ) -> Result<Option<TypeRef>, CompilerError> {
     let Some(first) = values.first() else { return Ok(None) };
-    let Ok(first_type) = infer_expr_type(first, constants, types) else { return Ok(None) };
+    let first_type = infer_expr_type(first, constants, types)?;
     if fixed_type_size(&first_type, constants)?.is_none() {
         return Ok(None);
     }
-    if values
-        .iter()
-        .skip(1)
-        .all(|value| infer_expr_type(value, constants, types).is_ok_and(|type_ref| type_refs_equal(&type_ref, &first_type, constants)))
-    {
-        let mut array_type = first_type;
-        array_type.array_dims.push(ArrayDim::Dynamic);
-        Ok(Some(array_type))
-    } else {
-        Ok(None)
+    for value in values.iter().skip(1) {
+        let type_ref = infer_expr_type(value, constants, types)?;
+        if !type_refs_equal(&type_ref, &first_type, constants)? {
+            return Ok(None);
+        }
     }
+    let mut array_type = first_type;
+    array_type.array_dims.push(ArrayDim::Dynamic);
+    Ok(Some(array_type))
 }
 
 fn compile_state_object_expr() -> Result<(), CompilerError> {
@@ -268,7 +271,10 @@ fn compile_ternary_expr<'i>(
     compile_expr_with_context(ctx, condition, Some(&bool_type))?;
     ctx.emit_op(OpIf, -1)?;
     let depth_before = ctx.emitter.stack_depth();
-    let branch_type = expected_type.cloned().or_else(|| infer_expr_type(then_expr, ctx.env.constants, ctx.env.types).ok());
+    let branch_type = match expected_type {
+        Some(type_ref) => Some(type_ref.clone()),
+        None => Some(infer_expr_type(then_expr, ctx.env.constants, ctx.env.types)?),
+    };
     compile_expr_with_context(ctx, then_expr, branch_type.as_ref())?;
     ctx.emit_op(OpElse, 0)?;
     ctx.emitter.set_stack_depth(depth_before);
@@ -344,7 +350,7 @@ fn compile_binary_expr<'i>(
     left: &Expr<'i>,
     right: &Expr<'i>,
 ) -> Result<(), CompilerError> {
-    let left_value_type = infer_expr_type(left, ctx.env.constants, ctx.env.types).ok();
+    let left_value_type = Some(infer_expr_type(left, ctx.env.constants, ctx.env.types)?);
     let right_value_type = if matches!(op, BinaryOp::Add)
         && let Some(element_type) = left_value_type.as_ref().and_then(TypeRef::array_element_type)
         && let ExprKind::Array { values, .. } = &right.kind
@@ -353,7 +359,7 @@ fn compile_binary_expr<'i>(
         type_ref.array_dims.push(ArrayDim::Fixed(values.len()));
         Some(type_ref)
     } else {
-        infer_expr_type(right, ctx.env.constants, ctx.env.types).ok()
+        Some(infer_expr_type(right, ctx.env.constants, ctx.env.types)?)
     };
     debug_assert!(
         !matches!(op, BinaryOp::Add)
@@ -634,7 +640,7 @@ fn compile_split_part<'i>(
 
 fn compile_length_expr<'i>(ctx: &mut CompileExprContext<'_, '_, 'i>, expr: &Expr<'i>) -> Result<(), CompilerError> {
     let expr_type = infer_expr_type(expr, ctx.env.constants, ctx.env.types)?;
-    if let Some(size) = array_type_size(&expr_type, ctx.env.contract_constants) {
+    if let Some(size) = array_type_size(&expr_type, ctx.env.contract_constants)? {
         let is_literal_or_identifier = matches!(expr.kind, ExprKind::Identifier(_) | ExprKind::Array { .. });
         if !is_literal_or_identifier {
             compile_expr_with_context(ctx, expr, Some(&expr_type))?;
@@ -670,22 +676,33 @@ fn uses_concat_for_add(type_ref: &TypeRef) -> bool {
     type_ref.is_array() || type_ref.is_string()
 }
 
-fn byte_sequence_cast_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<Option<i64>> {
+fn byte_sequence_cast_size<'i>(
+    type_ref: &TypeRef,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<Option<Option<i64>>, CompilerError> {
     if type_ref.is_string() {
-        return Some(None);
+        return Ok(Some(None));
     }
     if type_ref.is_byte() {
-        return Some(Some(1));
+        return Ok(Some(Some(1)));
     }
     if !type_ref.is_array()
         && let Some(size) = type_ref.base.fixed_byte_sequence_len()
     {
-        return i64::try_from(size).ok().map(Some);
+        let size = i64::try_from(size)
+            .map_err(|_| CompilerError::ArithmeticOverflow(format!("byte sequence size {size} does not fit in i64")))?;
+        return Ok(Some(Some(size)));
     }
-    match type_ref.array_element_type() {
-        Some(element) if element.is_byte() => Some(array_type_size(type_ref, constants).and_then(|size| i64::try_from(size).ok())),
+    Ok(match type_ref.array_element_type() {
+        Some(element) if element.is_byte() => match array_type_size(type_ref, constants)? {
+            Some(size) => Some(Some(
+                i64::try_from(size)
+                    .map_err(|_| CompilerError::ArithmeticOverflow(format!("byte sequence size {size} does not fit in i64")))?,
+            )),
+            None => Some(None),
+        },
         _ => None,
-    }
+    })
 }
 
 pub(super) fn data_prefix(data_len: usize) -> Result<Vec<u8>, CompilerError> {

--- a/silverscript-lang/src/compiler/compile/expression.rs
+++ b/silverscript-lang/src/compiler/compile/expression.rs
@@ -137,11 +137,12 @@ fn compile_array_expr<'i>(
         ctx.push_data(&[])?;
         return Ok(());
     }
-    let array_type = expected_type
-        .filter(|type_ref| type_ref.is_array())
-        .cloned()
-        .or_else(|| infer_array_literal_type(values, ctx.env.constants, ctx.env.types))
-        .ok_or_else(|| CompilerError::Unsupported("array literal type cannot be inferred".to_string()))?;
+    let array_type = if let Some(expected_type) = expected_type.filter(|type_ref| type_ref.is_array()) {
+        expected_type.clone()
+    } else {
+        infer_array_literal_type(values, ctx.env.constants, ctx.env.types)?
+            .ok_or_else(|| CompilerError::Unsupported("array literal type cannot be inferred".to_string()))?
+    };
 
     // First we try to encode the array literal as a single constant value. If that fails, we fall back to compiling it as a runtime expression.
     if let Ok(encoded) = encode_array_literal(values, &array_type, ctx.env.constants) {
@@ -191,9 +192,16 @@ fn compile_array_literal_element<'i>(
     }
 }
 
-fn infer_array_literal_type<'i>(values: &[Expr<'i>], constants: &HashMap<String, Expr<'i>>, types: &TypeMap) -> Option<TypeRef> {
-    let first_type = infer_expr_type(values.first()?, constants, types).ok()?;
-    fixed_type_size(&first_type, constants)?;
+fn infer_array_literal_type<'i>(
+    values: &[Expr<'i>],
+    constants: &HashMap<String, Expr<'i>>,
+    types: &TypeMap,
+) -> Result<Option<TypeRef>, CompilerError> {
+    let Some(first) = values.first() else { return Ok(None) };
+    let Ok(first_type) = infer_expr_type(first, constants, types) else { return Ok(None) };
+    if fixed_type_size(&first_type, constants)?.is_none() {
+        return Ok(None);
+    }
     if values
         .iter()
         .skip(1)
@@ -201,9 +209,9 @@ fn infer_array_literal_type<'i>(values: &[Expr<'i>], constants: &HashMap<String,
     {
         let mut array_type = first_type;
         array_type.array_dims.push(ArrayDim::Dynamic);
-        Some(array_type)
+        Ok(Some(array_type))
     } else {
-        None
+        Ok(None)
     }
 }
 
@@ -464,7 +472,7 @@ fn compile_array_index_expr<'i>(
         .array_element_type()
         .ok_or_else(|| CompilerError::Unsupported(format!("array index requires array source, got {}", source_type.type_name())))?;
     let element_size = i64::try_from(
-        fixed_type_size(&element_type, ctx.env.constants)
+        fixed_type_size(&element_type, ctx.env.constants)?
             .ok_or_else(|| CompilerError::Unsupported("array element type must have known size".to_string()))?,
     )
     .map_err(|_| CompilerError::Unsupported("array element size is too large".to_string()))?;
@@ -487,7 +495,7 @@ fn compile_slice_expr<'i>(
     end: &Expr<'i>,
 ) -> Result<(), CompilerError> {
     let source_type = infer_expr_type(source, ctx.env.constants, ctx.env.types)?;
-    let element_size = array_element_size(&source_type, ctx.env.contract_constants);
+    let element_size = array_element_size(&source_type, ctx.env.contract_constants)?;
     let int_type = scalar_type(TypeBase::Int);
     compile_expr_with_context(ctx, source, Some(&source_type))?;
     compile_expr_with_context(ctx, start, Some(&int_type))?;
@@ -596,7 +604,7 @@ fn compile_split_part<'i>(
     part: SplitPart,
 ) -> Result<(), CompilerError> {
     let source_type = infer_expr_type(source, ctx.env.constants, ctx.env.types)?;
-    let element_size = array_element_size(&source_type, ctx.env.contract_constants);
+    let element_size = array_element_size(&source_type, ctx.env.contract_constants)?;
     let int_type = scalar_type(TypeBase::Int);
     compile_expr_with_context(ctx, source, Some(&source_type))?;
     match part {
@@ -635,7 +643,7 @@ fn compile_length_expr<'i>(ctx: &mut CompileExprContext<'_, '_, 'i>, expr: &Expr
         ctx.push_int(size as i64)?;
         return Ok(());
     }
-    if let Some(element_size) = array_element_size(&expr_type, ctx.env.contract_constants) {
+    if let Some(element_size) = array_element_size(&expr_type, ctx.env.contract_constants)? {
         compile_expr_with_context(ctx, expr, Some(&expr_type))?;
         ctx.emit_op(OpSize, 1)?;
         ctx.emit_op(OpSwap, 0)?;

--- a/silverscript-lang/src/compiler/compile/expression/builtin.rs
+++ b/silverscript-lang/src/compiler/compile/expression/builtin.rs
@@ -120,7 +120,7 @@ fn compile_as_cast<'i>(ctx: &mut CompileExprContext<'_, '_, 'i>, args: &[Expr<'i
     let size = if cast_type.is_byte() {
         1
     } else {
-        array_type_size(cast_type, ctx.env.constants)
+        array_type_size(cast_type, ctx.env.constants)?
             .ok_or_else(|| CompilerError::Unsupported("byte size in 'as byte[N]' must be known at compile time".to_string()))?
     };
     compile_call_arg_with_context(ctx, source)?;
@@ -180,7 +180,7 @@ fn compile_byte_sequence_cast_call<'i>(
         return ctx.push_data(&[byte]);
     }
     let source_type = infer_expr_type(&args[0], ctx.env.constants, ctx.env.types)?;
-    if let Some(source_size) = byte_sequence_cast_size(&source_type, ctx.env.constants)
+    if let Some(source_size) = byte_sequence_cast_size(&source_type, ctx.env.constants)?
         && let Some(source_size) = source_size
         && source_size != size
     {

--- a/silverscript-lang/src/compiler/compile/helpers.rs
+++ b/silverscript-lang/src/compiler/compile/helpers.rs
@@ -14,7 +14,7 @@ pub(super) fn compile_contract_fields<'i>(
         let mut resolve_visiting = HashSet::new();
         let resolved = resolve_constant_references(field.expr.clone(), base_constants, &mut resolve_visiting)?;
 
-        if fixed_type_size(&field.type_ref, base_constants).is_some() {
+        if fixed_type_size(&field.type_ref, base_constants)?.is_some() {
             let encoded = encode_value_with_constant_size(&resolved, &field.type_ref, base_constants)?;
             builder.add_data_with_push_opcode(&encoded)?;
         } else {
@@ -87,9 +87,12 @@ pub(super) fn build_function_abi_entries<'i>(
         .collect()
 }
 
-pub(super) fn array_element_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<i64> {
-    let element_type = type_ref.array_element_type()?;
-    i64::try_from(fixed_type_size(&element_type, constants)?).ok()
+pub(super) fn array_element_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Result<Option<i64>, CompilerError> {
+    let Some(element_type) = type_ref.array_element_type() else { return Ok(None) };
+    let Some(size) = fixed_type_size(&element_type, constants)? else { return Ok(None) };
+    let size = i64::try_from(size)
+        .map_err(|_| CompilerError::ArithmeticOverflow(format!("array element size {size} does not fit in i64")))?;
+    Ok(Some(size))
 }
 
 pub(super) fn encode_value_with_constant_size<'i>(
@@ -197,9 +200,22 @@ pub(in crate::compiler) fn encode_array_literal<'i>(
         .array_element_type()
         .ok_or_else(|| CompilerError::Unsupported("array element type must have known size".to_string()))?;
     let mut out = Vec::new();
-    debug_assert!(fixed_type_size(&element_type, constants).is_some(), "type_check must validate array element type has known size");
+    debug_assert!(fixed_type_size(&element_type, constants)?.is_some(), "type_check must validate array element type has known size");
     for value in values {
         out.extend(encode_value_with_constant_size(value, &element_type, constants)?);
     }
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn array_element_size_reports_i64_conversion_overflow() {
+        let type_ref = TypeRef { base: TypeBase::Byte, array_dims: vec![ArrayDim::Fixed(usize::MAX), ArrayDim::Dynamic] };
+
+        let err = array_element_size(&type_ref, &HashMap::new()).expect_err("an element size larger than i64 must be rejected");
+        assert!(matches!(err, CompilerError::ArithmeticOverflow(_)), "unexpected error: {err}");
+    }
 }

--- a/silverscript-lang/src/compiler/compile/helpers.rs
+++ b/silverscript-lang/src/compiler/compile/helpers.rs
@@ -60,31 +60,62 @@ pub(super) fn build_function_abi_entries<'i>(
                 .params
                 .iter()
                 .map(|param| {
-                    let mut type_ref = param.type_ref.clone();
-                    for dimension in &mut type_ref.array_dims {
-                        if matches!(dimension, ArrayDim::Inferred) {
-                            return Err(CompilerError::NonCanonicalEntrypointParameter {
-                                function: func.name.clone(),
-                                param: param.name.clone(),
-                            });
-                        }
-                        if let ArrayDim::Constant(name) = dimension {
-                            let value = constants
-                                .get(name)
-                                .ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))
-                                .and_then(|expr| eval_const_int(expr, constants))?;
-                            let size = usize::try_from(value).map_err(|_| {
-                                CompilerError::Unsupported(format!("array size constant '{name}' must be a non-negative integer"))
-                            })?;
-                            *dimension = ArrayDim::Fixed(size);
-                        }
-                    }
+                    let type_ref = resolve_abi_type_ref(&param.type_ref, constants, &func.name, &param.name)?;
                     Ok(FunctionInputAbi { name: param.name.clone(), type_name: type_ref.type_name() })
                 })
                 .collect::<Result<Vec<_>, CompilerError>>()?;
             Ok(FunctionAbiEntry { name: func.name.clone(), inputs })
         })
         .collect()
+}
+
+pub(super) fn resolve_artifact_struct_type_refs<'i>(
+    contract: &ContractAst<'i>,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<ContractAst<'i>, CompilerError> {
+    let mut resolved = contract.clone();
+    for item in &mut resolved.structs {
+        for field in &mut item.fields {
+            field.type_ref =
+                resolve_abi_type_ref(&field.type_ref, constants, "artifact struct schema", &format!("{}.{}", item.name, field.name))?;
+        }
+    }
+    Ok(resolved)
+}
+
+pub(super) fn resolve_abi_type_ref<'i>(
+    type_ref: &TypeRef,
+    constants: &HashMap<String, Expr<'i>>,
+    function_name: &str,
+    parameter_name: &str,
+) -> Result<TypeRef, CompilerError> {
+    let mut resolved = type_ref.clone();
+    if let TypeBase::Tuple(elements) = &mut resolved.base {
+        for element in elements {
+            *element = resolve_abi_type_ref(element, constants, function_name, parameter_name)?;
+        }
+    }
+    for dimension in &mut resolved.array_dims {
+        match dimension {
+            ArrayDim::Inferred => {
+                return Err(CompilerError::NonCanonicalEntrypointParameter {
+                    function: function_name.to_string(),
+                    param: parameter_name.to_string(),
+                });
+            }
+            ArrayDim::Constant(name) => {
+                let value = constants
+                    .get(name)
+                    .ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))
+                    .and_then(|expr| eval_const_int(expr, constants))?;
+                let size = usize::try_from(value)
+                    .map_err(|_| CompilerError::Unsupported(format!("array size constant '{name}' must be a non-negative integer")))?;
+                *dimension = ArrayDim::Fixed(size);
+            }
+            ArrayDim::Dynamic | ArrayDim::Fixed(_) => {}
+        }
+    }
+    Ok(resolved)
 }
 
 pub(super) fn array_element_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Result<Option<i64>, CompilerError> {

--- a/silverscript-lang/src/compiler/compile/helpers.rs
+++ b/silverscript-lang/src/compiler/compile/helpers.rs
@@ -44,7 +44,7 @@ pub(super) fn infer_expr_type<'i>(
     let structs = StructRegistry::new();
     let functions = HashMap::new();
     let ctx = type_check::TypeCheckContext { types, structs: &structs, constants, functions: &functions, contract_fields: &[] };
-    type_check::check_expr(expr, None, &ctx)
+    type_check::infer_expr_type(expr, &ctx)
 }
 
 pub(super) fn build_function_abi_entries<'i>(

--- a/silverscript-lang/src/compiler/compile/helpers.rs
+++ b/silverscript-lang/src/compiler/compile/helpers.rs
@@ -113,7 +113,7 @@ pub(super) fn encode_value_with_constant_size<'i>(
         (TypeBase::Int | TypeBase::Temporal, []) => {
             let number = match &value.kind {
                 ExprKind::Int(number) | ExprKind::Temporal(number) | ExprKind::DateLiteral(number) => *number,
-                _ => return Err(CompilerError::Unsupported("array literal element type mismatch".to_string())),
+                _ => return Err(array_literal_encoding_error(value)),
             };
             serialize_i64(number, Some(8usize))
                 .map(|bytes| bytes.to_vec())
@@ -121,7 +121,7 @@ pub(super) fn encode_value_with_constant_size<'i>(
         }
         (TypeBase::Bool, []) => {
             let ExprKind::Bool(flag) = &value.kind else {
-                return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
+                return Err(array_literal_encoding_error(value));
             };
             Ok(vec![u8::from(*flag)])
         }
@@ -131,13 +131,13 @@ pub(super) fn encode_value_with_constant_size<'i>(
                 ExprKind::Int(value) => {
                     (*value).try_into().map_err(|_| CompilerError::Unsupported("array literal element type mismatch".to_string()))?
                 }
-                _ => return Err(CompilerError::Unsupported("array literal element type mismatch".to_string())),
+                _ => return Err(array_literal_encoding_error(value)),
             };
             Ok(vec![byte])
         }
         (base @ (TypeBase::Pubkey | TypeBase::Sig | TypeBase::Datasig), []) => {
             let ExprKind::Array { values: bytes_exprs, .. } = &value.kind else {
-                return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
+                return Err(array_literal_encoding_error(value));
             };
             if Some(bytes_exprs.len()) != base.fixed_byte_sequence_len() {
                 return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
@@ -146,16 +146,16 @@ pub(super) fn encode_value_with_constant_size<'i>(
                 .iter()
                 .map(|value| match &value.kind {
                     ExprKind::Byte(byte) => Ok(*byte),
-                    _ => Err(CompilerError::Unsupported("array literal element type mismatch".to_string())),
+                    _ => Err(array_literal_encoding_error(value)),
                 })
                 .collect()
         }
         _ => {
             // Handle fixed-size byte arrays like byte[N]
-            if let (Some(inner_type), Some(size)) = (type_ref.array_element_type(), array_type_size(type_ref, constants)) {
+            if let (Some(inner_type), Some(size)) = (type_ref.array_element_type(), array_type_size(type_ref, constants)?) {
                 if inner_type.is_byte() {
                     let ExprKind::Array { values, .. } = &value.kind else {
-                        return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
+                        return Err(array_literal_encoding_error(value));
                     };
                     if values.len() != size {
                         return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
@@ -173,7 +173,7 @@ pub(super) fn encode_value_with_constant_size<'i>(
                 let element_type = type_ref
                     .array_element_type()
                     .ok_or_else(|| CompilerError::Unsupported("array element type must have known size".to_string()))?;
-                let expected_len = array_type_size(type_ref, constants)
+                let expected_len = array_type_size(type_ref, constants)?
                     .ok_or_else(|| CompilerError::Unsupported("array literal element type mismatch".to_string()))?;
                 if values.len() != expected_len {
                     return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
@@ -186,8 +186,23 @@ pub(super) fn encode_value_with_constant_size<'i>(
                 return Ok(encoded);
             }
 
-            Err(CompilerError::Unsupported("array literal element type mismatch".to_string()))
+            Err(array_literal_encoding_error(value))
         }
+    }
+}
+
+fn array_literal_encoding_error(value: &Expr<'_>) -> CompilerError {
+    match &value.kind {
+        ExprKind::Int(_)
+        | ExprKind::Temporal(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Byte(_)
+        | ExprKind::String(_)
+        | ExprKind::DateLiteral(_)
+        | ExprKind::Array { .. }
+        | ExprKind::StructLiteral { .. }
+        | ExprKind::NumberWithUnit { .. } => CompilerError::Unsupported("array literal element type mismatch".to_string()),
+        _ => CompilerError::RuntimeEvaluationRequired,
     }
 }
 
@@ -217,5 +232,19 @@ mod tests {
 
         let err = array_element_size(&type_ref, &HashMap::new()).expect_err("an element size larger than i64 must be rejected");
         assert!(matches!(err, CompilerError::ArithmeticOverflow(_)), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn constant_value_encoding_only_requests_runtime_fallback_for_runtime_expressions() {
+        let int_type = TypeRef { base: TypeBase::Int, array_dims: Vec::new() };
+        let constants = HashMap::new();
+
+        let err = encode_value_with_constant_size(&Expr::identifier("runtime_value"), &int_type, &constants)
+            .expect_err("a runtime value cannot be encoded ahead of time");
+        assert!(matches!(err, CompilerError::RuntimeEvaluationRequired), "unexpected error: {err}");
+
+        let err = encode_value_with_constant_size(&Expr::bool(true), &int_type, &constants)
+            .expect_err("an invalid literal must not request runtime fallback");
+        assert!(matches!(err, CompilerError::Unsupported(_)), "unexpected error: {err}");
     }
 }

--- a/silverscript-lang/src/compiler/compile/state.rs
+++ b/silverscript-lang/src/compiler/compile/state.rs
@@ -50,7 +50,7 @@ pub(in crate::compiler) fn read_input_state_field_expr_symbolic<'i>(
 }
 
 fn fixed_state_payload_len<'i>(type_ref: &TypeRef, contract_constants: &HashMap<String, Expr<'i>>) -> Result<usize, CompilerError> {
-    fixed_type_size(type_ref, contract_constants)
+    fixed_type_size(type_ref, contract_constants)?
         .ok_or_else(|| CompilerError::Unsupported(format!("readInputState does not support field type {}", type_ref.type_name())))
 }
 
@@ -59,21 +59,28 @@ pub(in crate::compiler) fn encoded_type_chunk_size<'i>(
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<usize, CompilerError> {
     let payload_size = fixed_state_payload_len(type_ref, contract_constants)?;
-    Ok(data_prefix(payload_size)?.len() + payload_size)
+    let prefix_size = data_prefix(payload_size)?.len();
+    checked_add(prefix_size, payload_size)
 }
 
 pub(super) fn encoded_state_len<'i>(
     contract_fields: &[ContractFieldAst<'i>],
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<usize, CompilerError> {
-    contract_fields.iter().try_fold(0usize, |acc, field| Ok(acc + encoded_type_chunk_size(&field.type_ref, contract_constants)?))
+    contract_fields.iter().try_fold(0usize, |acc, field| {
+        let field_size = encoded_type_chunk_size(&field.type_ref, contract_constants)?;
+        checked_add(acc, field_size)
+    })
 }
 
 pub(in crate::compiler) fn encoded_state_len_for_layout_field_types<'i>(
     layout_field_types: &[TypeRef],
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<usize, CompilerError> {
-    layout_field_types.iter().try_fold(0usize, |acc, type_ref| Ok(acc + encoded_type_chunk_size(type_ref, contract_constants)?))
+    layout_field_types.iter().try_fold(0usize, |acc, type_ref| {
+        let field_size = encoded_type_chunk_size(type_ref, contract_constants)?;
+        checked_add(acc, field_size)
+    })
 }
 
 pub(super) fn state_start_offset<'i>(
@@ -82,7 +89,7 @@ pub(super) fn state_start_offset<'i>(
     contract_constants: &HashMap<String, Expr<'i>>,
 ) -> Result<usize, CompilerError> {
     let total_state_len = encoded_state_len(contract_fields, contract_constants)?;
-    state_end.checked_sub(total_state_len).ok_or_else(|| CompilerError::Unsupported("state offset underflow".to_string()))
+    checked_sub(state_end, total_state_len)
 }
 
 pub(super) fn templated_input_bytecode_size_expr<'i>(
@@ -108,13 +115,13 @@ pub(super) fn read_input_state_field_expr<'i>(
     contract_constants: &HashMap<String, Expr<'i>>,
     builtin_name: &str,
 ) -> Result<Expr<'i>, CompilerError> {
-    let field_payload_len = fixed_state_payload_len(field_type, contract_constants)
-        .map_err(|_| CompilerError::Unsupported(format!("{builtin_name} does not support field type {}", field_type.type_name())))?;
-    let field_payload_offset = binary_expr(
-        BinaryOp::Add,
-        state_start_offset_expr,
-        Expr::int((field_chunk_offset + data_prefix(field_payload_len)?.len()) as i64),
-    );
+    let field_payload_len = fixed_state_payload_len(field_type, contract_constants).map_err(|err| match err {
+        CompilerError::ArithmeticOverflow(_) => err,
+        _ => CompilerError::Unsupported(format!("{builtin_name} does not support field type {}", field_type.type_name())),
+    })?;
+    let field_prefix_len = data_prefix(field_payload_len)?.len();
+    let field_data_offset = checked_add(field_chunk_offset, field_prefix_len)?;
+    let field_payload_offset = binary_expr(BinaryOp::Add, state_start_offset_expr, Expr::int(field_data_offset as i64));
     let start = binary_expr(BinaryOp::Add, input_sigscript_base_expr(input_idx, bytecode_size_expr), field_payload_offset);
     let end = binary_expr(BinaryOp::Add, start.clone(), Expr::int(field_payload_len as i64));
     let substr = input_sigscript_substr_expr(input_idx, start, end);
@@ -276,9 +283,7 @@ pub(super) fn compile_validate_output_state_inner_statement(
     )?;
 
     let total_state_len = encoded_state_len(contract_fields, contract_constants)?;
-    let state_start_offset = state_end
-        .checked_sub(total_state_len)
-        .ok_or_else(|| CompilerError::Unsupported("validateOutputState state offset underflow".to_string()))?;
+    let state_start_offset = checked_sub(state_end, total_state_len)?;
 
     let bytecode_size_value =
         bytecode_size.ok_or_else(|| CompilerError::Unsupported("validateOutputState requires this.bytecodeSize".to_string()))?;

--- a/silverscript-lang/src/compiler/compile/statement.rs
+++ b/silverscript-lang/src/compiler/compile/statement.rs
@@ -111,13 +111,13 @@ fn compile_param_size_validations<'i>(
         }
 
         let exact_size = if param.type_ref.is_array() {
-            fixed_type_size(&param.type_ref, constants)
+            fixed_type_size(&param.type_ref, constants)?
         } else if param.type_ref.is_byte() {
             Some(1)
         } else {
             param.type_ref.base.fixed_byte_sequence_len()
         };
-        let is_dynamic_array = param.type_ref.is_array() && exact_size.is_none();
+        let is_dynamic_array = param.type_ref.is_dynamic_array();
         if exact_size.is_none() && !is_dynamic_array && !param.type_ref.is_int_like() && !param.type_ref.is_bool() {
             continue;
         }
@@ -133,7 +133,7 @@ fn compile_param_size_validations<'i>(
             builder.add_i64(expected_size)?;
             builder.add_op(OpNumEqualVerify)?;
         } else if is_dynamic_array {
-            let element_size = array_element_size(&param.type_ref, constants)
+            let element_size = array_element_size(&param.type_ref, constants)?
                 .expect("type_check must validate dynamic array element types have known size");
             builder.add_i64(element_size)?;
             builder.add_op(OpMod)?;
@@ -190,7 +190,7 @@ fn emit_checked_dynamic_array_length<'i>(
         .find(|param| param.name == param_name)
         .expect("struct lowering must retain every grouped leaf parameter");
     let element_size =
-        array_element_size(&param.type_ref, constants).expect("type checking must validate dynamic struct-array leaf element sizes");
+        array_element_size(&param.type_ref, constants)?.expect("type checking must validate dynamic struct-array leaf element sizes");
 
     let copied = stack_bindings.emit_copy_binding_to_top(param_name, stack_depth, builder)?;
     debug_assert!(copied, "entrypoint parameter must have a stack binding");
@@ -568,9 +568,7 @@ fn compile_read_input_state_statement<'i>(
                 .bytecode_size
                 .ok_or_else(|| CompilerError::Unsupported("readInputState requires this.bytecodeSize".to_string()))?;
             let total_state_len = encoded_state_len(contract_fields, ctx.contract_constants)?;
-            let state_start_offset = state_end
-                .checked_sub(total_state_len)
-                .ok_or_else(|| CompilerError::Unsupported("readInputState state offset underflow".to_string()))?;
+            let state_start_offset = checked_sub(state_end, total_state_len)?;
 
             let input_idx = args[0].clone();
             let mut field_chunk_offset = 0usize;
@@ -603,7 +601,8 @@ fn compile_read_input_state_statement<'i>(
                     binding_expr,
                 )?);
 
-                field_chunk_offset += encoded_type_chunk_size(&field.type_ref, ctx.contract_constants)?;
+                let field_chunk_size = encoded_type_chunk_size(&field.type_ref, ctx.contract_constants)?;
+                field_chunk_offset = checked_add(field_chunk_offset, field_chunk_size)?;
             }
 
             Ok(added_stack_locals)
@@ -677,7 +676,8 @@ fn compile_read_input_state_statement<'i>(
                     binding_expr,
                 )?);
 
-                field_chunk_offset += encoded_type_chunk_size(&field.type_ref, ctx.contract_constants)?;
+                let field_chunk_size = encoded_type_chunk_size(&field.type_ref, ctx.contract_constants)?;
+                field_chunk_offset = checked_add(field_chunk_offset, field_chunk_size)?;
             }
 
             Ok(added_stack_locals)

--- a/silverscript-lang/src/compiler/covenant_declarations.rs
+++ b/silverscript-lang/src/compiler/covenant_declarations.rs
@@ -234,8 +234,13 @@ fn parse_covenant_declaration<'i>(
         }
     };
 
-    let from_value = eval_const_int(&from_expr, constants)
-        .map_err(|_| CompilerError::Unsupported("covenant 'from' must be a compile-time integer".to_string()))?;
+    let from_value = match eval_const_int(&from_expr, constants) {
+        Ok(value) => value,
+        Err(CompilerError::NonConstantInteger(_)) => {
+            return Err(CompilerError::Unsupported("covenant 'from' must be a compile-time integer".to_string()));
+        }
+        Err(err) => return Err(err),
+    };
     if from_value < 1 {
         return Err(CompilerError::Unsupported("covenant 'from' must be >= 1".to_string()));
     }
@@ -336,8 +341,13 @@ fn parse_covenant_declaration<'i>(
         None if infers_single_state_transition_to_one => Expr::int(1),
         None => return Err(CompilerError::Unsupported("missing covenant attribute argument 'to'".to_string())),
     };
-    let to_value = eval_const_int(&to_expr, constants)
-        .map_err(|_| CompilerError::Unsupported("covenant 'to' must be a compile-time integer".to_string()))?;
+    let to_value = match eval_const_int(&to_expr, constants) {
+        Ok(value) => value,
+        Err(CompilerError::NonConstantInteger(_)) => {
+            return Err(CompilerError::Unsupported("covenant 'to' must be a compile-time integer".to_string()));
+        }
+        Err(err) => return Err(err),
+    };
     if to_value < 1 {
         return Err(CompilerError::Unsupported("covenant 'to' must be >= 1".to_string()));
     }

--- a/silverscript-lang/src/compiler/for.rs
+++ b/silverscript-lang/src/compiler/for.rs
@@ -215,7 +215,10 @@ impl<'a, 'i> ForLowerer<'a, 'i> {
         span: span::Span<'i>,
         ident_span: span::Span<'i>,
     ) -> Result<Vec<Statement<'i>>, CompilerError> {
-        if i128::from(end) - i128::from(start) > max_iterations as i128 {
+        // Keep constant lowering compatible with the runtime guard `require(end - start <= max_iterations)`: if the runtime
+        // subtraction cannot be represented as an i64, the equivalent constant loop must fail compilation.
+        let range = checked_sub(end, start)?;
+        if range > max_iterations as i64 {
             return Err(CompilerError::Unsupported("for loop range must not exceed max iterations".to_string()));
         }
 

--- a/silverscript-lang/src/compiler/for.rs
+++ b/silverscript-lang/src/compiler/for.rs
@@ -79,7 +79,7 @@ impl<'a, 'i> ForLowerer<'a, 'i> {
     ) -> Result<Vec<Statement<'i>>, CompilerError> {
         let max_iterations = match eval_const_int(max_iterations, self.constants) {
             Ok(value) => value,
-            Err(CompilerError::InvalidLiteral(message)) => return Err(CompilerError::InvalidLiteral(message)),
+            Err(err @ (CompilerError::InvalidLiteral(_) | CompilerError::ArithmeticOverflow(_))) => return Err(err),
             Err(_) => return Err(CompilerError::Unsupported("for loop max iterations must be a compile-time integer".to_string())),
         };
         if max_iterations < 0 {

--- a/silverscript-lang/src/compiler/for.rs
+++ b/silverscript-lang/src/compiler/for.rs
@@ -79,8 +79,10 @@ impl<'a, 'i> ForLowerer<'a, 'i> {
     ) -> Result<Vec<Statement<'i>>, CompilerError> {
         let max_iterations = match eval_const_int(max_iterations, self.constants) {
             Ok(value) => value,
-            Err(err @ (CompilerError::InvalidLiteral(_) | CompilerError::ArithmeticOverflow(_))) => return Err(err),
-            Err(_) => return Err(CompilerError::Unsupported("for loop max iterations must be a compile-time integer".to_string())),
+            Err(CompilerError::NonConstantInteger(_)) => {
+                return Err(CompilerError::Unsupported("for loop max iterations must be a compile-time integer".to_string()));
+            }
+            Err(err) => return Err(err),
         };
         if max_iterations < 0 {
             return Err(CompilerError::Unsupported("for loop max iterations must be a non-negative compile-time integer".to_string()));
@@ -89,8 +91,20 @@ impl<'a, 'i> ForLowerer<'a, 'i> {
             return Err(CompilerError::Unsupported(format!("for loop max iterations must not exceed {MAX_FOR_LOOP_ITERATIONS}")));
         }
 
-        if let (Ok(start_value), Ok(end_value)) = (eval_const_int(start, self.constants), eval_const_int(end, self.constants)) {
-            return self.lower_constant_for_statement(ident, start_value, end_value, max_iterations as usize, body, span, ident_span);
+        {
+            let start_value = eval_optional_const_int(start, self.constants)?;
+            let end_value = eval_optional_const_int(end, self.constants)?;
+            if let (Some(start_value), Some(end_value)) = (start_value, end_value) {
+                return self.lower_constant_for_statement(
+                    ident,
+                    start_value,
+                    end_value,
+                    max_iterations as usize,
+                    body,
+                    span,
+                    ident_span,
+                );
+            }
         }
 
         let lowered_body = self.lower_block(body)?;

--- a/silverscript-lang/src/compiler/infer_array.rs
+++ b/silverscript-lang/src/compiler/infer_array.rs
@@ -61,14 +61,14 @@ fn infer_fixed_array_type_from_initializer<'i>(
     let Some(init_type) = infer_expr_type(init, types, constants, functions)? else { return Ok(None) };
 
     let Some(init_element_type) = init_type.array_element_type() else { return Ok(None) };
-    if !init_type.is_array() || !type_refs_equal(&init_element_type, &element_type, constants) {
+    if !init_type.is_array() || !type_refs_equal(&init_element_type, &element_type, constants)? {
         return Ok(None);
     }
 
     let size = if let ExprKind::Array { values, .. } = &init.kind {
         values.len()
     } else {
-        let Some(size) = array_type_size(&init_type, constants) else { return Ok(None) };
+        let Some(size) = array_type_size(&init_type, constants)? else { return Ok(None) };
         size
     };
     let mut inferred = element_type;
@@ -313,7 +313,7 @@ fn infer_expr_type<'i>(
         ExprKind::Ternary { then_expr, else_expr, .. } => {
             let Some(then_type) = infer_expr_type(then_expr, types, constants, functions)? else { return Ok(None) };
             let Some(else_type) = infer_expr_type(else_expr, types, constants, functions)? else { return Ok(None) };
-            type_refs_equal(&then_type, &else_type, constants).then_some(then_type)
+            type_refs_equal(&then_type, &else_type, constants)?.then_some(then_type)
         }
         ExprKind::Append { source, args, .. } => {
             let Some(source_type) = infer_expr_type(source, types, constants, functions)? else { return Ok(None) };

--- a/silverscript-lang/src/compiler/infer_array.rs
+++ b/silverscript-lang/src/compiler/infer_array.rs
@@ -51,23 +51,29 @@ fn infer_fixed_array_type_from_initializer<'i>(
     types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
-) -> Option<TypeRef> {
+) -> Result<Option<TypeRef>, CompilerError> {
     if !matches!(declared_type.array_size(), Some(ArrayDim::Inferred)) {
-        return None;
+        return Ok(None);
     }
 
-    let element_type = declared_type.array_element_type()?;
-    let init = initializer?;
-    let init_type = infer_expr_type(init, types, constants, functions)?;
+    let Some(element_type) = declared_type.array_element_type() else { return Ok(None) };
+    let Some(init) = initializer else { return Ok(None) };
+    let Some(init_type) = infer_expr_type(init, types, constants, functions)? else { return Ok(None) };
 
-    if !init_type.is_array() || !type_refs_equal(&init_type.array_element_type()?, &element_type, constants) {
-        return None;
+    let Some(init_element_type) = init_type.array_element_type() else { return Ok(None) };
+    if !init_type.is_array() || !type_refs_equal(&init_element_type, &element_type, constants) {
+        return Ok(None);
     }
 
-    let size = if let ExprKind::Array { values, .. } = &init.kind { values.len() } else { array_type_size(&init_type, constants)? };
+    let size = if let ExprKind::Array { values, .. } = &init.kind {
+        values.len()
+    } else {
+        let Some(size) = array_type_size(&init_type, constants) else { return Ok(None) };
+        size
+    };
     let mut inferred = element_type;
     inferred.array_dims.push(ArrayDim::Fixed(size));
-    Some(inferred)
+    Ok(Some(inferred))
 }
 
 fn lower_constant<'i>(
@@ -76,7 +82,7 @@ fn lower_constant<'i>(
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Result<ConstantAst<'i>, CompilerError> {
-    let type_ref = infer_type(&constant.type_ref, Some(&constant.expr), types, constants, functions)
+    let type_ref = infer_type(&constant.type_ref, Some(&constant.expr), types, constants, functions)?
         .ok_or_else(|| CompilerError::Unsupported(format!("cannot infer fixed array size from constant '{}'", constant.name)))?;
     types.insert(constant.name.clone(), type_ref.clone());
     Ok(ConstantAst { type_ref, ..constant.clone() })
@@ -88,7 +94,7 @@ fn lower_field<'i>(
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
 ) -> Result<ContractFieldAst<'i>, CompilerError> {
-    let type_ref = infer_type(&field.type_ref, Some(&field.expr), types, constants, functions)
+    let type_ref = infer_type(&field.type_ref, Some(&field.expr), types, constants, functions)?
         .ok_or_else(|| CompilerError::Unsupported(format!("cannot infer fixed array size from contract field '{}'", field.name)))?;
     types.insert(field.name.clone(), type_ref.clone());
     Ok(ContractFieldAst { type_ref, ..field.clone() })
@@ -129,7 +135,7 @@ fn lower_statement<'i>(
 ) -> Result<Statement<'i>, CompilerError> {
     match statement {
         Statement::VariableDefinition { type_ref, name, expr, .. } => {
-            let lowered_type = infer_type(type_ref, expr.as_ref(), types, constants, functions)
+            let lowered_type = infer_type(type_ref, expr.as_ref(), types, constants, functions)?
                 .ok_or_else(|| CompilerError::Unsupported(format!("cannot infer fixed array size from variable '{}'", name)))?;
             types.insert(name.clone(), lowered_type.clone());
             Ok(match statement {
@@ -173,9 +179,9 @@ fn lower_statement<'i>(
                 ),
                 _ => (None, None),
             };
-            let lowered_left = infer_type(left_type_ref, left_initializer.as_ref(), types, constants, functions)
+            let lowered_left = infer_type(left_type_ref, left_initializer.as_ref(), types, constants, functions)?
                 .ok_or_else(|| CompilerError::Unsupported(format!("cannot infer fixed array size from variable '{left_name}'")))?;
-            let lowered_right = infer_type(right_type_ref, right_initializer.as_ref(), types, constants, functions)
+            let lowered_right = infer_type(right_type_ref, right_initializer.as_ref(), types, constants, functions)?
                 .ok_or_else(|| CompilerError::Unsupported(format!("cannot infer fixed array size from variable '{right_name}'")))?;
             types.insert(left_name.clone(), lowered_left.clone());
             types.insert(right_name.clone(), lowered_right.clone());
@@ -196,7 +202,7 @@ fn lower_statement<'i>(
             let lowered_bindings = bindings
                 .iter()
                 .map(|binding| {
-                    let lowered_type = infer_type(&binding.type_ref, None, types, constants, functions).ok_or_else(|| {
+                    let lowered_type = infer_type(&binding.type_ref, None, types, constants, functions)?.ok_or_else(|| {
                         CompilerError::Unsupported(format!("cannot infer fixed array size from binding '{}'", binding.name))
                     })?;
                     types.insert(binding.name.clone(), lowered_type.clone());
@@ -260,11 +266,11 @@ fn infer_type<'i>(
     types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
-) -> Option<TypeRef> {
+) -> Result<Option<TypeRef>, CompilerError> {
     if matches!(declared_type.array_size(), Some(ArrayDim::Inferred)) {
         infer_fixed_array_type_from_initializer(declared_type, initializer, types, constants, functions)
     } else {
-        Some(declared_type.clone())
+        Ok(Some(declared_type.clone()))
     }
 }
 
@@ -273,8 +279,8 @@ pub(super) fn infer_expr_type<'i>(
     types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,
     functions: &HashMap<String, &FunctionAst<'i>>,
-) -> Option<TypeRef> {
-    match &expr.kind {
+) -> Result<Option<TypeRef>, CompilerError> {
+    Ok(match &expr.kind {
         ExprKind::Int(_) => Some(TypeRef { base: TypeBase::Int, array_dims: Vec::new() }),
         ExprKind::NumberWithUnit { unit, .. } if crate::ast::is_temporal_unit(unit) => {
             Some(TypeRef { base: TypeBase::Temporal, array_dims: Vec::new() })
@@ -288,10 +294,10 @@ pub(super) fn infer_expr_type<'i>(
         ExprKind::Array { type_ref, .. } => Some(type_ref.clone()),
         ExprKind::Call { name, .. } => {
             if let Some(type_ref) = as_cast_type(name) {
-                return Some(type_ref);
+                return Ok(Some(type_ref));
             }
             if let Some(function) = functions.get(name) {
-                return (!function.entrypoint).then(|| function.return_type()).flatten();
+                return Ok((!function.entrypoint).then(|| function.return_type()).flatten());
             }
             parse_type_ref(name)
                 .ok()
@@ -300,25 +306,25 @@ pub(super) fn infer_expr_type<'i>(
         }
         ExprKind::New { name, .. } => constructor_return_type(name),
         ExprKind::Binary { op: BinaryOp::Add, left, right } => {
-            let left_type = infer_expr_type(left, types, constants, functions)?;
-            let right_type = infer_expr_type(right, types, constants, functions)?;
-            concat_types(&left_type, &right_type, constants)
+            let Some(left_type) = infer_expr_type(left, types, constants, functions)? else { return Ok(None) };
+            let Some(right_type) = infer_expr_type(right, types, constants, functions)? else { return Ok(None) };
+            return concat_types(&left_type, &right_type, constants);
         }
         ExprKind::Ternary { then_expr, else_expr, .. } => {
-            let then_type = infer_expr_type(then_expr, types, constants, functions)?;
-            let else_type = infer_expr_type(else_expr, types, constants, functions)?;
+            let Some(then_type) = infer_expr_type(then_expr, types, constants, functions)? else { return Ok(None) };
+            let Some(else_type) = infer_expr_type(else_expr, types, constants, functions)? else { return Ok(None) };
             type_refs_equal(&then_type, &else_type, constants).then_some(then_type)
         }
         ExprKind::Append { source, args, .. } => {
-            let source_type = infer_expr_type(source, types, constants, functions)?;
-            append_type(&source_type, args.len(), constants)
+            let Some(source_type) = infer_expr_type(source, types, constants, functions)? else { return Ok(None) };
+            return append_type(&source_type, args.len(), constants);
         }
         ExprKind::Split { source, index, part, .. } => {
-            let source_type = infer_expr_type(source, types, constants, functions)?;
+            let Some(source_type) = infer_expr_type(source, types, constants, functions)? else { return Ok(None) };
             split_part_type(&source_type, index, *part, constants).ok()
         }
         ExprKind::Introspection(kind) => Some(introspection_type(*kind)),
         ExprKind::IndexedIntrospection { kind, .. } => Some(indexed_introspection_type(*kind)),
         _ => None,
-    }
+    })
 }

--- a/silverscript-lang/src/compiler/infer_array.rs
+++ b/silverscript-lang/src/compiler/infer_array.rs
@@ -274,7 +274,7 @@ fn infer_type<'i>(
     }
 }
 
-pub(super) fn infer_expr_type<'i>(
+fn infer_expr_type<'i>(
     expr: &Expr<'i>,
     types: &TypeMap,
     constants: &HashMap<String, Expr<'i>>,

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -33,8 +33,8 @@ mod validate_output_state;
 
 use compile::compile_contract_impl;
 pub use compile::compile_debug_expr;
-pub(super) use compile::eval_const_int;
 pub(crate) use compile::resolve_constant_references;
+pub(super) use compile::{eval_const_int, eval_optional_const_int};
 pub(crate) use debug_recording::DebugRecorder;
 use r#for::lower_for_loops;
 use read_input_state::lower_read_input_state_calls;
@@ -158,7 +158,7 @@ impl<'i> ContractAst<'i> {
 
         for (param, value) in self.params.iter().zip(constructor_args.iter()) {
             let type_name = param.type_ref.type_name();
-            if validate_expr_matches_type(value, &param.type_ref, &HashMap::new(), &structs, &constants, &HashMap::new(), &self.fields)
+            if validate_expr_matches_type(value, &param.type_ref, &HashMap::new(), &structs, &env, &HashMap::new(), &self.fields)
                 .is_err()
             {
                 return Err(CompilerError::Unsupported(format!("constructor argument '{}' expects {}", param.name, type_name)));
@@ -174,16 +174,8 @@ impl<'i> ContractAst<'i> {
 
             let type_name = field.type_ref.type_name();
             let resolved = resolve_constant_references(field.expr.clone(), &env, &mut std::collections::HashSet::new())?;
-            if validate_expr_matches_type(
-                &resolved,
-                &field.type_ref,
-                &HashMap::new(),
-                &structs,
-                &constants,
-                &HashMap::new(),
-                &self.fields,
-            )
-            .is_err()
+            if validate_expr_matches_type(&resolved, &field.type_ref, &HashMap::new(), &structs, &env, &HashMap::new(), &self.fields)
+                .is_err()
             {
                 return Err(CompilerError::Unsupported(format!("contract field '{}' expects {}", field.name, type_name)));
             }

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -220,8 +220,10 @@ impl<'i> CompiledContract<'i> {
 
     pub fn build_sig_script(&self, function_name: &str, args: Vec<Expr<'i>>) -> Result<Vec<u8>, CompilerError> {
         let structs = build_struct_registry(&self.ast)?;
-        let constants: HashMap<_, _> =
-            self.ast.constants.iter().map(|constant| (constant.name.clone(), constant.expr.clone())).collect();
+        // ABI parameter types and artifact struct fields have already had
+        // constant array dimensions resolved to fixed dimensions during
+        // compilation, so argument validation does not need a constants map.
+        let constants = HashMap::new();
         let function = self
             .entry_by_name(function_name)
             .ok_or_else(|| CompilerError::Unsupported(format!("function '{}' not found", function_name)))?;

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -38,7 +38,7 @@ pub(super) use compile::{eval_const_int, eval_optional_const_int};
 pub(crate) use debug_recording::DebugRecorder;
 use r#for::lower_for_loops;
 use read_input_state::lower_read_input_state_calls;
-use static_check::validate_expr_matches_type;
+use static_check::{validate_concrete_constructor_argument, validate_expr_matches_type};
 pub use structs::flattened_struct_name;
 pub(super) use structs::{
     StructArrayParamGroups, StructRegistry, build_struct_registry, dynamic_struct_array_param_groups, ensure_known_type,
@@ -157,6 +157,7 @@ impl<'i> ContractAst<'i> {
         let mut env = constants.clone();
 
         for (param, value) in self.params.iter().zip(constructor_args.iter()) {
+            validate_concrete_constructor_argument(param, value)?;
             let type_name = param.type_ref.type_name();
             if validate_expr_matches_type(value, &param.type_ref, &HashMap::new(), &structs, &env, &HashMap::new(), &self.fields)
                 .is_err()

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -301,10 +301,32 @@ fn validate_sigscript_arg<'i>(
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
 ) -> Result<(), CompilerError> {
+    // Signature-script construction receives already classified AST values.
+    // Unlike source-language checking, do not reinterpret an integer literal
+    // as a byte: callers must use Expr::byte so encoding retains byte semantics.
+    validate_explicit_sigscript_bytes(arg, type_ref)?;
+
     let types = HashMap::new();
     let functions = HashMap::new();
     let type_context = type_check::TypeCheckContext { types: &types, structs, constants, functions: &functions, contract_fields: &[] };
     type_check::check_expr(arg, Some(type_ref), &type_context)?;
+    Ok(())
+}
+
+fn validate_explicit_sigscript_bytes(arg: &Expr<'_>, type_ref: &TypeRef) -> Result<(), CompilerError> {
+    if !matches!(type_ref.base, TypeBase::Byte) {
+        return Ok(());
+    }
+
+    if type_ref.is_byte() {
+        return if matches!(arg.kind, ExprKind::Byte(_)) { Ok(()) } else { Err(CompilerError::TypeMismatch) };
+    }
+
+    if let (Some(element_type), ExprKind::Array { values, .. }) = (type_ref.array_element_type(), &arg.kind) {
+        for value in values {
+            validate_explicit_sigscript_bytes(value, &element_type)?;
+        }
+    }
     Ok(())
 }
 

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -9,6 +9,7 @@ use crate::ast::{
     IntrospectionKind, ParamAst, STATE_TYPE_NAME, SplitPart, StateFieldExpr, Statement, StructBindingAst, TypeBase, TypeRef, UnaryOp,
     UnarySuffixKind, as_cast_call_name, as_cast_type, parse_contract_ast, parse_type_ref,
 };
+pub(crate) use crate::checked_arithmetic::{checked_add, checked_div, checked_mul, checked_neg, checked_rem, checked_sub};
 use crate::debug_info::{DebugInfo, DebugNamedValue};
 pub use crate::errors::{CompilerError, ErrorSpan};
 use crate::span;

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -41,8 +41,8 @@ use read_input_state::lower_read_input_state_calls;
 use static_check::validate_expr_matches_type;
 pub use structs::flattened_struct_name;
 pub(super) use structs::{
-    StructArrayParamGroups, StructRegistry, build_struct_registry, dynamic_struct_array_param_groups,
-    ensure_known_struct_or_builtin_type, flatten_constructor_args_env, flatten_type_leaves, flattened_struct_field_specs_for_type,
+    StructArrayParamGroups, StructRegistry, build_struct_registry, dynamic_struct_array_param_groups, ensure_known_type,
+    ensure_known_type_without_struct_arrays, flatten_constructor_args_env, flatten_type_leaves, flattened_struct_field_specs_for_type,
     is_struct, is_struct_array, lower_structs_contract, struct_name, validate_struct_graph,
 };
 pub(super) use type_system::{append_type, array_size as array_type_size, concat_types, fixed_type_size, type_refs_equal};

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -185,12 +185,28 @@ pub(super) fn static_check_contract<'i>(
     }
 
     let structs = build_struct_registry(contract)?;
+    for item in &contract.structs {
+        if item.fields.is_empty() {
+            return Err(CompilerError::Unsupported(format!("struct '{}' must contain at least one field", item.name))
+                .with_span(&item.name_span));
+        }
+    }
     validate_struct_graph(&structs)?;
     validate_contract_struct_usage(contract, &structs)?;
     let mut constants: HashMap<String, Expr<'i>> =
         contract.constants.iter().map(|constant| (constant.name.clone(), constant.expr.clone())).collect();
     for (param, value) in contract.params.iter().zip(constructor_args) {
         constants.insert(param.name.clone(), value.clone());
+    }
+    for param in &contract.params {
+        ensure_array_elements_have_known_size(&param.type_ref, &structs, &constants, &param.type_ref.type_name())
+            .map_err(|err| err.with_span(&param.type_span))?;
+    }
+    for item in &contract.structs {
+        for field in &item.fields {
+            ensure_array_elements_have_known_size(&field.type_ref, &structs, &constants, &field.type_ref.type_name())
+                .map_err(|err| err.with_span(&field.type_span))?;
+        }
     }
     validate_constant_initializers(contract, &structs, &constants)?;
     validate_contract_field_initializers(contract, &structs, &constants)?;
@@ -1023,14 +1039,28 @@ fn ensure_array_elements_have_known_size<'i>(
     type_name: &str,
 ) -> Result<(), CompilerError> {
     for dimension in &type_ref.array_dims {
-        let ArrayDim::Constant(name) = dimension else {
-            continue;
-        };
-        let expr =
-            constants.get(name).ok_or_else(|| CompilerError::UndefinedIdentifier(format!("array dimension constant '{name}'")))?;
-        let value = eval_const_int(expr, constants)?;
-        usize::try_from(value)
-            .map_err(|_| CompilerError::InvalidLiteral(format!("array dimension '{name}' must be a non-negative integer")))?;
+        match dimension {
+            ArrayDim::Fixed(0) => {
+                return Err(CompilerError::InvalidLiteral(format!("array dimensions must be greater than zero: {type_name}")));
+            }
+            ArrayDim::Constant(name) => {
+                let expr = constants
+                    .get(name)
+                    .ok_or_else(|| CompilerError::UndefinedIdentifier(format!("array dimension constant '{name}'")))?;
+                let value = eval_const_int(expr, constants)?;
+                let size = usize::try_from(value)
+                    .map_err(|_| CompilerError::InvalidLiteral(format!("array dimension '{name}' must be a non-negative integer")))?;
+                if size == 0 {
+                    return Err(CompilerError::InvalidLiteral(format!("array dimension '{name}' must be greater than zero")));
+                }
+            }
+            ArrayDim::Dynamic | ArrayDim::Inferred | ArrayDim::Fixed(_) => {}
+        }
+    }
+    if let TypeBase::Tuple(elements) = &type_ref.base {
+        for element in elements {
+            ensure_array_elements_have_known_size(element, structs, constants, &element.type_name())?;
+        }
     }
 
     if type_ref.is_array()

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -328,13 +328,13 @@ pub(crate) fn validate_return_types<'i>(
 
 fn validate_contract_struct_usage<'i>(contract: &ContractAst<'i>, structs: &StructRegistry) -> Result<(), CompilerError> {
     for param in &contract.params {
-        ensure_known_struct_or_builtin_type(&param.type_ref, structs, "contract parameter")?;
+        ensure_known_type_without_struct_arrays(&param.type_ref, structs, "contract parameter")?;
     }
     for field in &contract.fields {
-        ensure_known_struct_or_builtin_type(&field.type_ref, structs, "contract field")?;
+        ensure_known_type_without_struct_arrays(&field.type_ref, structs, "contract field")?;
     }
     for constant in &contract.constants {
-        ensure_known_struct_or_builtin_type(&constant.type_ref, structs, "constant")?;
+        ensure_known_type_without_struct_arrays(&constant.type_ref, structs, "constant")?;
     }
 
     Ok(())
@@ -367,9 +367,12 @@ fn validate_function_signatures<'i>(
             }
         }
         for param in &function.params {
+            ensure_known_type(&param.type_ref, structs, "function parameter").map_err(|err| err.with_span(&param.type_span))?;
             ensure_array_elements_have_known_size(&param.type_ref, structs, constants, &param.type_ref.type_name())?;
         }
-        for return_type in &function.return_types {
+        for (index, return_type) in function.return_types.iter().enumerate() {
+            ensure_known_type(return_type, structs, "function return type")
+                .map_err(|err| err.with_span(function.return_type_spans.get(index).unwrap_or(&function.name_span)))?;
             ensure_array_elements_have_known_size(return_type, structs, constants, &return_type.type_name())?;
         }
 
@@ -452,8 +455,8 @@ fn validate_statement_shapes<'i>(
 
     for stmt in statements {
         match stmt {
-            Statement::VariableDefinition { type_ref, name, expr, .. } => {
-                validate_variable_definition_statement_shape(&mut ctx, type_ref, name, expr.as_ref())?
+            Statement::VariableDefinition { type_ref, name, expr, type_span, .. } => {
+                validate_variable_definition_statement_shape(&mut ctx, type_ref, name, expr.as_ref(), type_span)?
             }
             Statement::TupleAssignment { left_type_ref, left_name, right_type_ref, right_name, expr, .. } => {
                 validate_tuple_assignment_statement_shape(&mut ctx, left_type_ref, left_name, right_type_ref, right_name, expr)?
@@ -523,7 +526,9 @@ fn validate_variable_definition_statement_shape<'i>(
     type_ref: &TypeRef,
     name: &str,
     expr: Option<&Expr<'i>>,
+    type_span: &span::Span<'i>,
 ) -> Result<(), CompilerError> {
+    ensure_known_type(type_ref, ctx.structs, "variable").map_err(|err| err.with_span(type_span))?;
     let type_name = type_ref.type_name();
     ensure_array_elements_have_known_size(type_ref, ctx.structs, ctx.constants, &type_name)?;
     if expr.is_none() && type_ref.is_array() && array_type_size(type_ref, ctx.constants)?.is_some() {
@@ -908,7 +913,7 @@ fn validate_struct_destructure_bindings<'i>(
     let mut seen_names = HashSet::new();
 
     for binding in bindings {
-        ensure_known_struct_or_builtin_type(&binding.type_ref, structs, "struct destructuring")?;
+        ensure_known_type_without_struct_arrays(&binding.type_ref, structs, "struct destructuring")?;
         if !seen_fields.insert(binding.field_name.clone()) {
             return Err(CompilerError::Unsupported(format!("duplicate struct field '{}'", binding.field_name)));
         }

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -224,6 +224,29 @@ pub(super) fn static_check_contract<'i>(
     Ok(())
 }
 
+pub(super) fn validate_concrete_constructor_argument(param: &ParamAst<'_>, value: &Expr<'_>) -> Result<(), CompilerError> {
+    if is_concrete_constructor_value(value) {
+        return Ok(());
+    }
+
+    Err(CompilerError::Unsupported(format!("constructor argument '{}' must be a concrete value", param.name)).with_span(&value.span))
+}
+
+fn is_concrete_constructor_value(value: &Expr<'_>) -> bool {
+    match &value.kind {
+        ExprKind::Int(_)
+        | ExprKind::Temporal(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Byte(_)
+        | ExprKind::String(_)
+        | ExprKind::DateLiteral(_) => true,
+        // Composite values are concrete only when every nested value is.
+        ExprKind::Array { values, .. } => values.iter().all(is_concrete_constructor_value),
+        ExprKind::StructLiteral { fields, .. } => fields.iter().all(|field| is_concrete_constructor_value(&field.expr)),
+        _ => false,
+    }
+}
+
 fn validate_constant_initializers<'i>(
     contract: &ContractAst<'i>,
     structs: &StructRegistry,

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -1032,7 +1032,7 @@ fn ensure_array_elements_have_known_size<'i>(
     }
 
     if type_ref.is_array()
-        && fixed_type_size_with_structs(type_ref.array_element_type().as_ref().unwrap_or(type_ref), structs, constants).is_none()
+        && fixed_type_size_with_structs(type_ref.array_element_type().as_ref().unwrap_or(type_ref), structs, constants)?.is_none()
     {
         return Err(CompilerError::Unsupported(format!("array element type must have known size: {type_name}")));
     }
@@ -1043,21 +1043,25 @@ fn fixed_type_size_with_structs<'i>(
     type_ref: &TypeRef,
     structs: &StructRegistry,
     constants: &HashMap<String, Expr<'i>>,
-) -> Option<usize> {
+) -> Result<Option<usize>, CompilerError> {
     if type_ref.is_array() {
-        let element_type = type_ref.array_element_type()?;
-        let array_len = array_type_size(type_ref, constants)?;
-        return fixed_type_size_with_structs(&element_type, structs, constants)?.checked_mul(array_len);
+        let Some(element_type) = type_ref.array_element_type() else { return Ok(None) };
+        let Some(array_len) = array_type_size(type_ref, constants) else { return Ok(None) };
+        let Some(element_size) = fixed_type_size_with_structs(&element_type, structs, constants)? else { return Ok(None) };
+        return checked_mul(element_size, array_len).map(Some);
     }
 
     match &type_ref.base {
         TypeBase::Custom(name) => {
-            let struct_spec = structs.get(name)?;
+            let Some(struct_spec) = structs.get(name) else { return Ok(None) };
             let mut total = 0usize;
             for field in &struct_spec.fields {
-                total = total.checked_add(fixed_type_size_with_structs(&field.type_ref, structs, constants)?)?;
+                let Some(field_size) = fixed_type_size_with_structs(&field.type_ref, structs, constants)? else {
+                    return Ok(None);
+                };
+                total = checked_add(total, field_size)?;
             }
-            Some(total)
+            Ok(Some(total))
         }
         _ => fixed_type_size(type_ref, constants),
     }

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -526,15 +526,12 @@ fn validate_variable_definition_statement_shape<'i>(
 ) -> Result<(), CompilerError> {
     let type_name = type_ref.type_name();
     ensure_array_elements_have_known_size(type_ref, ctx.structs, ctx.constants, &type_name)?;
-    if expr.is_none() && type_ref.is_array() && array_type_size(type_ref, ctx.constants).is_some() {
+    if expr.is_none() && type_ref.is_array() && array_type_size(type_ref, ctx.constants)?.is_some() {
         return Err(CompilerError::Unsupported("variable definition requires initializer".to_string()));
     }
     if let Some(expr) = expr {
         ctx.check_expr(expr, Some(type_ref)).map_err(|err| {
-            if type_ref.is_array()
-                && matches!(expr.kind, ExprKind::Array { .. })
-                && !matches!(&err, CompilerError::Unsupported(message) if message == "size mismatch")
-            {
+            if type_ref.is_array() && matches!(expr.kind, ExprKind::Array { .. }) && !matches!(&err, CompilerError::SizeMismatch) {
                 return CompilerError::Unsupported(format!("array element type mismatch for type {type_name}"));
             }
             map_declared_type_error(
@@ -718,7 +715,7 @@ fn validate_function_call_assign_statement_shape<'i>(
         return Err(CompilerError::Unsupported("function call assignment return count mismatch".to_string()));
     }
     for (binding, return_type) in bindings.iter().zip(&return_types) {
-        if !type_refs_equal(&binding.type_ref, return_type, ctx.constants) {
+        if !type_refs_equal(&binding.type_ref, return_type, ctx.constants)? {
             return Err(CompilerError::Unsupported(format!(
                 "function return binding '{}' expects {}",
                 binding.name,
@@ -749,7 +746,7 @@ fn validate_require_age_daa_statement_shape<'i>(
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
     ctx.check_expr(expr, Some(&TypeRef { base: TypeBase::Int, array_dims: Vec::new() }))?;
-    if let Ok(value) = eval_const_int(expr, ctx.constants) {
+    if let Some(value) = eval_optional_const_int(expr, ctx.constants)? {
         if !(0..(1_i64 << 32)).contains(&value) {
             return Err(CompilerError::Unsupported(format!("this.ageDaa value must satisfy 0 <= value < 2^32, got {value}")));
         }
@@ -762,7 +759,7 @@ fn validate_require_tx_daa_statement_shape<'i>(
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
     ctx.check_expr(expr, Some(&TypeRef { base: TypeBase::Int, array_dims: Vec::new() }))?;
-    if let Ok(value) = eval_const_int(expr, ctx.constants) {
+    if let Some(value) = eval_optional_const_int(expr, ctx.constants)? {
         let lock_time_threshold = kaspa_txscript::LOCK_TIME_THRESHOLD as i64;
         if !(0..lock_time_threshold).contains(&value) {
             return Err(CompilerError::Unsupported(format!(
@@ -778,7 +775,7 @@ fn validate_require_tx_time_statement_shape<'i>(
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
     ctx.check_expr(expr, Some(&TypeRef { base: TypeBase::Temporal, array_dims: Vec::new() }))?;
-    if let Ok(value) = eval_const_int(expr, ctx.constants) {
+    if let Some(value) = eval_optional_const_int(expr, ctx.constants)? {
         let lock_time_threshold = kaspa_txscript::LOCK_TIME_THRESHOLD as i64;
         if value < lock_time_threshold {
             return Err(CompilerError::Unsupported(format!(
@@ -928,7 +925,7 @@ fn validate_struct_destructure_bindings<'i>(
         let Some(binding) = bindings.iter().find(|binding| binding.field_name == field.name) else {
             return Err(CompilerError::Unsupported("struct destructuring must bind all fields exactly once".to_string()));
         };
-        if !type_refs_equal(&binding.type_ref, &field.type_ref, constants) {
+        if !type_refs_equal(&binding.type_ref, &field.type_ref, constants)? {
             return Err(CompilerError::Unsupported(format!("struct field '{}' expects {}", field.name, field.type_ref.type_name())));
         }
         if let Some(state_reader) = state_reader
@@ -1004,7 +1001,7 @@ fn map_declared_type_error<'i>(
     constants: &HashMap<String, Expr<'i>>,
 ) -> CompilerError {
     match err {
-        CompilerError::Unsupported(message) if message == "type mismatch" => {
+        CompilerError::TypeMismatch => {
             let hint = expr_matches_return_type_hint(expr, type_ref, types, structs, constants)
                 .map(|hint| format!("; {hint}"))
                 .unwrap_or_default();
@@ -1046,7 +1043,7 @@ fn fixed_type_size_with_structs<'i>(
 ) -> Result<Option<usize>, CompilerError> {
     if type_ref.is_array() {
         let Some(element_type) = type_ref.array_element_type() else { return Ok(None) };
-        let Some(array_len) = array_type_size(type_ref, constants) else { return Ok(None) };
+        let Some(array_len) = array_type_size(type_ref, constants)? else { return Ok(None) };
         let Some(element_size) = fixed_type_size_with_structs(&element_type, structs, constants)? else { return Ok(None) };
         return checked_mul(element_size, array_len).map(Some);
     }

--- a/silverscript-lang/src/compiler/structs.rs
+++ b/silverscript-lang/src/compiler/structs.rs
@@ -27,7 +27,7 @@ use declaration::lower_variable_definition;
 use destructure::lower_struct_destructure_statement;
 use expr_lowering::{
     flatten_named_type, flatten_runtime_return_exprs, lower_call_args, lower_expr, lower_function_call_bindings, lower_named_expr,
-    lower_struct_array_expr,
+    lower_struct_array_expr, lower_struct_expr,
 };
 use layout::flatten_struct_fields;
 pub use layout::flattened_struct_name;

--- a/silverscript-lang/src/compiler/structs.rs
+++ b/silverscript-lang/src/compiler/structs.rs
@@ -36,8 +36,8 @@ use scalar_expr::lower_scalar_expr;
 pub(crate) use scalar_expr::resolve_struct_access;
 use schema::is_struct_like;
 pub(crate) use schema::{
-    StructRegistry, build_struct_registry, ensure_known_struct_or_builtin_type, is_struct, is_struct_array, struct_array_name,
-    struct_name, validate_struct_graph,
+    StructRegistry, build_struct_registry, ensure_known_type, ensure_known_type_without_struct_arrays, is_struct, is_struct_array,
+    struct_array_name, struct_name, validate_struct_graph,
 };
 use statement::lower_statements;
 

--- a/silverscript-lang/src/compiler/structs/expr_lowering.rs
+++ b/silverscript-lang/src/compiler/structs/expr_lowering.rs
@@ -15,7 +15,7 @@ pub(super) fn lower_expr<'i>(
     Ok(vec![lower_scalar_expr(expr, scope, lowerer)?])
 }
 
-fn lower_struct_expr<'i>(
+pub(super) fn lower_struct_expr<'i>(
     expr: &Expr<'i>,
     expected_type: &TypeRef,
     scope: &LoweringScope,
@@ -77,6 +77,7 @@ fn lower_struct_expr<'i>(
             Ok(flattened)
         }
         ExprKind::ArrayIndex { source, index } => {
+            // TODO: Support indexing any struct-array expression, not only an identifier.
             let source_type = match &source.kind {
                 ExprKind::Identifier(name) => scope
                     .vars

--- a/silverscript-lang/src/compiler/structs/scalar_expr.rs
+++ b/silverscript-lang/src/compiler/structs/scalar_expr.rs
@@ -80,12 +80,10 @@ pub(super) fn lower_scalar_expr<'i>(
                 let left_type = struct_array_expr_type(left, scope, structs, lowerer.contract_constants)?;
                 let right_type = struct_array_expr_type(right, scope, structs, lowerer.contract_constants)?;
                 if let Some(expected_type) = left_type.as_ref().or(right_type.as_ref()) {
-                    if left_type
-                        .as_ref()
-                        .zip(right_type.as_ref())
-                        .is_some_and(|(left, right)| !type_refs_equal(left, right, lowerer.contract_constants))
-                    {
-                        return Err(CompilerError::Unsupported("struct array comparison requires matching types".to_string()));
+                    if let Some((left, right)) = left_type.as_ref().zip(right_type.as_ref()) {
+                        if !type_refs_equal(left, right, lowerer.contract_constants)? {
+                            return Err(CompilerError::Unsupported("struct array comparison requires matching types".to_string()));
+                        }
                     }
                     let left_leaves = lower_struct_array_expr(left, expected_type, scope, lowerer)?;
                     let right_leaves = lower_struct_array_expr(right, expected_type, scope, lowerer)?;

--- a/silverscript-lang/src/compiler/structs/scalar_expr.rs
+++ b/silverscript-lang/src/compiler/structs/scalar_expr.rs
@@ -214,8 +214,10 @@ fn struct_array_expr_type(
     let type_ref = match &expr.kind {
         ExprKind::Identifier(name) => scope.type_of(name).cloned(),
         ExprKind::Array { type_ref, .. } => Some(type_ref.clone()),
-        ExprKind::Append { source, args, .. } => struct_array_expr_type(source, scope, structs, constants)?
-            .and_then(|source_type| append_type(&source_type, args.len(), constants)),
+        ExprKind::Append { source, args, .. } => {
+            let Some(source_type) = struct_array_expr_type(source, scope, structs, constants)? else { return Ok(None) };
+            append_type(&source_type, args.len(), constants)?
+        }
         ExprKind::Split { source, index, part, .. } => struct_array_expr_type(source, scope, structs, constants)?
             .map(|source_type| crate::compiler::type_check::split_part_type(&source_type, index, *part, constants))
             .transpose()?,

--- a/silverscript-lang/src/compiler/structs/scalar_expr.rs
+++ b/silverscript-lang/src/compiler/structs/scalar_expr.rs
@@ -77,16 +77,16 @@ pub(super) fn lower_scalar_expr<'i>(
         }
         ExprKind::Binary { op, left, right } => {
             if matches!(op, BinaryOp::Eq | BinaryOp::Ne) {
-                let left_type = struct_array_expr_type(left, scope, structs, lowerer.contract_constants)?;
-                let right_type = struct_array_expr_type(right, scope, structs, lowerer.contract_constants)?;
+                let left_type = scalar_struct_expr_type(left, scope, structs);
+                let right_type = scalar_struct_expr_type(right, scope, structs);
                 if let Some(expected_type) = left_type.as_ref().or(right_type.as_ref()) {
                     if let Some((left, right)) = left_type.as_ref().zip(right_type.as_ref()) {
                         if !type_refs_equal(left, right, lowerer.contract_constants)? {
-                            return Err(CompilerError::Unsupported("struct array comparison requires matching types".to_string()));
+                            return Err(CompilerError::Unsupported("struct comparison requires matching types".to_string()));
                         }
                     }
-                    let left_leaves = lower_struct_array_expr(left, expected_type, scope, lowerer)?;
-                    let right_leaves = lower_struct_array_expr(right, expected_type, scope, lowerer)?;
+                    let left_leaves = lower_struct_expr(left, expected_type, scope, lowerer)?;
+                    let right_leaves = lower_struct_expr(right, expected_type, scope, lowerer)?;
                     let comparison_op = *op;
                     let combination_op = if *op == BinaryOp::Eq { BinaryOp::And } else { BinaryOp::Or };
                     let comparisons = left_leaves.into_iter().zip(right_leaves).map(|(left, right)| {
@@ -96,7 +96,7 @@ pub(super) fn lower_scalar_expr<'i>(
                         .reduce(|left, right| {
                             Expr::new(ExprKind::Binary { op: combination_op, left: Box::new(left), right: Box::new(right) }, span)
                         })
-                        .ok_or_else(|| CompilerError::Unsupported("cannot compare empty struct arrays".to_string()));
+                        .ok_or_else(|| CompilerError::Unsupported("cannot compare empty structs".to_string()));
                 }
             }
 
@@ -201,6 +201,21 @@ pub(super) fn lower_scalar_expr<'i>(
         }
         _ => Ok(expr.clone()),
     }
+}
+
+fn scalar_struct_expr_type(expr: &Expr<'_>, scope: &LoweringScope, structs: &StructRegistry) -> Option<TypeRef> {
+    let type_ref = match &expr.kind {
+        ExprKind::Identifier(name) => scope.type_of(name).cloned(),
+        ExprKind::StructLiteral { name, .. } => Some(TypeRef { base: TypeBase::Custom(name.clone()), array_dims: Vec::new() }),
+        ExprKind::FieldAccess { .. } => resolve_struct_access(expr, scope, structs).ok().map(|(_, _, type_ref)| type_ref),
+        // TODO: Support indexing any struct-array expression, not only an identifier.
+        ExprKind::ArrayIndex { source, .. } => match &source.kind {
+            ExprKind::Identifier(name) => scope.type_of(name).and_then(TypeRef::array_element_type),
+            _ => None,
+        },
+        _ => None,
+    };
+    type_ref.filter(|type_ref| is_struct(type_ref, structs))
 }
 
 fn struct_array_expr_type(

--- a/silverscript-lang/src/compiler/structs/schema.rs
+++ b/silverscript-lang/src/compiler/structs/schema.rs
@@ -79,25 +79,33 @@ pub(super) fn is_struct_like(type_ref: &TypeRef, structs: &StructRegistry) -> bo
     is_struct(type_ref, structs) || is_struct_array(type_ref, structs)
 }
 
-pub(crate) fn ensure_known_struct_or_builtin_type(
+pub(crate) fn ensure_known_type_without_struct_arrays(
     type_ref: &TypeRef,
     structs: &StructRegistry,
     context: &str,
 ) -> Result<(), CompilerError> {
+    ensure_known_type(type_ref, structs, context)?;
     if !type_ref.is_array() {
-        match &type_ref.base {
-            TypeBase::Custom(name) if !structs.contains_key(name) => {
-                return Err(CompilerError::Unsupported(format!("unknown type '{}' in {context}", name)));
-            }
-            _ => {}
-        }
+        return Ok(());
     } else if let TypeBase::Custom(name) = &type_ref.base {
-        if structs.contains_key(name) {
-            return Err(CompilerError::Unsupported(format!("arrays of struct type '{}' are not supported", name)));
-        }
-        return Err(CompilerError::Unsupported(format!("unknown type '{}' in {context}", name)));
+        return Err(CompilerError::Unsupported(format!("arrays of struct type '{}' are not supported", name)));
     }
     Ok(())
+}
+
+pub(crate) fn ensure_known_type(type_ref: &TypeRef, structs: &StructRegistry, context: &str) -> Result<(), CompilerError> {
+    match &type_ref.base {
+        TypeBase::Custom(name) if !structs.contains_key(name) => {
+            Err(CompilerError::Unsupported(format!("unknown type '{}' in {context}", name)))
+        }
+        TypeBase::Tuple(elements) => {
+            for element in elements {
+                ensure_known_type(element, structs, context)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
 }
 
 pub(crate) fn validate_struct_graph(structs: &StructRegistry) -> Result<(), CompilerError> {
@@ -115,7 +123,7 @@ pub(crate) fn validate_struct_graph(structs: &StructRegistry) -> Result<(), Comp
         }
         let item = structs.get(name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{name}'")))?;
         for field in &item.fields {
-            ensure_known_struct_or_builtin_type(&field.type_ref, structs, "struct field")?;
+            ensure_known_type_without_struct_arrays(&field.type_ref, structs, "struct field")?;
             if let Some(child) = struct_name(&field.type_ref, structs) {
                 visit(child, structs, visiting, visited)?;
             }

--- a/silverscript-lang/src/compiler/ternary.rs
+++ b/silverscript-lang/src/compiler/ternary.rs
@@ -475,7 +475,7 @@ impl<'a, 'i> TernaryLowerer<'a, 'i> {
                 .ok_or_else(|| CompilerError::Unsupported("ternary result array element type is missing".to_string()))?;
             let len = match type_ref.array_size() {
                 Some(ArrayDim::Dynamic) => 0,
-                Some(ArrayDim::Fixed(_) | ArrayDim::Constant(_)) => array_type_size(type_ref, self.constants)
+                Some(ArrayDim::Fixed(_) | ArrayDim::Constant(_)) => array_type_size(type_ref, self.constants)?
                     .ok_or_else(|| CompilerError::Unsupported(format!("cannot determine size of {}", type_ref.type_name())))?,
                 Some(ArrayDim::Inferred) | None => {
                     return Err(CompilerError::Unsupported(format!("cannot create default {}", type_ref.type_name())));

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -11,7 +11,7 @@ use super::builtin_types::{
 };
 use super::structs::{StructRegistry, flattened_struct_field_specs_for_type, is_struct, struct_name};
 use super::{
-    CompilerError, STATE_TYPE_NAME, TypeMap, append_type, array_type_size, concat_types, eval_const_int, fixed_type_size,
+    CompilerError, STATE_TYPE_NAME, TypeMap, append_type, array_type_size, concat_types, eval_optional_const_int, fixed_type_size,
     parse_type_ref, type_refs_equal,
 };
 
@@ -109,7 +109,7 @@ pub(super) fn check_expr<'i>(
             } else {
                 let then_type = check_expr(then_expr, None, ctx)?;
                 let else_type = check_expr(else_expr, None, ctx)?;
-                if !type_refs_equal(&then_type, &else_type, ctx.constants) {
+                if !type_refs_equal(&then_type, &else_type, ctx.constants)? {
                     return Err(CompilerError::Unsupported(format!(
                         "ternary branch type mismatch: then expression is {}, else expression is {}",
                         then_type.type_name(),
@@ -182,10 +182,10 @@ fn check_typed_array_literal<'i>(
         .ok_or_else(|| CompilerError::Unsupported("array literal requires an array type".to_string()))?;
     check_array_literal_with_element_type(values, &literal_element_type, ctx)
         .map_err(|_| CompilerError::Unsupported("array element type mismatch".to_string()))?;
-    if let Some(literal_size) = array_type_size(literal_type, ctx.constants)
+    if let Some(literal_size) = array_type_size(literal_type, ctx.constants)?
         && literal_size != values.len()
     {
-        return Err(CompilerError::Unsupported("size mismatch".to_string()));
+        return Err(CompilerError::SizeMismatch);
     }
 
     if let Some(expected) = expected {
@@ -197,11 +197,10 @@ fn check_typed_array_literal<'i>(
             {
                 return Ok(expected.clone());
             }
-            return Err(CompilerError::Unsupported("type mismatch".to_string()));
+            return Err(CompilerError::TypeMismatch);
         }
-        let expected_element_type =
-            expected.array_element_type().ok_or_else(|| CompilerError::Unsupported("type mismatch".to_string()))?;
-        if !type_refs_equal(&literal_element_type, &expected_element_type, ctx.constants) {
+        let expected_element_type = expected.array_element_type().ok_or(CompilerError::TypeMismatch)?;
+        if !type_refs_equal(&literal_element_type, &expected_element_type, ctx.constants)? {
             if let (TypeBase::Custom(expected_name), TypeBase::Custom(actual_name)) =
                 (&expected_element_type.base, &literal_element_type.base)
             {
@@ -210,15 +209,15 @@ fn check_typed_array_literal<'i>(
             return Err(CompilerError::Unsupported("array element type mismatch".to_string()));
         }
         if expected.is_dynamic_array() && !literal_type.is_dynamic_array() {
-            return Err(CompilerError::Unsupported("type mismatch".to_string()));
+            return Err(CompilerError::TypeMismatch);
         }
-        if array_type_size(expected, ctx.constants).is_some() && literal_type.is_dynamic_array() {
-            return Err(CompilerError::Unsupported("type mismatch".to_string()));
+        if array_type_size(expected, ctx.constants)?.is_some() && literal_type.is_dynamic_array() {
+            return Err(CompilerError::TypeMismatch);
         }
-        if let Some(expected_size) = array_type_size(expected, ctx.constants)
+        if let Some(expected_size) = array_type_size(expected, ctx.constants)?
             && expected_size != values.len()
         {
-            return Err(CompilerError::Unsupported("size mismatch".to_string()));
+            return Err(CompilerError::SizeMismatch);
         }
         return Ok(expected.clone());
     }
@@ -269,7 +268,7 @@ pub(super) fn check_call<'i>(
         let size = if cast_type.is_byte() {
             1
         } else {
-            array_type_size(&cast_type, ctx.constants)
+            array_type_size(&cast_type, ctx.constants)?
                 .ok_or_else(|| CompilerError::Unsupported("byte size in 'as byte[N]' must be known at compile time".to_string()))?
         };
         if size == 0 || size > 8 {
@@ -366,7 +365,7 @@ fn validate_scalar_cast_compatibility<'i>(
         source_type.is_int_like()
             || matches!(source_type.base, TypeBase::Byte)
                 && source_type.array_dims.len() == 1
-                && array_type_size(source_type, constants).is_some_and(|size| size <= 8)
+                && array_type_size(source_type, constants)?.is_some_and(|size| size <= 8)
     } else if cast_type.is_temporal() {
         source_type.is_int_like()
     } else if cast_type.is_bool() {
@@ -484,7 +483,7 @@ fn check_binary<'i>(
             Ok(scalar_type(TypeBase::Bool))
         }
         BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => {
-            if !left_type.is_int_like() || !type_refs_equal(&left_type, &right_type, ctx.constants) {
+            if !left_type.is_int_like() || !type_refs_equal(&left_type, &right_type, ctx.constants)? {
                 return Err(CompilerError::Unsupported(format!(
                     "ordered comparison requires matching int or temporal operands, got {} and {}",
                     left_type.type_name(),
@@ -515,7 +514,7 @@ fn check_binary<'i>(
                     right_type.type_name()
                 )));
             }
-            if !type_refs_equal(&left_type, &right_type, ctx.constants) {
+            if !type_refs_equal(&left_type, &right_type, ctx.constants)? {
                 return Err(CompilerError::Unsupported(format!(
                     "bitwise operations require byte arrays of equal size, got {} and {}",
                     left_type.type_name(),
@@ -525,7 +524,7 @@ fn check_binary<'i>(
             Ok(left_type)
         }
         BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod => {
-            if !left_type.is_int_like() || !type_refs_equal(&left_type, &right_type, ctx.constants) {
+            if !left_type.is_int_like() || !type_refs_equal(&left_type, &right_type, ctx.constants)? {
                 return Err(CompilerError::Unsupported(format!(
                     "arithmetic requires matching int or temporal operands, got {} and {}",
                     left_type.type_name(),
@@ -580,10 +579,13 @@ fn ensure_expected<'i>(
     expected: Option<&TypeRef>,
     constants: &HashMap<String, Expr<'i>>,
 ) -> Result<(), CompilerError> {
-    if expected.is_none_or(|expected| type_refs_equal(actual, expected, constants)) {
+    if match expected {
+        Some(expected) => type_refs_equal(actual, expected, constants)?,
+        None => true,
+    } {
         Ok(())
     } else {
-        Err(CompilerError::Unsupported("type mismatch".to_string()))
+        Err(CompilerError::TypeMismatch)
     }
 }
 
@@ -611,8 +613,8 @@ fn sequence_part_type(type_ref: &TypeRef, operation: &str) -> Result<TypeRef, Co
     Err(CompilerError::Unsupported(format!("{operation} source must be an array, string, or fixed-byte type")))
 }
 
-fn known_sequence_length<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
-    array_type_size(type_ref, constants).or_else(|| type_ref.base.fixed_byte_sequence_len())
+fn known_sequence_length<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Result<Option<usize>, CompilerError> {
+    Ok(array_type_size(type_ref, constants)?.or_else(|| type_ref.base.fixed_byte_sequence_len()))
 }
 
 fn validate_constant_sequence_index<'i>(
@@ -622,11 +624,11 @@ fn validate_constant_sequence_index<'i>(
     source_type: &TypeRef,
     constants: &HashMap<String, Expr<'i>>,
 ) -> Result<Option<i64>, CompilerError> {
-    let Ok(index) = eval_const_int(index, constants) else { return Ok(None) };
+    let Some(index) = eval_optional_const_int(index, constants)? else { return Ok(None) };
     if index < 0 {
         return Err(CompilerError::Unsupported(format!("{operation} {index_name} {index} is out of bounds")));
     }
-    if let Some(source_size) = known_sequence_length(source_type, constants)
+    if let Some(source_size) = known_sequence_length(source_type, constants)?
         && usize::try_from(index).is_ok_and(|index| index > source_size)
     {
         return Err(CompilerError::Unsupported(format!(

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -537,6 +537,16 @@ fn check_binary<'i>(
                     left_type.type_name()
                 )));
             }
+            if is_struct(&left_type, ctx.structs) {
+                for leaf_type in flattened_struct_field_specs_for_type(&left_type, ctx.structs)? {
+                    if leaf_type.is_array() && !supports_array_comparison(&leaf_type) {
+                        return Err(CompilerError::Unsupported(format!(
+                            "struct comparison is not supported for field type {}",
+                            leaf_type.type_name()
+                        )));
+                    }
+                }
+            }
             Ok(scalar_type(TypeBase::Bool))
         }
         BinaryOp::Lt | BinaryOp::Le | BinaryOp::Gt | BinaryOp::Ge => {

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -323,19 +323,10 @@ pub(super) fn check_call<'i>(
                 cast_type.type_name()
             )));
         }
-        validate_scalar_cast_compatibility(&cast_type, &source_type, ctx.constants)?;
-        if cast_type.is_array() || cast_type.base.fixed_byte_sequence_len().is_some() {
-            let target_size = fixed_type_size(&cast_type, ctx.constants)?;
-            let source_size = known_cast_source_size(&args[0], &source_type, ctx.constants)?;
-            if let (Some(target_size), Some(source_size)) = (target_size, source_size)
-                && target_size != source_size
-            {
-                return Err(CompilerError::Unsupported(format!(
-                    "cannot cast {} to {}",
-                    source_type.type_name(),
-                    cast_type.type_name()
-                )));
-            }
+        if cast_type.is_array() {
+            validate_array_cast_compatibility(&cast_type, &args[0], &source_type, ctx.constants)?;
+        } else {
+            validate_scalar_cast_compatibility(&cast_type, &source_type, ctx.constants)?;
         }
         return Ok(Some(cast_type));
     }
@@ -370,24 +361,90 @@ fn validate_scalar_cast_compatibility<'i>(
         source_type.is_int_like()
     } else if cast_type.is_bool() {
         source_type.is_byte()
+    } else if cast_type.is_byte() {
+        // Integer sources have already been restricted above to in-range
+        // literals. All other scalar byte casts must preserve a one-byte
+        // runtime representation.
+        source_type.is_byte() || source_type.is_int()
     } else if cast_type.is_string() {
         source_type.is_string()
             || source_type.is_byte()
             || matches!(source_type.base, TypeBase::Byte) && source_type.is_array()
             || source_type.base.fixed_byte_sequence_len().is_some()
-    } else if cast_type.base.fixed_byte_sequence_len().is_some() {
-        source_type.is_byte()
-            || source_type.is_array()
-            || source_type.is_string()
-            || source_type.base.fixed_byte_sequence_len().is_some()
+    } else if let Some(target_size) = cast_type.base.fixed_byte_sequence_len() {
+        // A dynamic byte array may be asserted as a fixed-byte scalar because
+        // its length is not known statically. A statically sized source is
+        // accepted only when its size matches the scalar's encoded width.
+        let compatible_source = source_type.is_byte()
+            || matches!(source_type.base, TypeBase::Byte) && source_type.array_dims.len() == 1
+            || source_type.base.fixed_byte_sequence_len().is_some();
+        compatible_source && fixed_type_size(source_type, constants)?.is_none_or(|source_size| source_size == target_size)
     } else {
-        true
+        false
     };
-    if compatible {
-        Ok(())
-    } else {
-        Err(CompilerError::Unsupported(format!("cannot cast {} to {}", source_type.type_name(), cast_type.type_name())))
+    if !compatible {
+        return Err(CompilerError::Unsupported(format!("cannot cast {} to {}", source_type.type_name(), cast_type.type_name())));
     }
+    Ok(())
+}
+
+fn validate_array_cast_compatibility<'i>(
+    cast_type: &TypeRef,
+    source_expr: &Expr<'i>,
+    source_type: &TypeRef,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<(), CompilerError> {
+    // `byte[]`, `byte[N]`, and `byte[_]` are universal representation-cast
+    // targets: any source type may be viewed as a flat byte sequence. This
+    // only grants type compatibility; the size check below still rejects known
+    // fixed-size mismatches (for example, byte[32] to byte[31]).
+    let compatible = if matches!(cast_type.base, TypeBase::Byte) && cast_type.array_dims.len() == 1 {
+        true
+    // Supported same-rank array dimension casts:
+    // - Arrays may change dimension specificity.
+    // - The source and target must have the same base type and number of dimensions.
+    // - Dynamic and inferred dimensions may be cast to or from fixed dimensions.
+    // - Fixed and constant dimensions must resolve to the same size.
+    } else if source_type.is_array()
+        && cast_type.base == source_type.base
+        && cast_type.array_dims.len() == source_type.array_dims.len()
+        && array_dimensions_are_compatible(source_type, cast_type, constants)?
+    {
+        true
+    } else {
+        false
+    };
+    if !compatible {
+        return Err(CompilerError::Unsupported(format!("cannot cast {} to {}", source_type.type_name(), cast_type.type_name())));
+    }
+    let target_size = fixed_type_size(cast_type, constants)?;
+    let source_size = known_cast_source_size(source_expr, source_type, constants)?;
+    if let (Some(target_size), Some(source_size)) = (target_size, source_size)
+        && target_size != source_size
+    {
+        return Err(CompilerError::Unsupported(format!("cannot cast {} to {}", source_type.type_name(), cast_type.type_name())));
+    }
+    Ok(())
+}
+
+fn array_dimensions_are_compatible<'i>(
+    source_type: &TypeRef,
+    cast_type: &TypeRef,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<bool, CompilerError> {
+    for (source_dimension, cast_dimension) in source_type.array_dims.iter().zip(&cast_type.array_dims) {
+        let matching = type_refs_equal(
+            &TypeRef { base: TypeBase::Byte, array_dims: vec![source_dimension.clone()] },
+            &TypeRef { base: TypeBase::Byte, array_dims: vec![cast_dimension.clone()] },
+            constants,
+        )?;
+        let unspecified = matches!(source_dimension, ArrayDim::Dynamic | ArrayDim::Inferred)
+            || matches!(cast_dimension, ArrayDim::Dynamic | ArrayDim::Inferred);
+        if !matching && !unspecified {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
 fn known_cast_source_size<'i>(

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -398,22 +398,17 @@ fn validate_array_cast_compatibility<'i>(
     // targets: any source type may be viewed as a flat byte sequence. This
     // only grants type compatibility; the size check below still rejects known
     // fixed-size mismatches (for example, byte[32] to byte[31]).
-    let compatible = if matches!(cast_type.base, TypeBase::Byte) && cast_type.array_dims.len() == 1 {
-        true
+    let is_flat_byte_target = matches!(cast_type.base, TypeBase::Byte) && cast_type.array_dims.len() == 1;
     // Supported same-rank array dimension casts:
     // - Arrays may change dimension specificity.
     // - The source and target must have the same base type and number of dimensions.
     // - Dynamic and inferred dimensions may be cast to or from fixed dimensions.
     // - Fixed and constant dimensions must resolve to the same size.
-    } else if source_type.is_array()
-        && cast_type.base == source_type.base
-        && cast_type.array_dims.len() == source_type.array_dims.len()
-        && array_dimensions_are_compatible(source_type, cast_type, constants)?
-    {
-        true
-    } else {
-        false
-    };
+    let compatible = is_flat_byte_target
+        || source_type.is_array()
+            && cast_type.base == source_type.base
+            && cast_type.array_dims.len() == source_type.array_dims.len()
+            && array_dimensions_are_compatible(source_type, cast_type, constants)?;
     if !compatible {
         return Err(CompilerError::Unsupported(format!("cannot cast {} to {}", source_type.type_name(), cast_type.type_name())));
     }

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -64,7 +64,7 @@ pub(super) fn check_expr<'i>(
                     CompilerError::Unsupported(format!("array append element type mismatch: expected {}", element_type.type_name()))
                 })?;
             }
-            append_type(&source_type, args.len(), ctx.constants)
+            append_type(&source_type, args.len(), ctx.constants)?
                 .ok_or_else(|| CompilerError::Unsupported("cannot determine appended array type".to_string()))?
         }
         ExprKind::ArrayIndex { source, index } => {
@@ -201,10 +201,10 @@ fn check_typed_array_literal<'i>(
             }
             return Err(CompilerError::Unsupported("array element type mismatch".to_string()));
         }
-        if matches!(expected.array_size(), Some(ArrayDim::Dynamic)) && !matches!(literal_type.array_size(), Some(ArrayDim::Dynamic)) {
+        if expected.is_dynamic_array() && !literal_type.is_dynamic_array() {
             return Err(CompilerError::Unsupported("type mismatch".to_string()));
         }
-        if array_type_size(expected, ctx.constants).is_some() && matches!(literal_type.array_size(), Some(ArrayDim::Dynamic)) {
+        if array_type_size(expected, ctx.constants).is_some() && literal_type.is_dynamic_array() {
             return Err(CompilerError::Unsupported("type mismatch".to_string()));
         }
         if let Some(expected_size) = array_type_size(expected, ctx.constants)
@@ -317,12 +317,18 @@ pub(super) fn check_call<'i>(
             )));
         }
         validate_scalar_cast_compatibility(&cast_type, &source_type, ctx.constants)?;
-        if (cast_type.is_array() || cast_type.base.fixed_byte_sequence_len().is_some())
-            && let (Some(target_size), Some(source_size)) =
-                (fixed_type_size(&cast_type, ctx.constants), known_cast_source_size(&args[0], &source_type, ctx.constants))
-            && target_size != source_size
-        {
-            return Err(CompilerError::Unsupported(format!("cannot cast {} to {}", source_type.type_name(), cast_type.type_name())));
+        if cast_type.is_array() || cast_type.base.fixed_byte_sequence_len().is_some() {
+            let target_size = fixed_type_size(&cast_type, ctx.constants)?;
+            let source_size = known_cast_source_size(&args[0], &source_type, ctx.constants)?;
+            if let (Some(target_size), Some(source_size)) = (target_size, source_size)
+                && target_size != source_size
+            {
+                return Err(CompilerError::Unsupported(format!(
+                    "cannot cast {} to {}",
+                    source_type.type_name(),
+                    cast_type.type_name()
+                )));
+            }
         }
         return Ok(Some(cast_type));
     }
@@ -377,11 +383,15 @@ fn validate_scalar_cast_compatibility<'i>(
     }
 }
 
-fn known_cast_source_size<'i>(expr: &Expr<'i>, source_type: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
-    fixed_type_size(source_type, constants).or(match &expr.kind {
+fn known_cast_source_size<'i>(
+    expr: &Expr<'i>,
+    source_type: &TypeRef,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<Option<usize>, CompilerError> {
+    Ok(fixed_type_size(source_type, constants)?.or(match &expr.kind {
         ExprKind::String(value) => Some(value.len()),
         _ => None,
-    })
+    }))
 }
 
 fn check_g16_verify_args<'i>(args: &[Expr<'i>], ctx: &TypeCheckContext<'_, 'i>) -> Result<(), CompilerError> {
@@ -481,7 +491,7 @@ fn check_binary<'i>(
             ensure_expected(&right_type, Some(&bool_type), ctx.constants)?;
             Ok(bool_type)
         }
-        BinaryOp::Add if left_type.is_array() && right_type.is_array() => concat_types(&left_type, &right_type, ctx.constants)
+        BinaryOp::Add if left_type.is_array() && right_type.is_array() => concat_types(&left_type, &right_type, ctx.constants)?
             .ok_or_else(|| CompilerError::Unsupported("array concatenation requires identical element types".to_string())),
         BinaryOp::Add if left_type.is_string() && right_type.is_string() => Ok(scalar_type(TypeBase::String)),
         BinaryOp::BitOr | BinaryOp::BitXor | BinaryOp::BitAnd => {

--- a/silverscript-lang/src/compiler/type_check.rs
+++ b/silverscript-lang/src/compiler/type_check.rs
@@ -23,6 +23,14 @@ pub(super) struct TypeCheckContext<'a, 'i> {
     pub contract_fields: &'a [ContractFieldAst<'i>],
 }
 
+/// Determines an expression's type using the canonical type checker.
+///
+/// TODO: Have static checking produce a typed IR whose type annotations are preserved through lowering, so later passes do not
+/// need to re-check expressions merely to recover their types.
+pub(super) fn infer_expr_type<'i>(expr: &Expr<'i>, ctx: &TypeCheckContext<'_, 'i>) -> Result<TypeRef, CompilerError> {
+    check_expr(expr, None, ctx)
+}
+
 pub(super) fn check_expr<'i>(
     expr: &Expr<'i>,
     expected: Option<&TypeRef>,

--- a/silverscript-lang/src/compiler/type_system.rs
+++ b/silverscript-lang/src/compiler/type_system.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
 use crate::ast::{ArrayDim, Expr, TypeBase, TypeRef};
+use crate::checked_arithmetic::{checked_add, checked_mul};
+use crate::errors::CompilerError;
 
 use super::eval_const_int;
 
@@ -23,43 +25,63 @@ pub(crate) fn array_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Exp
     dimension_value(type_ref.array_size()?, constants)
 }
 
-pub(crate) fn fixed_type_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
+pub(crate) fn fixed_type_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Result<Option<usize>, CompilerError> {
     if type_ref.is_array() {
-        let element_type = type_ref.array_element_type()?;
-        return fixed_type_size(&element_type, constants)?.checked_mul(array_size(type_ref, constants)?);
+        let Some(element_type) = type_ref.array_element_type() else { return Ok(None) };
+        let Some(element_size) = fixed_type_size(&element_type, constants)? else { return Ok(None) };
+        let Some(array_len) = array_size(type_ref, constants) else { return Ok(None) };
+        return checked_mul(element_size, array_len).map(Some);
     }
 
-    match type_ref.base {
+    Ok(match type_ref.base {
         TypeBase::Int | TypeBase::Temporal => Some(8),
         TypeBase::Bool | TypeBase::Byte => Some(1),
         TypeBase::Pubkey | TypeBase::Sig | TypeBase::Datasig => type_ref.base.fixed_byte_sequence_len(),
         TypeBase::String | TypeBase::Tuple(_) | TypeBase::Custom(_) => None,
-    }
+    })
 }
 
-pub(crate) fn concat_types<'i>(left: &TypeRef, right: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<TypeRef> {
-    let element = left.array_element_type()?;
-    if !type_refs_equal(&element, &right.array_element_type()?, constants) {
-        return None;
+pub(crate) fn concat_types<'i>(
+    left: &TypeRef,
+    right: &TypeRef,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<Option<TypeRef>, CompilerError> {
+    let Some(element) = left.array_element_type() else { return Ok(None) };
+    let Some(right_element) = right.array_element_type() else { return Ok(None) };
+    if !type_refs_equal(&element, &right_element, constants) {
+        return Ok(None);
     }
 
-    let dimension = match (left.array_size()?, right.array_size()?) {
+    let Some(left_dimension) = left.array_size() else { return Ok(None) };
+    let Some(right_dimension) = right.array_size() else { return Ok(None) };
+    let dimension = match (left_dimension, right_dimension) {
         (ArrayDim::Dynamic, _) | (_, ArrayDim::Dynamic) => ArrayDim::Dynamic,
-        (left, right) => ArrayDim::Fixed(dimension_value(left, constants)?.checked_add(dimension_value(right, constants)?)?),
+        (left, right) => {
+            let Some(left) = dimension_value(left, constants) else { return Ok(None) };
+            let Some(right) = dimension_value(right, constants) else { return Ok(None) };
+            ArrayDim::Fixed(checked_add(left, right)?)
+        }
     };
     let mut result = element;
     result.array_dims.push(dimension);
-    Some(result)
+    Ok(Some(result))
 }
 
-pub(crate) fn append_type<'i>(source: &TypeRef, appended: usize, constants: &HashMap<String, Expr<'i>>) -> Option<TypeRef> {
+pub(crate) fn append_type<'i>(
+    source: &TypeRef,
+    appended: usize,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<Option<TypeRef>, CompilerError> {
     let mut result = source.clone();
-    let dimension = result.array_dims.last_mut()?;
+    let Some(dimension) = result.array_dims.last_mut() else { return Ok(None) };
     *dimension = match &*dimension {
         ArrayDim::Dynamic => ArrayDim::Dynamic,
-        dimension => ArrayDim::Fixed(dimension_value(dimension, constants)?.checked_add(appended)?),
+        dimension => {
+            let Some(size) = dimension_value(dimension, constants) else { return Ok(None) };
+            ArrayDim::Fixed(checked_add(size, appended)?)
+        }
     };
-    Some(result)
+    Ok(Some(result))
 }
 
 fn dimensions_equal<'i>(left: &ArrayDim, right: &ArrayDim, constants: &HashMap<String, Expr<'i>>) -> bool {
@@ -78,5 +100,30 @@ fn dimension_value<'i>(dimension: &ArrayDim, constants: &HashMap<String, Expr<'i
         ArrayDim::Fixed(size) => Some(*size),
         ArrayDim::Constant(name) => usize::try_from(eval_const_int(constants.get(name)?, constants).ok()?).ok(),
         ArrayDim::Dynamic | ArrayDim::Inferred => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_type_size_reports_multiplication_overflow() {
+        let type_ref = TypeRef { base: TypeBase::Int, array_dims: vec![ArrayDim::Fixed(usize::MAX / 8 + 1)] };
+        let err = fixed_type_size(&type_ref, &HashMap::new()).expect_err("fixed byte-size overflow must be an error");
+
+        assert!(matches!(err, CompilerError::ArithmeticOverflow(_)), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn array_dimension_arithmetic_reports_overflow_instead_of_inference_failure() {
+        let max = TypeRef { base: TypeBase::Int, array_dims: vec![ArrayDim::Fixed(usize::MAX)] };
+        let one = TypeRef { base: TypeBase::Int, array_dims: vec![ArrayDim::Fixed(1)] };
+
+        let concat_err = concat_types(&max, &one, &HashMap::new()).expect_err("concatenated dimension must overflow");
+        assert!(matches!(concat_err, CompilerError::ArithmeticOverflow(_)), "unexpected error: {concat_err}");
+
+        let append_err = append_type(&max, 1, &HashMap::new()).expect_err("appended dimension must overflow");
+        assert!(matches!(append_err, CompilerError::ArithmeticOverflow(_)), "unexpected error: {append_err}");
     }
 }

--- a/silverscript-lang/src/compiler/type_system.rs
+++ b/silverscript-lang/src/compiler/type_system.rs
@@ -6,30 +6,49 @@ use crate::errors::CompilerError;
 
 use super::eval_const_int;
 
-pub(crate) fn type_refs_equal<'i>(left: &TypeRef, right: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> bool {
-    bases_equal(&left.base, &right.base, constants)
-        && left.array_dims.len() == right.array_dims.len()
-        && left.array_dims.iter().zip(&right.array_dims).all(|(left, right)| dimensions_equal(left, right, constants))
+pub(crate) fn type_refs_equal<'i>(
+    left: &TypeRef,
+    right: &TypeRef,
+    constants: &HashMap<String, Expr<'i>>,
+) -> Result<bool, CompilerError> {
+    if !bases_equal(&left.base, &right.base, constants)? || left.array_dims.len() != right.array_dims.len() {
+        return Ok(false);
+    }
+    for (left, right) in left.array_dims.iter().zip(&right.array_dims) {
+        if !dimensions_equal(left, right, constants)? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
 }
 
-fn bases_equal<'i>(left: &TypeBase, right: &TypeBase, constants: &HashMap<String, Expr<'i>>) -> bool {
+fn bases_equal<'i>(left: &TypeBase, right: &TypeBase, constants: &HashMap<String, Expr<'i>>) -> Result<bool, CompilerError> {
     match (left, right) {
         (TypeBase::Tuple(left), TypeBase::Tuple(right)) => {
-            left.len() == right.len() && left.iter().zip(right).all(|(left, right)| type_refs_equal(left, right, constants))
+            if left.len() != right.len() {
+                return Ok(false);
+            }
+            for (left, right) in left.iter().zip(right) {
+                if !type_refs_equal(left, right, constants)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
         }
-        _ => left == right,
+        _ => Ok(left == right),
     }
 }
 
-pub(crate) fn array_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
-    dimension_value(type_ref.array_size()?, constants)
+pub(crate) fn array_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Result<Option<usize>, CompilerError> {
+    let Some(dimension) = type_ref.array_size() else { return Ok(None) };
+    dimension_value(dimension, constants)
 }
 
 pub(crate) fn fixed_type_size<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Result<Option<usize>, CompilerError> {
     if type_ref.is_array() {
         let Some(element_type) = type_ref.array_element_type() else { return Ok(None) };
         let Some(element_size) = fixed_type_size(&element_type, constants)? else { return Ok(None) };
-        let Some(array_len) = array_size(type_ref, constants) else { return Ok(None) };
+        let Some(array_len) = array_size(type_ref, constants)? else { return Ok(None) };
         return checked_mul(element_size, array_len).map(Some);
     }
 
@@ -48,7 +67,7 @@ pub(crate) fn concat_types<'i>(
 ) -> Result<Option<TypeRef>, CompilerError> {
     let Some(element) = left.array_element_type() else { return Ok(None) };
     let Some(right_element) = right.array_element_type() else { return Ok(None) };
-    if !type_refs_equal(&element, &right_element, constants) {
+    if !type_refs_equal(&element, &right_element, constants)? {
         return Ok(None);
     }
 
@@ -57,8 +76,8 @@ pub(crate) fn concat_types<'i>(
     let dimension = match (left_dimension, right_dimension) {
         (ArrayDim::Dynamic, _) | (_, ArrayDim::Dynamic) => ArrayDim::Dynamic,
         (left, right) => {
-            let Some(left) = dimension_value(left, constants) else { return Ok(None) };
-            let Some(right) = dimension_value(right, constants) else { return Ok(None) };
+            let Some(left) = dimension_value(left, constants)? else { return Ok(None) };
+            let Some(right) = dimension_value(right, constants)? else { return Ok(None) };
             ArrayDim::Fixed(checked_add(left, right)?)
         }
     };
@@ -77,30 +96,35 @@ pub(crate) fn append_type<'i>(
     *dimension = match &*dimension {
         ArrayDim::Dynamic => ArrayDim::Dynamic,
         dimension => {
-            let Some(size) = dimension_value(dimension, constants) else { return Ok(None) };
+            let Some(size) = dimension_value(dimension, constants)? else { return Ok(None) };
             ArrayDim::Fixed(checked_add(size, appended)?)
         }
     };
     Ok(Some(result))
 }
 
-fn dimensions_equal<'i>(left: &ArrayDim, right: &ArrayDim, constants: &HashMap<String, Expr<'i>>) -> bool {
-    match (left, right) {
+fn dimensions_equal<'i>(left: &ArrayDim, right: &ArrayDim, constants: &HashMap<String, Expr<'i>>) -> Result<bool, CompilerError> {
+    Ok(match (left, right) {
         (ArrayDim::Dynamic, ArrayDim::Dynamic) | (ArrayDim::Inferred, ArrayDim::Inferred) => true,
         (ArrayDim::Dynamic | ArrayDim::Inferred, _) | (_, ArrayDim::Dynamic | ArrayDim::Inferred) => false,
-        _ => match (dimension_value(left, constants), dimension_value(right, constants)) {
-            (Some(left), Some(right)) => left == right,
-            _ => left == right,
-        },
-    }
+        _ => dimension_value(left, constants)? == dimension_value(right, constants)?,
+    })
 }
 
-fn dimension_value<'i>(dimension: &ArrayDim, constants: &HashMap<String, Expr<'i>>) -> Option<usize> {
-    match dimension {
+fn dimension_value<'i>(dimension: &ArrayDim, constants: &HashMap<String, Expr<'i>>) -> Result<Option<usize>, CompilerError> {
+    Ok(match dimension {
         ArrayDim::Fixed(size) => Some(*size),
-        ArrayDim::Constant(name) => usize::try_from(eval_const_int(constants.get(name)?, constants).ok()?).ok(),
+        ArrayDim::Constant(name) => {
+            let expr =
+                constants.get(name).ok_or_else(|| CompilerError::UndefinedIdentifier(format!("array dimension constant '{name}'")))?;
+            let value = eval_const_int(expr, constants)?;
+            Some(
+                usize::try_from(value)
+                    .map_err(|_| CompilerError::InvalidLiteral(format!("array dimension '{name}' must be a non-negative integer")))?,
+            )
+        }
         ArrayDim::Dynamic | ArrayDim::Inferred => None,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -125,5 +149,29 @@ mod tests {
 
         let append_err = append_type(&max, 1, &HashMap::new()).expect_err("appended dimension must overflow");
         assert!(matches!(append_err, CompilerError::ArithmeticOverflow(_)), "unexpected error: {append_err}");
+    }
+
+    #[test]
+    fn invalid_constant_dimensions_are_errors_instead_of_unknown_sizes() {
+        let type_ref = TypeRef { base: TypeBase::Byte, array_dims: vec![ArrayDim::Constant("N".to_string())] };
+
+        let err = array_size(&type_ref, &HashMap::new()).expect_err("a missing dimension constant must not become None");
+        assert!(matches!(err, CompilerError::UndefinedIdentifier(_)), "unexpected error: {err}");
+
+        let negative_constants = HashMap::from([("N".to_string(), Expr::int(-1))]);
+        let err = array_size(&type_ref, &negative_constants).expect_err("a negative dimension must not become None");
+        assert!(matches!(err, CompilerError::InvalidLiteral(_)), "unexpected error: {err}");
+
+        let overflow = Expr::new(
+            crate::ast::ExprKind::Binary {
+                op: crate::ast::BinaryOp::Add,
+                left: Box::new(Expr::int(i64::MAX)),
+                right: Box::new(Expr::int(1)),
+            },
+            Default::default(),
+        );
+        let overflow_constants = HashMap::from([("N".to_string(), overflow)]);
+        let err = fixed_type_size(&type_ref, &overflow_constants).expect_err("dimension overflow must not become an unknown size");
+        assert!(matches!(err, CompilerError::ArithmeticOverflow(_)), "unexpected error: {err}");
     }
 }

--- a/silverscript-lang/src/errors.rs
+++ b/silverscript-lang/src/errors.rs
@@ -32,6 +32,14 @@ pub enum CompilerError {
     NonCanonicalEntrypointParameter { function: String, param: String },
     #[error("entrypoint dispatch tag collision between {f1} and {f2}")]
     EntrypointDispatchTagCollision { f1: String, f2: String },
+    #[error("compiled redeem script is {actual} bytes, exceeding the {maximum}-byte signature-script limit")]
+    RedeemScriptTooLarge { actual: usize, maximum: usize },
+    #[error("entrypoint '{function}' requires {actual} initial stack items, exceeding the consensus limit of {maximum}")]
+    EntrypointStackTooLarge { function: String, actual: usize, maximum: usize },
+    #[error(
+        "entrypoint '{function}' has a conservative signature-script size estimate of {estimated} bytes, exceeding the consensus limit of {maximum}"
+    )]
+    EntrypointSignatureScriptTooLarge { function: String, estimated: usize, maximum: usize },
     // QUESTION: not entierly sure about this pattern
     #[error("{source}")]
     Context {

--- a/silverscript-lang/src/errors.rs
+++ b/silverscript-lang/src/errors.rs
@@ -12,6 +12,8 @@ pub enum CompilerError {
     Unsupported(String),
     #[error("invalid literal: {0}")]
     InvalidLiteral(String),
+    #[error("arithmetic overflow: {0}")]
+    ArithmeticOverflow(String),
     #[error("undefined identifier: {0}")]
     UndefinedIdentifier(String),
     #[error("cyclic identifier reference: {0}")]

--- a/silverscript-lang/src/errors.rs
+++ b/silverscript-lang/src/errors.rs
@@ -10,6 +10,14 @@ pub enum CompilerError {
     Parse(#[from] ParseDiagnostic),
     #[error("unsupported feature: {0}")]
     Unsupported(String),
+    #[error("expression is not a compile-time integer: {0}")]
+    NonConstantInteger(String),
+    #[error("expression requires runtime evaluation")]
+    RuntimeEvaluationRequired,
+    #[error("type mismatch")]
+    TypeMismatch,
+    #[error("size mismatch")]
+    SizeMismatch,
     #[error("invalid literal: {0}")]
     InvalidLiteral(String),
     #[error("arithmetic overflow: {0}")]

--- a/silverscript-lang/src/lib.rs
+++ b/silverscript-lang/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod ast;
+pub(crate) mod checked_arithmetic;
 pub mod compiler;
 pub mod debug_info;
 pub mod diagnostic;

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -2163,6 +2163,26 @@ fn rejects_cast_between_different_fixed_byte_array_sizes() {
 }
 
 #[test]
+fn fixed_byte_scalars_accept_dynamic_and_compatible_fixed_byte_array_casts() {
+    let source = r#"
+        contract T() {
+            entry f(byte[] dynamicBytes, byte[32] pubkeyBytes, byte[65] sigBytes, byte[64] datasigBytes) {
+                pubkey dynamicPubkey = pubkey(dynamicBytes);
+                sig dynamicSig = sig(dynamicBytes);
+                datasig dynamicDatasig = datasig(dynamicBytes);
+
+                pubkey fixedPubkey = pubkey(pubkeyBytes);
+                sig fixedSig = sig(sigBytes);
+                datasig fixedDatasig = datasig(datasigBytes);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default())
+        .expect("dynamic and correctly sized fixed byte arrays should cast to fixed-byte scalar types");
+}
+
+#[test]
 fn rejects_cast_from_wrong_sized_fixed_bytes_to_signature() {
     let source = r#"
         pragma silverscript ^0.1.0;
@@ -2177,6 +2197,16 @@ fn rejects_cast_from_wrong_sized_fixed_bytes_to_signature() {
     let err =
         compile_contract(source, &[], CompileOptions::default()).expect_err("a ten-byte value cannot be cast to a 65-byte signature");
     assert!(err.to_string().contains("cannot cast byte[10] to sig"), "unexpected error: {err}");
+}
+
+#[test]
+fn rejects_cast_from_wrong_sized_fixed_bytes_to_fixed_byte_scalars() {
+    for (source_type, target_type) in [("byte[31]", "pubkey"), ("byte[64]", "sig"), ("byte[63]", "datasig")] {
+        let source = format!("contract T() {{ entry f({source_type} bytes) {{ {target_type} value = {target_type}(bytes); }} }}");
+        let err = compile_contract(&source, &[], CompileOptions::default())
+            .expect_err("a fixed byte array with the wrong size must not cast to a fixed-byte scalar");
+        assert!(err.to_string().contains(&format!("cannot cast {source_type} to {target_type}")), "unexpected error: {err}");
+    }
 }
 
 #[test]
@@ -2279,6 +2309,82 @@ fn encodes_non_byte_array_literal_cast_in_contract_field() {
         run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok(),
         "encoded non-byte array literal cast should execute"
     );
+}
+
+#[test]
+fn allows_same_rank_multidimensional_array_cast_refinement() {
+    let source = r#"
+        contract Arrays() {
+            entry main(int[2][] rows) {
+                int[2][1] fixedRows = int[2][1](rows);
+                require(fixedRows.length == 1);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default())
+        .expect("a multidimensional array cast may fix a dynamic dimension without changing rank");
+}
+
+#[test]
+fn allows_array_cast_to_less_specific_dimensions() {
+    let source = r#"
+        contract Arrays() {
+            entry main(int[2][1] rows) {
+                int[2][] dynamicRows = int[2][](rows);
+                require(dynamicRows.length == 1);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default())
+        .expect("a multidimensional array cast may make a fixed dimension dynamic without changing rank");
+}
+
+#[test]
+fn allows_array_cast_without_dimension_changes() {
+    let source = r#"
+        contract Arrays() {
+            entry main(int[2][1] rows) {
+                int[2][1] sameRows = int[2][1](rows);
+                require(sameRows.length == 1);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default()).expect("an array cast may preserve every dimension");
+}
+
+#[test]
+fn rejects_array_cast_that_changes_rank() {
+    let source = r#"
+        contract Arrays() {
+            entry main(int[2][] rows) {
+                int[2] row = int[2](rows);
+                require(row.length == 2);
+            }
+        }
+    "#;
+
+    let err =
+        compile_contract(source, &[], CompileOptions::default()).expect_err("an array cast must preserve the number of dimensions");
+    assert!(err.to_string().contains("cannot cast int[2][] to int[2]"), "unexpected error: {err}");
+}
+
+#[test]
+fn rejects_array_cast_with_incompatible_fixed_dimensions() {
+    let source = r#"
+        contract Arrays() {
+            entry main(int[2][3] rows) {
+                int[3][2] reshapedRows = int[3][2](rows);
+                require(reshapedRows.length == 2);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default())
+        .expect_err("equal total size must not permit incompatible fixed dimensions");
+    assert!(err.to_string().contains("cannot cast int[2][3] to int[3][2]"), "unexpected error: {err}");
 }
 
 #[test]
@@ -13366,6 +13472,39 @@ fn scalar_int_and_byte_cast_directionality() {
 }
 
 #[test]
+fn scalar_byte_cast_cannot_escape_validate_output_state_push() {
+    let direct_cast_source = r#"
+        contract ByteCast() {
+            entry main(string value) {
+                require(byte(value) == byte(1));
+            }
+        }
+    "#;
+    let err =
+        compile_contract(direct_cast_source, &[], CompileOptions::default()).expect_err("a string must not cast to a scalar byte");
+    assert!(err.to_string().contains("cannot cast string to byte"), "unexpected error: {err}");
+
+    let source = r#"
+        contract ByteCastState(byte initial) {
+            byte marker = initial;
+
+            entry roll(string next_marker) {
+                validateOutputState(0, State {
+                    marker: byte(next_marker)
+                });
+            }
+
+            entry accept() {
+                require(marker == byte(1));
+            }
+        }
+    "#;
+
+    compile_contract(source, &[Expr::byte(0)], CompileOptions::default())
+        .expect_err("a string must not cast to a scalar byte and escape the generated one-byte state push");
+}
+
+#[test]
 fn int_cast_rejects_scalar_byte_expressions() {
     let variable_source = r#"
         contract Test() {
@@ -16172,6 +16311,38 @@ fn allows_fixed_array_cast_with_compatible_encoded_size() {
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
     let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
     assert!(result.is_ok(), "the reinterpreted byte array should preserve the int payload bytes: {result:?}");
+}
+
+#[test]
+fn array_casts_require_the_same_base_type() {
+    let incompatible_element_source = r#"
+        contract ArrayCastRepresentation() {
+            entry main() {
+                int[1] values = int[1](bool[8]{true, false, false, false, false, false, false, false});
+                require(values.length == 1);
+            }
+        }
+    "#;
+    let err = compile_contract(incompatible_element_source, &[], CompileOptions::default())
+        .expect_err("equal encoded size must not permit a bool-array to int-array cast");
+    assert!(err.to_string().contains("cannot cast bool[8] to int[1]"), "unexpected error: {err}");
+}
+
+#[test]
+fn allows_signature_array_dimension_casts_in_both_directions() {
+    let source = r#"
+        contract ArrayCastRepresentation() {
+            entry main(sig[] dynamicSignatures, sig[1] fixedSignatures) {
+                sig[1] refined = sig[1](dynamicSignatures);
+                sig[] derefined = sig[](fixedSignatures);
+                require(refined.length == 1);
+                require(derefined.length == 1);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default())
+        .expect("same-base signature arrays may cast between dynamic and fixed dimensions");
 }
 
 #[test]

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -35,9 +35,9 @@ fn script_builder() -> ScriptBuilder {
 #[test]
 fn constructors_validate_argument_types() {
     let cases = [
-        ("ScriptPubKeyP2PK", "1", "publicKey", "pubkey", "byte[34]"),
-        ("ScriptPubKeyP2SH", "byte[31](byte[]{0x00})", "scriptHash", "byte[32]", "byte[35]"),
-        ("ScriptPubKeyP2SHFromRedeemScript", "1", "redeemScript", "byte[]", "byte[35]"),
+        ("ScriptPubKeyP2PK", "1", "publicKey", "pubkey", "byte[36]"),
+        ("ScriptPubKeyP2SH", "byte[31](byte[]{0x00})", "scriptHash", "byte[32]", "byte[37]"),
+        ("ScriptPubKeyP2SHFromRedeemScript", "1", "redeemScript", "byte[]", "byte[37]"),
     ];
 
     for (constructor, argument, parameter, expected, result_type) in cases {
@@ -1516,15 +1516,42 @@ fn opcode_builtins_return_their_declared_types() {
                 byte[32] sequence_commitment = OpChainblockSeqCommit(
                     byte[_](0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f)
                 );
-                byte[34] p2pk = new ScriptPubKeyP2PK(pk);
-                byte[35] p2sh = new ScriptPubKeyP2SH(outpoint_tx_id);
-                byte[35] p2sh_from_redeem_script = new ScriptPubKeyP2SHFromRedeemScript(redeem_script);
+                byte[36] p2pk = new ScriptPubKeyP2PK(pk);
+                byte[37] p2sh = new ScriptPubKeyP2SH(outpoint_tx_id);
+                byte[37] p2sh_from_redeem_script = new ScriptPubKeyP2SHFromRedeemScript(redeem_script);
                 require(true);
             }
         }
     "#;
 
     compile_contract(source, &[], CompileOptions::default()).expect("fixed-size builtin results should assign to their exact types");
+}
+
+#[test]
+fn script_pubkey_constructors_return_correct_fixed_dimension_types() {
+    let source = r#"
+        contract ScriptPubKeyDimensions() {
+            entry main() {
+                byte[36] p2pk = new ScriptPubKeyP2PK(
+                    pubkey(0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f)
+                );
+                byte[37] p2sh = new ScriptPubKeyP2SH(
+                    byte[32](0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f)
+                );
+                byte[37] p2sh_from_redeem_script =
+                    new ScriptPubKeyP2SHFromRedeemScript(byte[]("redeem"));
+
+                require(byte[](p2pk).length == 36);
+                require(byte[](p2sh).length == 37);
+                require(byte[](p2sh_from_redeem_script).length == 37);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("script-pubkey constructors should compile");
+    let sigscript = compiled.build_sig_script("main", vec![]).expect("signature script should build");
+    run_bytecode_with_sigscript(compiled.bytecode, sigscript)
+        .expect("script-pubkey constructor results should have their declared lengths after conversion to byte[]");
 }
 
 #[test]
@@ -1600,13 +1627,13 @@ fn rejects_assigning_fixed_size_builtin_results_to_wrong_byte_array_sizes() {
         ),
         (
             "ScriptPubKeyP2PK",
-            "byte[33] value = new ScriptPubKeyP2PK(pubkey(0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f));",
+            "byte[35] value = new ScriptPubKeyP2PK(pubkey(0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f));",
         ),
         (
             "ScriptPubKeyP2SH",
-            "byte[34] value = new ScriptPubKeyP2SH(byte[32](0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f));",
+            "byte[36] value = new ScriptPubKeyP2SH(byte[32](0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f));",
         ),
-        ("ScriptPubKeyP2SHFromRedeemScript", "byte[34] value = new ScriptPubKeyP2SHFromRedeemScript(byte[](\"redeem\"));"),
+        ("ScriptPubKeyP2SHFromRedeemScript", "byte[36] value = new ScriptPubKeyP2SHFromRedeemScript(byte[](\"redeem\"));"),
     ];
 
     for (name, statement) in cases {
@@ -16366,4 +16393,211 @@ fn public_ast_robustness_seeds_return_without_panicking() {
         let outcome = catch_unwind(AssertUnwindSafe(|| compile_contract_ast(&ast, &[], CompileOptions::default())));
         assert!(outcome.is_ok(), "public AST compilation panicked for seed: {seed}");
     }
+}
+
+#[test]
+fn artifact_state_resolution_supports_constructor_sized_arrays() {
+    let source = r#"
+        contract C(int N, byte[N] initial) {
+            byte[N] stored = initial;
+
+            entry main() {
+                require(stored.length == N);
+            }
+        }
+    "#;
+    let constructor_args = [Expr::int(2), Expr::bytes(vec![0xaa, 0xbb])];
+    let compiled = compile_contract(source, &constructor_args, CompileOptions::default()).expect("contract compiles");
+
+    let state = compiled
+        .ast
+        .resolve_contract_state_values(&constructor_args)
+        .expect("the compiled artifact should resolve with the same constructor arguments accepted by compilation");
+    assert_eq!(state.len(), 1);
+    assert_eq!(state[0].value, constructor_args[1]);
+}
+
+#[test]
+fn overflowing_fixed_array_size_is_rejected_at_the_untrusted_abi_boundary() {
+    let source = r#"
+        contract C() {
+            int constant N = 2305843009213693952;
+
+            entry main(int[N] values) {
+                require(values.length == N);
+            }
+        }
+    "#;
+    // N * sizeof(int) is 2^64 and overflows usize on the supported 64-bit host. A fixed parameter with that impossible encoded
+    // width must be rejected rather than weakened into the dynamic-array rule that accepts any multiple of eight bytes.
+    let err = compile_contract(source, &[], CompileOptions::default())
+        .expect_err("an impossible fixed-width entrypoint parameter must be rejected");
+    assert!(matches!(err.root(), CompilerError::ArithmeticOverflow(_)), "unexpected error: {err}");
+}
+
+#[test]
+fn append_accepts_a_slice_result_as_its_array_source() {
+    let source = r#"
+        contract SliceAppend() {
+            entry main(byte[] values) {
+                byte[] result = values.slice(0, values.length).append(byte(7));
+                require(result.length == values.length + 1);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default())
+        .expect("a statically typed byte[] slice should remain a valid append source after lowering");
+}
+
+#[test]
+fn append_accepts_a_nested_array_element_as_its_array_source() {
+    let source = r#"
+        contract NestedArrayAppend() {
+            entry main(int[2][] rows) {
+                int[3] result = rows[0].append(7);
+                require(result.length == 3);
+            }
+        }
+    "#;
+
+    compile_contract(source, &[], CompileOptions::default())
+        .expect("a statically typed nested-array element should remain a valid append source after lowering");
+}
+
+fn execute_handcrafted_p2sh(
+    compiled: &CompiledContract<'_>,
+    unlocking_prefix: Vec<u8>,
+) -> Result<(), kaspa_txscript_errors::TxScriptError> {
+    let flags = EngineFlags { covenants_enabled: true, ..Default::default() };
+    let signature_script = pay_to_script_hash_signature_script_with_flags(compiled.bytecode.clone(), unlocking_prefix, flags)
+        .expect("redeem script push should build");
+    let input = TransactionInput::new(
+        TransactionOutpoint { transaction_id: TransactionId::from_bytes([1; 32]), index: 0 },
+        signature_script,
+        0,
+        0,
+    );
+    let spent_output =
+        TransactionOutput { value: 1_000, script_public_key: pay_to_script_hash_script(&compiled.bytecode), covenant: None };
+    let tx = Transaction::new(1, vec![input.clone()], vec![spent_output.clone()], 0, SubnetworkId::default(), 0, vec![]);
+    let utxo = UtxoEntry::new(spent_output.value, spent_output.script_public_key, 0, tx.is_coinbase(), None);
+    let populated = PopulatedTransaction::new(&tx, vec![utxo.clone()]);
+    let reused_values = SigHashReusedValuesUnsync::new();
+    let sig_cache = Cache::new(10_000);
+    let mut vm = TxScriptEngine::from_transaction_input(
+        &populated,
+        &input,
+        0,
+        &utxo,
+        EngineCtx::new(&sig_cache).with_reused(&reused_values),
+        flags,
+    );
+    vm.execute()
+}
+
+fn compile_sigscript_boundary_contract() -> CompiledContract<'static> {
+    let source = r#"
+        contract Boundary(int committed) {
+            int stored = committed;
+
+            entry main(int left, int right) {
+                require(stored == 9);
+                require(left == 11);
+                require(right == 22);
+            }
+        }
+    "#;
+    compile_contract(source, &[Expr::int(9)], CompileOptions::default()).expect("boundary contract compiles")
+}
+
+fn valid_sigscript_boundary_prefix(compiled: &CompiledContract<'_>) -> Vec<u8> {
+    script_builder().add_i64(11).unwrap().add_i64(22).unwrap().add_data(&dispatch_tag_for(compiled, "main")).unwrap().drain()
+}
+
+#[test]
+fn handcrafted_p2sh_sigscript_accepts_exact_argument_stack() {
+    let compiled = compile_sigscript_boundary_contract();
+    execute_handcrafted_p2sh(&compiled, valid_sigscript_boundary_prefix(&compiled)).expect("exact argument stack must execute");
+}
+
+#[test]
+fn handcrafted_p2sh_sigscript_rejects_surplus_items_beneath_arguments() {
+    let compiled = compile_sigscript_boundary_contract();
+    let tag = dispatch_tag_for(&compiled, "main");
+    let cases = [
+        script_builder().add_i64(0).unwrap().add_i64(11).unwrap().add_i64(22).unwrap().add_data(&tag).unwrap().drain(),
+        script_builder().add_i64(99).unwrap().add_i64(11).unwrap().add_i64(22).unwrap().add_data(&tag).unwrap().drain(),
+        script_builder()
+            .add_data_with_push_opcode(&[0x55; 32])
+            .unwrap()
+            .add_i64(11)
+            .unwrap()
+            .add_i64(22)
+            .unwrap()
+            .add_data(&tag)
+            .unwrap()
+            .drain(),
+    ];
+
+    for unlocking_prefix in cases {
+        let err = execute_handcrafted_p2sh(&compiled, unlocking_prefix).expect_err("surplus stack item must not be accepted");
+        assert!(
+            matches!(err, kaspa_txscript_errors::TxScriptError::CleanStack(_)),
+            "surplus item should survive only to clean-stack rejection: {err:?}"
+        );
+    }
+}
+
+#[test]
+fn handcrafted_p2sh_sigscript_rejects_missing_reordered_and_trailing_items() {
+    let compiled = compile_sigscript_boundary_contract();
+    let tag = dispatch_tag_for(&compiled, "main");
+    let missing_leading = script_builder().add_i64(22).unwrap().add_data(&tag).unwrap().drain();
+    let reordered = script_builder().add_i64(22).unwrap().add_i64(11).unwrap().add_data(&tag).unwrap().drain();
+    let item_after_tag =
+        script_builder().add_i64(11).unwrap().add_i64(22).unwrap().add_data(&tag).unwrap().add_i64(1).unwrap().drain();
+
+    for unlocking_prefix in [missing_leading, reordered, item_after_tag] {
+        execute_handcrafted_p2sh(&compiled, unlocking_prefix).expect_err("malformed argument/dispatch position must fail");
+    }
+}
+
+#[test]
+fn handcrafted_p2sh_sigscript_rejects_unknown_tag_non_push_opcode_and_oversized_int() {
+    let compiled = compile_sigscript_boundary_contract();
+    let tag = dispatch_tag_for(&compiled, "main");
+    let unknown_tag = script_builder().add_i64(11).unwrap().add_i64(22).unwrap().add_data(&[0xde, 0xad, 0xbe, 0xef]).unwrap().drain();
+    execute_handcrafted_p2sh(&compiled, unknown_tag).expect_err("unknown dispatch tag must fail");
+
+    let mut non_push = vec![OpDup];
+    non_push.extend(valid_sigscript_boundary_prefix(&compiled));
+    let err = execute_handcrafted_p2sh(&compiled, non_push).expect_err("signature script must be push-only");
+    assert!(matches!(err, kaspa_txscript_errors::TxScriptError::SignatureScriptNotPushOnly), "unexpected non-push error: {err:?}");
+
+    let oversized = script_builder()
+        .add_data_with_push_opcode(&[11, 0, 0, 0, 0, 0, 0, 0, 0])
+        .unwrap()
+        .add_i64(22)
+        .unwrap()
+        .add_data(&tag)
+        .unwrap()
+        .drain();
+    execute_handcrafted_p2sh(&compiled, oversized).expect_err("nine-byte int must fail the compiler-emitted size guard");
+}
+
+#[test]
+fn handcrafted_p2sh_sigscript_preserves_nonminimal_but_valid_int_semantics() {
+    let compiled = compile_sigscript_boundary_contract();
+    let left = [11, 0, 0, 0, 0, 0, 0, 0];
+    let right = [22, 0, 0, 0, 0, 0, 0, 0];
+    let prefix = script_builder()
+        .add_data_with_push_opcode(&left)
+        .unwrap()
+        .add_data_with_push_opcode(&right)
+        .unwrap()
+        .add_data(&dispatch_tag_for(&compiled, "main"))
+        .unwrap()
+        .drain();
+    execute_handcrafted_p2sh(&compiled, prefix).expect("Rusty Kaspa permits nonminimal numeric encodings up to eight bytes");
 }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -452,6 +452,26 @@ fn resolve_contract_state_values_rejects_constructor_arg_type_mismatch() {
 }
 
 #[test]
+fn resolve_contract_state_values_checks_constructor_dependent_array_dimensions() {
+    let source = r#"
+        contract ResolveState(int N, byte[N] initial) {
+            byte[N] stored = initial;
+
+            entry spend() {
+                require(true);
+            }
+        }
+    "#;
+
+    let contract = parse_contract_ast(source).expect("contract parses");
+    let err = contract
+        .resolve_contract_state_values(&[Expr::int(2), Expr::bytes(vec![0xab])])
+        .expect_err("a constructor-sized array must use the resolved preceding constructor parameter");
+
+    assert!(err.to_string().contains("constructor argument 'initial' expects byte[N]"), "unexpected error: {err}");
+}
+
+#[test]
 fn resolve_contract_state_values_rejects_resolved_field_type_mismatch() {
     let source = r#"
         contract ResolveState(byte[2] initTag) {
@@ -5715,6 +5735,16 @@ fn rejects_invalid_constant_slice_bounds() {
             "contract C() { entry main(datasig value) { byte[] part = value.slice(0, 65); } }",
             "out of bounds",
         ),
+        (
+            "constant slice bound division by zero",
+            "contract C() { entry main(byte[] value) { byte[] part = value.slice(0, 1 / 0); } }",
+            "division by zero in constant expression",
+        ),
+        (
+            "constant slice bound overflow",
+            "contract C() { entry main(byte[] value) { byte[] part = value.slice(0, 9223372036854775807 + 1); } }",
+            "arithmetic overflow",
+        ),
     ];
 
     for (case, source, expected) in cases {
@@ -6315,6 +6345,31 @@ fn rejects_overflow_in_constant_for_loop_bounds() {
 
         let err = compile_contract(&source, &[], CompileOptions::default()).expect_err("compile should fail");
         assert!(err.to_string().contains(expected), "unexpected error: {err}");
+    }
+}
+
+#[test]
+fn rejects_invalid_constant_for_loop_start_and_end_expressions() {
+    let cases = [("1 / 0", "division by zero in constant expression"), ("9223372036854775807 + 1", "arithmetic overflow")];
+
+    for (expr, expected) in cases {
+        for (start, end) in [(expr, "1"), ("0", expr)] {
+            let source = format!(
+                r#"
+                    contract Loops() {{
+                        entry main() {{
+                            for (i, {start}, {end}, 1) {{
+                                require(i >= 0);
+                            }}
+                        }}
+                    }}
+                "#
+            );
+
+            let err = compile_contract(&source, &[], CompileOptions::default())
+                .expect_err("an invalid constant loop bound must be rejected instead of lowered as a runtime expression");
+            assert!(err.to_string().contains(expected), "unexpected error: {err}");
+        }
     }
 }
 
@@ -12137,6 +12192,24 @@ fn absolute_daa_and_time_locks_enforce_consensus_domains() {
 }
 
 #[test]
+fn lock_requirements_reject_invalid_constant_expressions() {
+    let cases = [
+        "contract C() { entry main() { require(this.ageDaa >= 9223372036854775807 + 1); } }",
+        "contract C() { entry main() { require(tx.daa >= 9223372036854775807 + 1); } }",
+        "contract C() { entry main() { require(tx.time >= temporal(9223372036854775807 / 0)); } }",
+    ];
+
+    for source in cases {
+        let err = compile_contract(source, &[], CompileOptions::default())
+            .expect_err("an invalid constant lock target must not be treated as a runtime expression");
+        assert!(
+            matches!(err.root(), CompilerError::ArithmeticOverflow(_) | CompilerError::InvalidLiteral(_)),
+            "unexpected error: {err}"
+        );
+    }
+}
+
+#[test]
 fn temporal_literals_use_milliseconds_and_are_separate_from_daa_age() {
     let relative_source = "contract C() { entry main() { require(this.ageDaa >= 1 days); } }";
     compile_contract(relative_source, &[], CompileOptions::default()).expect_err("this.ageDaa must reject temporal expressions");
@@ -12761,10 +12834,8 @@ fn rejects_fixed_size_array_init_with_too_few_elements() {
             }
         }
     "#;
-    let result = compile_contract(source, &[], CompileOptions::default());
-    assert!(result.is_err(), "Should reject array with too few elements");
-    let err_msg = format!("{:?}", result.unwrap_err());
-    assert!(err_msg.contains("type mismatch") || err_msg.contains("size mismatch"), "Error should mention type or size mismatch");
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("should reject array with too few elements");
+    assert!(matches!(err.root(), CompilerError::SizeMismatch), "unexpected error: {err:?}");
 }
 
 #[test]
@@ -12776,10 +12847,8 @@ fn rejects_fixed_size_array_init_with_too_many_elements() {
             }
         }
     "#;
-    let result = compile_contract(source, &[], CompileOptions::default());
-    assert!(result.is_err(), "Should reject array with too many elements");
-    let err_msg = format!("{:?}", result.unwrap_err());
-    assert!(err_msg.contains("type mismatch") || err_msg.contains("size mismatch"), "Error should mention type or size mismatch");
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("should reject array with too many elements");
+    assert!(matches!(err.root(), CompilerError::SizeMismatch), "unexpected error: {err:?}");
 }
 
 #[test]

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -16719,6 +16719,80 @@ fn variable_definition_rejects_undeclared_type_even_when_unused() {
 }
 
 #[test]
+fn dynamic_array_abi_rejects_zero_width_elements() {
+    let cases = [
+        r#"
+            contract ZeroWidthArray() {
+                entry main(byte[0][] values) {
+                    require(true);
+                }
+            }
+        "#,
+        r#"
+            contract ConstantZeroWidthArray() {
+                int constant N = 0;
+
+                entry main(byte[N][] values) {
+                    require(true);
+                }
+            }
+        "#,
+        r#"
+            contract ZeroWidthStructField() {
+                struct Item {
+                    byte[0] data;
+                }
+
+                entry main() {
+                    require(true);
+                }
+            }
+        "#,
+        r#"
+            contract InferredZeroWidthArray() {
+                entry main() {
+                    byte[_] values = byte[]{};
+                    require(true);
+                }
+            }
+        "#,
+    ];
+
+    for source in cases {
+        let err = compile_contract(source, &[], CompileOptions::default())
+            .expect_err("every fixed array dimension must be greater than zero");
+        assert!(err.to_string().contains("must be greater than zero"), "unexpected error: {err}");
+    }
+
+    let constructor_source = r#"
+        contract ZeroWidthConstructor(byte[0] value) {
+            entry main() {
+                require(true);
+            }
+        }
+    "#;
+    let err = compile_contract(constructor_source, &[Expr::bytes(Vec::new())], CompileOptions::default())
+        .expect_err("constructor parameter dimensions must be greater than zero");
+    assert!(err.to_string().contains("must be greater than zero"), "unexpected error: {err}");
+}
+
+#[test]
+fn dynamic_record_array_abi_rejects_empty_recursive_layouts() {
+    let source = r#"
+        contract EmptyRecordArray() {
+            struct Empty {}
+
+            entry main(Empty[] values) {
+                require(true);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("a struct must contain at least one field");
+    assert!(err.to_string().contains("struct 'Empty' must contain at least one field"), "unexpected error: {err}");
+}
+
+#[test]
 fn artifact_state_resolution_supports_constructor_sized_arrays() {
     let source = r#"
         contract C(int N, byte[N] initial) {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -15191,6 +15191,60 @@ fn rejects_struct_array_comparisons_with_structured_expressions_on_either_side()
 }
 
 #[test]
+fn scalar_struct_values_can_be_compared_directly() {
+    let source = r#"
+        contract StructEquality() {
+            struct Item {
+                int number;
+                byte tag;
+            }
+
+            entry main() {
+                Item left = Item {number: 7, tag: byte(1)};
+                Item same = Item {number: 7, tag: byte(1)};
+                Item different = Item {number: 8, tag: byte(2)};
+
+                // Identifier to identifier.
+                require(left == same);
+                require(left != different);
+
+                // Literal to literal.
+                require(Item {number: 7, tag: byte(1)} == Item {number: 7, tag: byte(1)});
+                require(Item {number: 7, tag: byte(1)} != Item {number: 8, tag: byte(2)});
+
+                // Identifier to literal, in both directions.
+                require(left == Item {number: 7, tag: byte(1)});
+                require(Item {number: 7, tag: byte(1)} == left);
+                require(left != Item {number: 8, tag: byte(2)});
+                require(Item {number: 8, tag: byte(2)} != left);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("scalar struct comparisons should compile");
+    let dispatch_tag = dispatch_tag_for(&compiled, "main");
+    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    assert!(result.is_ok(), "scalar struct comparisons should execute successfully: {result:?}");
+}
+
+#[test]
+fn rejects_scalar_struct_comparison_with_non_comparable_fields() {
+    let source = r#"
+        contract StructEquality() {
+            struct Item { int[] values; }
+
+            entry main(Item left, Item right) {
+                require(left == right);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default())
+        .expect_err("whole-struct comparison must preserve the comparison rules of each field");
+    assert!(err.to_string().contains("struct comparison is not supported for field type int[]"), "unexpected error: {err}");
+}
+
+#[test]
 fn allows_sequence_operations_on_string_and_fixed_byte_types() {
     let source = r#"
         contract ByteSequenceOperations() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -3,6 +3,7 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use kaspa_addresses::{Address, Prefix, Version};
 use kaspa_consensus_core::Hash;
+use kaspa_consensus_core::config::params::MAINNET_PARAMS;
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
 use kaspa_consensus_core::subnets::SubnetworkId;
 use kaspa_consensus_core::tx::{
@@ -17190,4 +17191,81 @@ fn runtime_empty_loop_with_extreme_reversed_bounds_matches_constant_lowering() {
     let err =
         run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect_err("the equivalent runtime range subtraction must overflow");
     assert!(matches!(err, kaspa_txscript_errors::TxScriptError::NumberTooBig(_)), "unexpected runtime error: {err:?}");
+}
+
+#[test]
+fn compiler_rejects_redeem_scripts_above_the_signature_script_limit() {
+    let source = r#"
+        contract OversizedLoop() {
+            entry main(int start, int end) {
+                for (i, start, end, 10000) {
+                    require(i >= start);
+                    require(i <= end);
+                    require(i != start - 1);
+                }
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default())
+        .expect_err("a redeem script that cannot fit in a signature script must be rejected");
+    match err.root() {
+        CompilerError::RedeemScriptTooLarge { actual, maximum } => {
+            assert!(*actual > *maximum);
+            assert_eq!(*maximum, MAINNET_PARAMS.new_max_signature_script_len);
+        }
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
+#[test]
+fn compiler_rejects_entry_abis_that_cannot_fit_the_unlocking_stack() {
+    fn source_with_params(count: usize) -> String {
+        let params = (0..count).map(|index| format!("int p{index}")).collect::<Vec<_>>().join(", ");
+        format!(
+            r#"
+                contract StackBoundary() {{
+                    entry main({params}) {{
+                        require(true);
+                    }}
+                }}
+            "#
+        )
+    }
+
+    compile_contract(&source_with_params(242), &[], CompileOptions::default())
+        .expect("242 arguments, the dispatch tag, and the redeem script fit the 244-item stack limit");
+
+    let err = compile_contract(&source_with_params(243), &[], CompileOptions::default())
+        .expect_err("243 arguments plus the dispatch tag and redeem script must be rejected");
+    match err.root() {
+        CompilerError::EntrypointStackTooLarge { function, actual, maximum } => {
+            assert_eq!(function, "main");
+            assert_eq!(*actual, 245);
+            assert_eq!(*maximum, 244);
+        }
+        other => panic!("unexpected error: {other}"),
+    }
+}
+
+#[test]
+fn compiler_rejects_fixed_abi_payloads_that_cannot_fit_a_signature_script() {
+    let source = r#"
+        contract OversizedFixedArgument() {
+            entry main(byte[250000] payload) {
+                require(true);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default())
+        .expect_err("an ABI whose minimum signature script is too large must be rejected");
+    match err.root() {
+        CompilerError::EntrypointSignatureScriptTooLarge { function, estimated, maximum } => {
+            assert_eq!(function, "main");
+            assert!(*estimated > *maximum);
+            assert_eq!(*maximum, MAINNET_PARAMS.new_max_signature_script_len);
+        }
+        other => panic!("unexpected error: {other}"),
+    }
 }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -354,6 +354,57 @@ fn supports_struct_contract_params_fields_and_constants() {
 }
 
 #[test]
+fn constructor_arguments_are_concrete_values_not_runtime_introspection() {
+    let source = r#"
+        contract RuntimeConstructor(int expected_lock_time) {
+            entry main() {
+                require(OpTxLockTime() == expected_lock_time);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[Expr::call("OpTxLockTime", vec![])], CompileOptions::default())
+        .expect_err("constructor arguments must not evaluate runtime expressions");
+    assert!(err.to_string().contains("constructor argument 'expected_lock_time' must be a concrete value"), "unexpected error: {err}");
+    let contract = parse_contract_ast(source).expect("contract parses");
+    contract
+        .resolve_contract_state_values(&[Expr::call("OpTxLockTime", vec![])])
+        .expect_err("state resolution must enforce the same concrete constructor boundary");
+
+    let struct_source = r#"
+        contract StructConstructor(Pair pair) {
+            struct Pair { int value; }
+
+            entry main() {
+                require(pair.value == 1);
+            }
+        }
+    "#;
+    let pair = struct_object("Pair", vec![("value", Expr::int(1))]);
+    compile_contract(struct_source, &[pair], CompileOptions::default())
+        .expect("structs containing only concrete values remain valid constructor arguments");
+
+    let runtime_pair = struct_object("Pair", vec![("value", Expr::call("OpTxLockTime", vec![]))]);
+    compile_contract(struct_source, &[runtime_pair], CompileOptions::default())
+        .expect_err("runtime expressions nested in constructor structs must be rejected");
+
+    let array_source = r#"
+        contract ArrayConstructor(int[] values) {
+            entry main() {
+                require(values.length == 1);
+            }
+        }
+    "#;
+    let literal_values = Expr::array(parse_type_ref("int[]").expect("array type parses"), vec![Expr::int(1)]);
+    compile_contract(array_source, &[literal_values], CompileOptions::default())
+        .expect("arrays containing only concrete values remain valid constructor arguments");
+
+    let runtime_values = Expr::array(parse_type_ref("int[]").expect("array type parses"), vec![Expr::call("OpTxLockTime", vec![])]);
+    compile_contract(array_source, &[runtime_values], CompileOptions::default())
+        .expect_err("runtime expressions nested in constructor arrays must be rejected");
+}
+
+#[test]
 fn nested_struct_field_path_does_not_alias_underscored_field_name() {
     let source = r#"
         contract C() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -16722,3 +16722,38 @@ fn handcrafted_p2sh_sigscript_preserves_nonminimal_but_valid_int_semantics() {
         .drain();
     execute_handcrafted_p2sh(&compiled, prefix).expect("Rusty Kaspa permits nonminimal numeric encodings up to eight bytes");
 }
+
+#[test]
+fn runtime_empty_loop_with_extreme_reversed_bounds_matches_constant_lowering() {
+    let constant_source = r#"
+        contract ConstantLoopBounds() {
+            entry main() {
+                for (i, 9223372036854775807, -9223372036854775807, 1) {
+                    require(false);
+                }
+                require(true);
+            }
+        }
+    "#;
+    let err = compile_contract(constant_source, &[], CompileOptions::default())
+        .expect_err("an overflowing constant loop range must fail compilation");
+    assert!(matches!(err.root(), CompilerError::ArithmeticOverflow(_)), "unexpected error: {err}");
+    assert!(err.to_string().contains("arithmetic overflow: -9223372036854775807 - 9223372036854775807"), "unexpected error: {err}");
+
+    let runtime_source = r#"
+        contract RuntimeLoopBounds() {
+            entry main(int start, int end) {
+                for (i, start, end, 1) {
+                    require(false);
+                }
+                require(true);
+            }
+        }
+    "#;
+    let compiled = compile_contract(runtime_source, &[], CompileOptions::default()).expect("runtime-bound contract compiles");
+    let sigscript =
+        compiled.build_sig_script("main", vec![Expr::int(i64::MAX), Expr::int(-i64::MAX)]).expect("runtime sigscript builds");
+    let err =
+        run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect_err("the equivalent runtime range subtraction must overflow");
+    assert!(matches!(err, kaspa_txscript_errors::TxScriptError::NumberTooBig(_)), "unexpected runtime error: {err:?}");
+}

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -16688,6 +16688,37 @@ fn public_ast_robustness_seeds_return_without_panicking() {
 }
 
 #[test]
+fn entrypoint_abi_rejects_undeclared_record_types_even_when_unused() {
+    let source = r#"
+        contract UnknownRecordAbi() {
+            entry main(Missing value) {
+                require(true);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default())
+        .expect_err("every custom type published in the entrypoint ABI must resolve to a declared struct");
+    assert!(err.to_string().contains("unknown type 'Missing' in function parameter"), "unexpected error: {err}");
+}
+
+#[test]
+fn variable_definition_rejects_undeclared_type_even_when_unused() {
+    let source = r#"
+        contract UnknownLocalType() {
+            entry main() {
+                Missing value;
+                require(true);
+            }
+        }
+    "#;
+
+    let err = compile_contract(source, &[], CompileOptions::default())
+        .expect_err("an unused local variable must still have a declared type");
+    assert!(err.to_string().contains("unknown type 'Missing' in variable"), "unexpected error: {err}");
+}
+
+#[test]
 fn artifact_state_resolution_supports_constructor_sized_arrays() {
     let source = r#"
         contract C(int N, byte[N] initial) {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -1555,6 +1555,40 @@ fn script_pubkey_constructors_return_correct_fixed_dimension_types() {
 }
 
 #[test]
+fn fixed_size_hash_builtins_return_their_declared_lengths() {
+    let source = r#"
+        contract FixedSizeHashes() {
+            entry main() {
+                byte[32] sha256_hash = sha256(byte[]("message"));
+                byte[32] blake2b_hash = blake2b(byte[]("message"));
+                byte[32] blake2b_keyed_hash = blake2bWithKey(
+                    byte[]("message"),
+                    byte[]("0123456789abcdef0123456789abcdef")
+                );
+                byte[32] blake3_hash = blake3(byte[]("message"));
+                byte[32] blake3_keyed_hash = blake3WithKey(
+                    byte[]("message"),
+                    byte[32]("0123456789abcdef0123456789abcdef")
+                );
+                byte[32] template_hash = templateHash(byte[]("prefix"), byte[]("suffix"));
+
+                require(byte[](sha256_hash).length == 32);
+                require(byte[](blake2b_hash).length == 32);
+                require(byte[](blake2b_keyed_hash).length == 32);
+                require(byte[](blake3_hash).length == 32);
+                require(byte[](blake3_keyed_hash).length == 32);
+                require(byte[](template_hash).length == 32);
+            }
+        }
+    "#;
+
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("fixed-size hash builtins should compile");
+    let sigscript = compiled.build_sig_script("main", vec![]).expect("signature script should build");
+    run_bytecode_with_sigscript(compiled.bytecode, sigscript)
+        .expect("fixed-size hash builtin results should have their declared lengths after conversion to byte[]");
+}
+
+#[test]
 fn introspection_fields_and_direct_lock_opcodes_emit_and_execute() {
     let source = r#"
         contract Introspection() {
@@ -1562,7 +1596,9 @@ fn introspection_fields_and_direct_lock_opcodes_emit_and_execute() {
                 require(tx.inputs[0].value == 5000);
                 require(tx.inputs[0].scriptPubKey.length >= 0);
                 require(tx.inputs[0].sigScript.length == 5);
-                require(tx.inputs[0].outpointTxId == byte[32]("0123456789abcdef0123456789abcdef"));
+                byte[32] outpoint_tx_id = tx.inputs[0].outpointTxId;
+                require(byte[](outpoint_tx_id).length == 32);
+                require(outpoint_tx_id == byte[32]("0123456789abcdef0123456789abcdef"));
                 require(tx.inputs[0].outpointIndex == 7);
                 require(tx.outputs[0].value == 1000);
                 require(tx.outputs[0].scriptPubKey.length >= 0);
@@ -11492,7 +11528,9 @@ fn executes_opcode_builtins_basic() {
             r#"
                 contract Test() {
                     entry main() {
-                        require(byte[](OpTxSubnetId()) == byte[]("abcdefghijklmnopqrst"));
+                        byte[20] subnet_id = OpTxSubnetId();
+                        require(byte[](subnet_id).length == 20);
+                        require(byte[](subnet_id) == byte[]("abcdefghijklmnopqrst"));
                     }
                 }
             "#,
@@ -11532,7 +11570,9 @@ fn executes_opcode_builtins_basic() {
             r#"
                 contract Test() {
                     entry main() {
-                        require(byte[](OpOutpointTxId(0)) == byte[]("0123456789abcdef0123456789abcdef"));
+                        byte[32] outpoint_tx_id = OpOutpointTxId(0);
+                        require(byte[](outpoint_tx_id).length == 32);
+                        require(byte[](outpoint_tx_id) == byte[]("0123456789abcdef0123456789abcdef"));
                     }
                 }
             "#,
@@ -11574,7 +11614,9 @@ fn executes_opcode_builtins_basic() {
             r#"
                 contract Test() {
                     entry main() {
-                        require(byte[](OpTxInputSeq(0)) == byte[]("sequence"));
+                        byte[8] input_sequence = OpTxInputSeq(0);
+                        require(byte[](input_sequence).length == 8);
+                        require(byte[](input_sequence) == byte[]("sequence"));
                     }
                 }
             "#,
@@ -11723,11 +11765,18 @@ fn executes_opcode_builtins_covenants() {
     let source = r#"
         contract Test() {
             entry main() {
+                byte[32] input_covenant_id = OpInputCovenantId(0);
+                byte[32] output_covenant_id_a = OpOutputCovenantId(0);
+                byte[32] output_covenant_id_b = OpOutputCovenantId(1);
+
+                require(byte[](input_covenant_id).length == 32);
+                require(byte[](output_covenant_id_a).length == 32);
+                require(byte[](output_covenant_id_b).length == 32);
                 require(OpAuthOutputCount(0) == 2);
                 require(OpAuthOutputIdx(0, 1) == 2);
-                require(byte[](OpInputCovenantId(0)) == byte[]("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
-                require(byte[](OpOutputCovenantId(0)) == byte[]("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
-                require(byte[](OpOutputCovenantId(1)) == byte[]("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"));
+                require(byte[](input_covenant_id) == byte[]("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+                require(byte[](output_covenant_id_a) == byte[]("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+                require(byte[](output_covenant_id_b) == byte[]("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"));
                 require(OpCovInputCount(byte[32]("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) == 2);
                 require(OpCovInputIdx(byte[32]("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), 1) == 2);
                 require(OpCovOutputCount(byte[32]("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) == 2);
@@ -11767,7 +11816,10 @@ fn executes_opcode_chainblock_seq_commit() {
     let source = r#"
         contract Test() {
             entry main() {
-                require(byte[](OpChainblockSeqCommit(byte[32]("0123456789abcdef0123456789abcdef"))) == byte[]("fedcba9876543210fedcba9876543210"));
+                byte[32] sequence_commitment =
+                    OpChainblockSeqCommit(byte[32]("0123456789abcdef0123456789abcdef"));
+                require(byte[](sequence_commitment).length == 32);
+                require(byte[](sequence_commitment) == byte[]("fedcba9876543210fedcba9876543210"));
             }
         }
     "#;

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -16710,6 +16710,59 @@ fn artifact_state_resolution_supports_constructor_sized_arrays() {
 }
 
 #[test]
+fn artifact_sigscript_builder_supports_constructor_sized_struct_array_fields() {
+    let source = r#"
+        contract C(int N) {
+            struct Item {
+                byte[N] data;
+            }
+
+            entry main(Item[] items) {
+                require(items.length == 1);
+            }
+        }
+    "#;
+    let compiled = compile_contract(source, &[Expr::int(3)], CompileOptions::default()).expect("contract compiles");
+    let input = &compiled.entry_by_name("main").expect("entrypoint exists").inputs[0];
+    assert_eq!(input.type_name, "Item[]");
+    assert_eq!(compiled.ast.structs[0].fields[0].type_ref, parse_type_ref("byte[3]").expect("resolved field type parses"));
+
+    let json = serde_json::to_string(&compiled).expect("compiled artifact serializes");
+    let compiled: CompiledContract<'_> = serde_json::from_str(&json).expect("compiled artifact deserializes");
+    assert_eq!(compiled.ast.structs[0].fields[0].type_ref, parse_type_ref("byte[3]").expect("resolved field type survives JSON"));
+    let item = struct_object("Item", vec![("data", Expr::bytes(vec![0xaa, 0xbb, 0xcc]))]);
+    let items = Expr::array(parse_type_ref("Item[]").expect("array type parses"), vec![item]);
+    let sigscript = compiled.build_sig_script("main", vec![items]).expect("resolved ABI encodes the valid argument");
+
+    run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect("artifact-built invocation executes");
+}
+
+#[test]
+fn artifact_sigscript_builder_rejects_wrong_constructor_sized_struct_fields() {
+    let source = r#"
+        contract C(int N) {
+            struct Item {
+                byte[N] data;
+            }
+
+            entry main(Item item) {
+                require(item.data.length == N);
+            }
+        }
+    "#;
+    let compiled = compile_contract(source, &[Expr::int(3)], CompileOptions::default()).expect("contract compiles");
+    let valid = struct_object("Item", vec![("data", Expr::bytes(vec![0xaa, 0xbb, 0xcc]))]);
+    compiled.build_sig_script("main", vec![valid]).expect("the valid constructor-sized struct argument encodes");
+
+    for data in [vec![0xaa, 0xbb], vec![0xaa, 0xbb, 0xcc, 0xdd]] {
+        let malformed = struct_object("Item", vec![("data", Expr::bytes(data))]);
+        compiled
+            .build_sig_script("main", vec![malformed])
+            .expect_err("the resolved ABI must reject an incorrectly sized nested field");
+    }
+}
+
+#[test]
 fn overflowing_fixed_array_size_is_rejected_at_the_untrusted_abi_boundary() {
     let source = r#"
         contract C() {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -6229,12 +6229,12 @@ fn rejects_assignment_to_loop_variable_for_constant_and_runtime_bounds() {
 #[test]
 fn rejects_overflow_in_constant_for_loop_bounds() {
     let cases = [
-        ("9223372036854775807 + 1", "constant integer overflow: 9223372036854775807 + 1"),
-        ("(-9223372036854775807) - 2", "constant integer overflow: -9223372036854775807 - 2"),
-        ("3037000500 * 3037000500", "constant integer overflow: 3037000500 * 3037000500"),
-        ("-(-9223372036854775807 - 1)", "constant integer overflow: -(-9223372036854775808)"),
-        ("(-9223372036854775807 - 1) / -1", "constant integer overflow: -9223372036854775808 / -1"),
-        ("(-9223372036854775807 - 1) % -1", "constant integer overflow: -9223372036854775808 % -1"),
+        ("9223372036854775807 + 1", "arithmetic overflow: 9223372036854775807 + 1"),
+        ("(-9223372036854775807) - 2", "arithmetic overflow: -9223372036854775807 - 2"),
+        ("3037000500 * 3037000500", "arithmetic overflow: 3037000500 * 3037000500"),
+        ("-(-9223372036854775807 - 1)", "arithmetic overflow: -(-9223372036854775808)"),
+        ("(-9223372036854775807 - 1) / -1", "arithmetic overflow: -9223372036854775808 / -1"),
+        ("(-9223372036854775807 - 1) % -1", "arithmetic overflow: -9223372036854775808 % -1"),
     ];
 
     for (expr, expected) in cases {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -17269,3 +17269,38 @@ fn compiler_rejects_fixed_abi_payloads_that_cannot_fit_a_signature_script() {
         other => panic!("unexpected error: {other}"),
     }
 }
+
+#[test]
+fn signature_script_builder_requires_explicit_byte_values() {
+    let source = r#"
+        contract ByteArgument() {
+            entry main(byte value) {
+                require(true);
+            }
+
+            entry array(byte[] values) {
+                require(values.length == 1);
+            }
+        }
+    "#;
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("byte contract compiles");
+
+    for value in [0, 0x80, 0xff] {
+        let err = compiled
+            .build_sig_script("main", vec![Expr::int(value)])
+            .expect_err("integer AST values must not be reinterpreted as ABI bytes");
+        assert!(err.to_string().contains("expects byte"), "unexpected error for {value:#04x}: {err}");
+    }
+
+    let sigscript = compiled.build_sig_script("main", vec![Expr::byte(0xff)]).expect("an explicit byte value builds");
+    run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript).expect("the explicit byte invocation executes");
+
+    let contextual_array = Expr::array(parse_type_ref("byte[]").expect("byte array type parses"), vec![Expr::int(1)]);
+    let err = compiled
+        .build_sig_script("array", vec![contextual_array])
+        .expect_err("integer AST elements must not be reinterpreted as ABI bytes");
+    assert!(err.to_string().contains("expects byte[]"), "unexpected array error: {err}");
+
+    let sigscript = compiled.build_sig_script("array", vec![Expr::dynamic_bytes(vec![1])]).expect("explicit byte elements build");
+    run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect("the explicit byte-array invocation executes");
+}

--- a/silverscript-lang/tests/examples/covenant_escrow.sil
+++ b/silverscript-lang/tests/examples/covenant_escrow.sil
@@ -11,8 +11,8 @@ contract Escrow(byte[32] arbiter, pubkey buyer, pubkey seller) {
         require(tx.outputs[0].value == amount);
 
         // Check that the transaction sends to either the buyer or the seller
-        byte[34] buyerLock = new ScriptPubKeyP2PK(buyer);
-        byte[34] sellerLock = new ScriptPubKeyP2PK(seller);
+        byte[36] buyerLock = new ScriptPubKeyP2PK(buyer);
+        byte[36] sellerLock = new ScriptPubKeyP2PK(seller);
         bool sendsToBuyer = tx.outputs[0].scriptPubKey == byte[](buyerLock);
         bool sendsToSeller = tx.outputs[0].scriptPubKey == byte[](sellerLock);
         require(sendsToBuyer || sendsToSeller);

--- a/silverscript-lang/tests/examples/covenant_mecenas.sil
+++ b/silverscript-lang/tests/examples/covenant_mecenas.sil
@@ -5,7 +5,7 @@ contract Mecenas(pubkey recipient, byte[32] funder, int pledge, int period) {
         require(this.ageDaa >= period);
 
         // Check that the first output sends to the recipient
-        byte[34] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
+        byte[36] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
         require(tx.outputs[0].scriptPubKey == byte[](recipientScriptPubKey));
 
         // Calculate the value that's left

--- a/silverscript-lang/tests/examples/mecenas_locktime.sil
+++ b/silverscript-lang/tests/examples/mecenas_locktime.sil
@@ -7,7 +7,7 @@ contract Mecenas(
     byte[8] initialBlock,
 ) {
     entry receive() {
-        byte[34] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
+        byte[36] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
         require(tx.outputs[0].scriptPubKey == byte[](recipientScriptPubKey));
 
         int initial = int(initialBlock);
@@ -27,7 +27,7 @@ contract Mecenas(
             require(tx.outputs[1].value == changeValue);
 
             byte[] bcValue = byte[](0x08) + OpTxLockTime() as byte[8] + this.activeScriptPubKey.split(9).1;
-            byte[35] lockValue = new ScriptPubKeyP2SH(blake2b(bcValue));
+            byte[37] lockValue = new ScriptPubKeyP2SH(blake2b(bcValue));
             require(tx.outputs[1].scriptPubKey == byte[](lockValue));
         }
     }

--- a/silverscript-lang/tests/examples/simulating_state.sil
+++ b/silverscript-lang/tests/examples/simulating_state.sil
@@ -8,7 +8,7 @@ contract SimulatingState(
 ) {
     entry receive() {
         // Check that the first output sends to the recipient
-        byte[34] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
+        byte[36] recipientScriptPubKey = new ScriptPubKeyP2PK(recipient);
         require(tx.outputs[0].scriptPubKey == byte[](recipientScriptPubKey));
 
         // Check that the DAA score has passed and that locktime is enabled
@@ -42,7 +42,7 @@ contract SimulatingState(
 
             // Create the locking bytecode for the new contract and check that
             // the change output sends to that contract
-            byte[35] newContractLock = new ScriptPubKeyP2SH(blake2b(newContract));
+            byte[37] newContractLock = new ScriptPubKeyP2SH(blake2b(newContract));
             require(tx.outputs[1].scriptPubKey == byte[](newContractLock));
         }
     }

--- a/silverscript-lang/tests/parser_tests.rs
+++ b/silverscript-lang/tests/parser_tests.rs
@@ -68,6 +68,15 @@ fn type_predicates_only_match_scalars() {
 }
 
 #[test]
+fn dynamic_array_predicate_checks_the_outermost_dimension() {
+    assert!(!parse_type_ref("int").unwrap().is_dynamic_array());
+    assert!(parse_type_ref("int[]").unwrap().is_dynamic_array());
+    assert!(!parse_type_ref("int[2]").unwrap().is_dynamic_array());
+    assert!(parse_type_ref("int[2][]").unwrap().is_dynamic_array());
+    assert!(!parse_type_ref("int[][2]").unwrap().is_dynamic_array());
+}
+
+#[test]
 fn scalar_byte_cast_remains_scalar_in_the_ast() {
     let input = r#"
         contract Convert() {


### PR DESCRIPTION
  This PR tightens SilverScript’s type and layout rules, rejects contracts that cannot be spent within consensus limits, and fixes several inconsistencies between static checking, lowering,
  and generated artifacts.

  It also adds direct scalar-struct comparison and expands append support to additional statically typed array expressions.

  ## Language Behavior Changes

  - Reject array dimensions whose encoded size overflows and reject zero-sized dimensions.
  - Reject empty structs and undeclared custom types in function signatures and local variables.
  - Require constructor arguments to be concrete scalar, array, or struct values. Calls, operators, introspection, casts, and unresolved identifiers are no longer accepted as constructor
  values.
  - Restrict casts to explicitly supported representation-compatible patterns:
    - Any value can be viewed as a flat `byte[]` or compatible `byte[N]`.
    - Same-base, same-rank arrays can refine or remove dimension specificity when their fixed dimensions are compatible.
    - Fixed-byte scalar casts require compatible known widths.
    - Unsupported reinterpretations are rejected.
  - Preserve constructor-resolved dimensions inside compiled struct schemas, so fields such as `byte[N]` become concrete in artifact-driven signature-script construction.
  - Require public signature-script callers to provide `Expr::byte(...)` for byte values rather than contextually reinterpreting `Expr::int(...)`.
  - Correct ScriptPubKey constructor result types:
    - `ScriptPubKeyP2PK`: `byte[36]`
    - `ScriptPubKeyP2SH`: `byte[37]`
    - `ScriptPubKeyP2SHFromRedeemScript`: `byte[37]`
  - Support equality and inequality between scalar structs by comparing their recursively flattened fields.

  ```silverscript
  struct Item {
      int amount;
      byte[2] code;
  }

  entry compare(Item left, Item right) {
      require(left == right);
  }
  ```

  - Allow `.append()` on statically typed results such as slices and nested-array indexing.

  ```silverscript
  entry extend(byte[] values) {
      byte[] result = values.slice(0, values.length).append(byte(7));
      require(result.length == values.length + 1);
  }
  ```

  - Reject constant loop ranges when calculating `end - start` overflows, matching the arithmetic requirements of runtime-bounded loops.
  - Preserve arithmetic, constant-evaluation, and layout errors instead of silently treating them as unknown or runtime-dependent values.
  - Reject artifacts that cannot produce a consensus-valid P2SH invocation:
    - Redeem scripts exceeding the mainnet signature-script limit.
    - Entrypoints requiring more than 244 initial stack items.
    - Entrypoints whose conservative signature-script size estimate exceeds the consensus limit.
