### PR TITLE
  Introduce portable SilverScript ABI artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3816,6 +3816,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "silverscript-abi"
+version = "0.1.0"
+dependencies = [
+ "blake3",
+ "faster-hex 0.10.0",
+ "kaspa-txscript",
+ "serde",
+ "serde_json",
+ "silverscript-lang",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "silverscript-lang"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3855,6 +3855,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "silverscript-abi",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3709,6 +3709,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3828,6 +3838,7 @@ dependencies = [
  "faster-hex 0.10.0",
  "kaspa-txscript",
  "serde",
+ "serde_bytes",
  "serde_json",
  "silverscript-lang",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,8 @@ dependencies = [
  "kaspa-consensus-core",
  "kaspa-txscript",
  "kaspa-txscript-errors",
+ "silverscript-abi",
+ "silverscript-debug-artifact",
  "silverscript-lang",
 ]
 
@@ -1250,7 +1252,10 @@ dependencies = [
  "kaspa-txscript-errors",
  "serde",
  "serde_json",
+ "silverscript-abi",
+ "silverscript-debug-artifact",
  "silverscript-lang",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3826,6 +3831,15 @@ dependencies = [
  "serde_json",
  "silverscript-lang",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "silverscript-debug-artifact"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "silverscript-abi",
+ "silverscript-lang",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "silverscript-lang",
     "silverscript-abi",
+    "silverscript-debug-artifact",
     "debugger/session",
     "debugger/cli",
 ]
@@ -41,4 +42,6 @@ secp256k1 = { version = "0.29.0", features = [
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 silverscript-lang = { path = "silverscript-lang" }
+silverscript-abi = { path = "silverscript-abi" }
+silverscript-debug-artifact = { path = "silverscript-debug-artifact" }
 thiserror = "1.0.61"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2024"
 license = "ISC"
 authors = ["Kaspa developers"]
 repository = ""
-rust-version = "1.85.0"
+rust-version = "1.94.0"
 
 [workspace.dependencies]
 # Keep all rusty-kaspa crates on this shared revision because v2.0.1 predates

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "silverscript-lang",
+    "silverscript-abi",
     "debugger/session",
     "debugger/cli",
 ]
@@ -29,6 +30,7 @@ kaspa-txscript-zk-sdk = { git = "https://github.com/kaspanet/rusty-kaspa", rev =
 kaspa-txscript-errors = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "a41a333b08848f41bf737b72592e463a6011b8ac" }
 blake2b_simd = "1.0.2"
 blake3 = "1.8.5"
+faster-hex = "0.10"
 indexmap = "2.7.0"
 rand = "0.8.5"
 secp256k1 = { version = "0.29.0", features = [
@@ -36,4 +38,7 @@ secp256k1 = { version = "0.29.0", features = [
     "rand-std",
     "serde",
 ] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+silverscript-lang = { path = "silverscript-lang" }
 thiserror = "1.0.61"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ secp256k1 = { version = "0.29.0", features = [
     "serde",
 ] }
 serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
 serde_json = "1.0"
 silverscript-lang = { path = "silverscript-lang" }
 silverscript-abi = { path = "silverscript-abi" }

--- a/debugger/cli/Cargo.toml
+++ b/debugger/cli/Cargo.toml
@@ -13,7 +13,9 @@ path = "src/main.rs"
 
 [dependencies]
 debugger-session = { path = "../session" }
-silverscript-lang = { path = "../../silverscript-lang" }
+silverscript-abi.workspace = true
+silverscript-debug-artifact.workspace = true
+silverscript-lang.workspace = true
 kaspa-consensus-core.workspace = true
 kaspa-txscript.workspace = true
 kaspa-txscript-errors.workspace = true

--- a/debugger/cli/src/main.rs
+++ b/debugger/cli/src/main.rs
@@ -211,9 +211,10 @@ fn build_covenant_input_sigscript<'i>(
     raw_args: &[String],
     output_states: Option<&[DebugValue]>,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let [contract] = compiled.abi.contracts.as_slice() else {
+    if compiled.abi.contracts.len() != 1 {
         return Err("debugger requires an artifact containing exactly one contract".into());
-    };
+    }
+    let (contract_name, contract) = compiled.abi.contracts.first_key_value().expect("contract count was checked");
     let entrypoint_name = target.generated_entrypoint_name_for(is_leader);
     let entry = contract.entry(&entrypoint_name).ok_or("generated covenant entrypoint not found")?;
     let typed_args = if target.binding == DebugCovenantBinding::Cov && !is_leader {
@@ -227,7 +228,7 @@ fn build_covenant_input_sigscript<'i>(
             args
         }
     };
-    Ok(encode_contract_entry_sig_script(&compiled.abi, &contract.name, &entrypoint_name, &typed_args)?)
+    Ok(encode_contract_entry_sig_script(&compiled.abi, contract_name, &entrypoint_name, &typed_args)?)
 }
 
 fn resolve_state_for_ctor_args(
@@ -750,7 +751,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let selected_name = if selected_name.is_empty() {
-        contract_artifact.entries.first().map(|entry| entry.name.clone()).ok_or("contract has no functions")?
+        contract_artifact.entries.first_key_value().map(|(name, _)| name.clone()).ok_or("contract has no functions")?
     } else {
         selected_name
     };
@@ -905,7 +906,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         let entry = active_contract.entry(&selected_name).ok_or_else(|| format!("entry '{selected_name}' not found"))?;
         let typed_args = parse_artifact_args(&active_compiled.abi, active_contract, &entry.params, &raw_args)?;
-        encode_contract_entry_sig_script(&active_compiled.abi, &active_contract.name, &selected_name, &typed_args)?
+        encode_contract_entry_sig_script(&active_compiled.abi, &parsed_contract.name, &selected_name, &typed_args)?
     };
 
     let mut tx_inputs = Vec::with_capacity(tx.inputs.len());

--- a/debugger/cli/src/main.rs
+++ b/debugger/cli/src/main.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
-use debugger_session::args::{parse_call_args, parse_call_args_with_prefix, parse_ctor_args, parse_hex_bytes, parse_state_value};
+use debugger_session::args::{parse_artifact_args, parse_ctor_args, parse_hex_bytes, parse_state_value};
 use debugger_session::covenant::{CovenantBinding as DebugCovenantBinding, ResolvedCovenantCallTarget, resolve_covenant_call_target};
 use debugger_session::session::{DebugEngine, DebugSession, DebugValue, ShadowTxContext, Variable, VariableOrigin};
 use debugger_session::test_runner::{
@@ -23,10 +23,10 @@ use kaspa_txscript::caches::Cache;
 use kaspa_txscript::covenants::CovenantsContext;
 use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::{EngineCtx, EngineFlags, pay_to_script_hash_script};
-use silverscript_lang::ast::{
-    ContractAst, Expr, ExprKind, STATE_TYPE_NAME, StateFieldExpr, TypeBase, TypeRef, parse_contract_ast, parse_type_ref,
-};
-use silverscript_lang::compiler::{CompileOptions, CompiledContract, compile_contract, compile_contract_ast};
+use silverscript_abi::{ArtifactValue, SilContractArtifact, TypeArtifact, encode_contract_entry_sig_script};
+use silverscript_debug_artifact::{SilDebugArtifact, compile_contract as compile_debug_artifact};
+use silverscript_lang::ast::{ContractAst, Expr, ExprKind, STATE_TYPE_NAME, TypeBase, parse_contract_ast, parse_type_ref};
+use silverscript_lang::compiler::{CompileOptions, compile_contract_ast};
 
 const PROMPT: &str = "(sdb) ";
 
@@ -62,18 +62,21 @@ fn compile_bytecode_for_ctor_args(
         return Ok(bytecode.clone());
     }
     let ctor_args = parse_ctor_args(parsed_contract, raw_ctor_args)?;
-    let compiled = compile_contract(source, &ctor_args, CompileOptions { record_debug_infos: true, ..Default::default() })?;
-    cache.insert(raw_ctor_args.to_vec(), compiled.bytecode.clone());
-    Ok(compiled.bytecode)
+    let artifact_ctor_args = ctor_args.iter().map(expr_to_artifact_value).collect::<Result<Vec<_>, _>>()?;
+    let compiled = compile_debug_artifact(source, &artifact_ctor_args, CompileOptions::default())?;
+    let bytecode = compiled.contract(&parsed_contract.name).ok_or("compiled artifact has no contract")?.compiled.bytecode.clone();
+    cache.insert(raw_ctor_args.to_vec(), bytecode.clone());
+    Ok(bytecode)
 }
 
 fn compile_contract_for_raw_ctor_args<'i>(
     source: &'i str,
     parsed_contract: &ContractAst<'i>,
     raw_ctor_args: &[String],
-) -> Result<CompiledContract<'i>, Box<dyn std::error::Error>> {
+) -> Result<SilDebugArtifact<'i>, Box<dyn std::error::Error>> {
     let ctor_args = parse_ctor_args(parsed_contract, raw_ctor_args)?;
-    Ok(compile_contract(source, &ctor_args, CompileOptions { record_debug_infos: true, ..Default::default() })?)
+    let artifact_ctor_args = ctor_args.iter().map(expr_to_artifact_value).collect::<Result<Vec<_>, _>>()?;
+    Ok(compile_debug_artifact(source, &artifact_ctor_args, CompileOptions::default())?)
 }
 
 fn expr_to_debug_value(expr: &Expr<'_>) -> Result<DebugValue, String> {
@@ -116,116 +119,115 @@ fn expr_to_debug_value(expr: &Expr<'_>) -> Result<DebugValue, String> {
     }
 }
 
-fn debug_value_to_expr(value: &DebugValue, struct_name: Option<&str>) -> Option<Expr<'static>> {
-    Some(match value {
-        DebugValue::Int(value) => Expr::int(*value),
-        DebugValue::Temporal(value) => Expr::temporal(*value),
-        DebugValue::Bool(value) => Expr::new(ExprKind::Bool(*value), Default::default()),
-        DebugValue::Bytes(bytes) => Expr::bytes(bytes.clone()),
-        DebugValue::String(value) => Expr::new(ExprKind::String(value.clone()), Default::default()),
-        DebugValue::Array(values) => {
-            Expr::inferred_array(values.iter().map(|value| debug_value_to_expr(value, struct_name)).collect::<Option<Vec<_>>>()?)?
+fn expr_to_artifact_value(expr: &Expr<'_>) -> Result<ArtifactValue, String> {
+    match &expr.kind {
+        ExprKind::Int(value) | ExprKind::Temporal(value) | ExprKind::DateLiteral(value) => Ok(ArtifactValue::Int(*value)),
+        ExprKind::Bool(value) => Ok(ArtifactValue::Bool(*value)),
+        ExprKind::Byte(value) => Ok(ArtifactValue::Byte(*value)),
+        ExprKind::String(value) => Ok(ArtifactValue::Text(value.clone())),
+        ExprKind::Array { type_ref, values } if matches!(type_ref.base, TypeBase::Byte) && type_ref.array_dims.len() == 1 => {
+            let bytes = values
+                .iter()
+                .map(|value| match value.kind {
+                    ExprKind::Byte(byte) => Ok(byte),
+                    _ => Err(format!("{} contains a non-byte value", type_ref.type_name())),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(ArtifactValue::Bytes(bytes))
         }
-        DebugValue::Object(fields) => Expr::new(
-            ExprKind::StructLiteral {
-                name: struct_name?.to_string(),
-                fields: fields
-                    .iter()
-                    .map(|(name, value)| {
-                        Some(StateFieldExpr {
-                            name: name.clone(),
-                            expr: debug_value_to_expr(value, None)?,
-                            span: Default::default(),
-                            name_span: Default::default(),
-                        })
-                    })
-                    .collect::<Option<Vec<_>>>()?,
-                name_span: Default::default(),
-            },
-            Default::default(),
-        ),
-        DebugValue::Unknown(_) => return None,
-    })
+        ExprKind::Array { values, .. } => {
+            Ok(ArtifactValue::Array(values.iter().map(expr_to_artifact_value).collect::<Result<Vec<_>, _>>()?))
+        }
+        ExprKind::StructLiteral { fields, .. } => Ok(ArtifactValue::Object(
+            fields
+                .iter()
+                .map(|field| Ok((field.name.clone(), expr_to_artifact_value(&field.expr)?)))
+                .collect::<Result<BTreeMap<_, _>, String>>()?,
+        )),
+        _ => Err("constructor argument is not a concrete artifact value".to_string()),
+    }
 }
 
-fn is_state_type(type_ref: &TypeRef) -> bool {
-    type_ref.is_custom() && matches!(&type_ref.base, TypeBase::Custom(name) if name == "State")
+fn debug_value_to_artifact_value(value: &DebugValue) -> Result<ArtifactValue, String> {
+    match value {
+        DebugValue::Int(value) | DebugValue::Temporal(value) => Ok(ArtifactValue::Int(*value)),
+        DebugValue::Bool(value) => Ok(ArtifactValue::Bool(*value)),
+        DebugValue::Bytes(bytes) => Ok(ArtifactValue::Bytes(bytes.clone())),
+        DebugValue::String(value) => Ok(ArtifactValue::Text(value.clone())),
+        DebugValue::Array(values) => {
+            Ok(ArtifactValue::Array(values.iter().map(debug_value_to_artifact_value).collect::<Result<Vec<_>, _>>()?))
+        }
+        DebugValue::Object(fields) => Ok(ArtifactValue::Object(
+            fields
+                .iter()
+                .map(|(name, value)| Ok((name.clone(), debug_value_to_artifact_value(value)?)))
+                .collect::<Result<_, String>>()?,
+        )),
+        DebugValue::Unknown(description) => Err(format!("cannot encode unknown debugger value '{description}'")),
+    }
 }
 
-fn is_state_array_type(type_ref: &TypeRef) -> bool {
-    matches!(&type_ref.base, TypeBase::Custom(name) if name == "State")
-        && type_ref.array_dims.len() == 1
-        && type_ref.is_dynamic_array()
+fn is_state_type(ty: &TypeArtifact) -> bool {
+    matches!(ty, TypeArtifact::Struct { name } if name == STATE_TYPE_NAME)
+}
+
+fn is_state_array_type(ty: &TypeArtifact) -> bool {
+    matches!(ty, TypeArtifact::DynamicArray { item } if is_state_type(item))
 }
 
 fn synthesized_covenant_prefix_args(
-    compiled: &CompiledContract<'_>,
+    contract: &SilContractArtifact,
     entrypoint_name: &str,
     target: &ResolvedCovenantCallTarget,
     output_states: Option<&[DebugValue]>,
-) -> Result<Vec<Expr<'static>>, Box<dyn std::error::Error>> {
+) -> Result<Vec<ArtifactValue>, Box<dyn std::error::Error>> {
     if target.binding == DebugCovenantBinding::Cov && entrypoint_name.starts_with("__delegate_") {
         return Ok(Vec::new());
     }
 
-    let function = compiled
-        .ast
-        .functions
-        .iter()
-        .find(|function| function.name == entrypoint_name)
-        .ok_or("generated covenant entrypoint not found")?;
-    let Some(first_param) = function.params.first() else {
+    let entry = contract.entry(entrypoint_name).ok_or("generated covenant entrypoint not found")?;
+    let Some(first_param) = entry.params.first() else {
         return Ok(Vec::new());
     };
 
     let states = output_states.ok_or("missing output states needed to synthesize covenant verification arguments")?;
-    if is_state_type(&first_param.type_ref) {
+    if is_state_type(&first_param.ty) {
         if states.len() != 1 {
             return Err(format!("expected exactly 1 output State for '{entrypoint_name}', got {}", states.len()).into());
         }
-        return Ok(vec![
-            debug_value_to_expr(&states[0], Some(STATE_TYPE_NAME)).ok_or("failed to materialize synthesized output State")?,
-        ]);
+        return Ok(vec![debug_value_to_artifact_value(&states[0])?]);
     }
-    if is_state_array_type(&first_param.type_ref) {
-        return Ok(vec![Expr::array(
-            first_param.type_ref.clone(),
-            states
-                .iter()
-                .map(|state| debug_value_to_expr(state, Some(STATE_TYPE_NAME)))
-                .collect::<Option<Vec<_>>>()
-                .ok_or("failed to materialize synthesized output State[]")?,
-        )]);
+    if is_state_array_type(&first_param.ty) {
+        return Ok(vec![ArtifactValue::Array(states.iter().map(debug_value_to_artifact_value).collect::<Result<Vec<_>, _>>()?)]);
     }
 
     Ok(Vec::new())
 }
 
 fn build_covenant_input_sigscript<'i>(
-    compiled: &CompiledContract<'i>,
+    compiled: &SilDebugArtifact<'i>,
     target: &ResolvedCovenantCallTarget,
     is_leader: bool,
     raw_args: &[String],
     output_states: Option<&[DebugValue]>,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let [contract] = compiled.abi.contracts.as_slice() else {
+        return Err("debugger requires an artifact containing exactly one contract".into());
+    };
     let entrypoint_name = target.generated_entrypoint_name_for(is_leader);
+    let entry = contract.entry(&entrypoint_name).ok_or("generated covenant entrypoint not found")?;
     let typed_args = if target.binding == DebugCovenantBinding::Cov && !is_leader {
-        parse_call_args(&compiled.ast, &entrypoint_name, raw_args)?
+        parse_artifact_args(&compiled.abi, contract, &entry.params, raw_args)?
     } else {
-        let function = compiled
-            .ast
-            .functions
-            .iter()
-            .find(|function| function.name == entrypoint_name)
-            .ok_or("generated covenant entrypoint not found")?;
-        if raw_args.len() == function.params.len() {
-            parse_call_args(&compiled.ast, &entrypoint_name, raw_args)?
+        if raw_args.len() == entry.params.len() {
+            parse_artifact_args(&compiled.abi, contract, &entry.params, raw_args)?
         } else {
-            let prefix_args = synthesized_covenant_prefix_args(compiled, &entrypoint_name, target, output_states)?;
-            parse_call_args_with_prefix(&compiled.ast, &entrypoint_name, prefix_args, raw_args)?
+            let mut args = synthesized_covenant_prefix_args(contract, &entrypoint_name, target, output_states)?;
+            args.extend(parse_artifact_args(&compiled.abi, contract, &entry.params[args.len()..], raw_args)?);
+            args
         }
     };
-    Ok(compiled.build_sig_script(&entrypoint_name, typed_args)?)
+    Ok(encode_contract_entry_sig_script(&compiled.abi, &contract.name, &entrypoint_name, &typed_args)?)
 }
 
 fn resolve_state_for_ctor_args(
@@ -271,29 +273,31 @@ fn materialize_bytecode_for_explicit_state(
     raw_state: &str,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let instance_args = parse_ctor_args(parsed_contract, raw_instance_args)?;
+    let artifact_instance_args = instance_args.iter().map(expr_to_artifact_value).collect::<Result<Vec<_>, _>>()?;
     let state = parse_state_value(parsed_contract, raw_state)?;
     let compile_opts = CompileOptions { record_debug_infos: true, ..Default::default() };
-    let base_compiled = compile_contract(source, &instance_args, compile_opts)?;
+    let base_compiled = compile_debug_artifact(source, &artifact_instance_args, compile_opts)?;
+    let base_contract = base_compiled.contract(&parsed_contract.name).ok_or("compiled artifact has no contract")?;
     let materialized_contract = contract_with_explicit_state(parsed_contract, &state)?;
     let materialized = compile_contract_ast(&materialized_contract, &instance_args, compile_opts)?;
 
-    let base_start = base_compiled.state_layout.start;
-    let base_end = base_start + base_compiled.state_layout.len;
+    let base_start = base_contract.compiled.state_span.offset;
+    let base_end = base_start + base_contract.compiled.state_span.len;
     let materialized_start = materialized.state_layout.start;
     let materialized_end = materialized_start + materialized.state_layout.len;
-    if base_compiled.state_layout.len != materialized.state_layout.len {
+    if base_contract.compiled.state_span.len != materialized.state_layout.len {
         return Err("explicit state changes encoded bytecode size; provide raw script_hex instead".into());
     }
-    if base_compiled.bytecode.len() < base_end || materialized.bytecode.len() < materialized_end {
+    if base_contract.compiled.bytecode.len() < base_end || materialized.bytecode.len() < materialized_end {
         return Err("state layout exceeds compiled bytecode length".into());
     }
-    if base_compiled.bytecode[..base_start] != materialized.bytecode[..materialized_start]
-        || base_compiled.bytecode[base_end..] != materialized.bytecode[materialized_end..]
+    if base_contract.compiled.bytecode[..base_start] != materialized.bytecode[..materialized_start]
+        || base_contract.compiled.bytecode[base_end..] != materialized.bytecode[materialized_end..]
     {
         return Err("explicit state changed non-state bytecode; provide raw script_hex instead".into());
     }
 
-    let mut bytecode = base_compiled.bytecode;
+    let mut bytecode = base_contract.compiled.bytecode.clone();
     bytecode[base_start..base_end].copy_from_slice(&materialized.bytecode[materialized_start..materialized_end]);
     Ok(bytecode)
 }
@@ -732,25 +736,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let ctor_args = parse_ctor_args(&parsed_contract, &raw_ctor_args)?;
+    let artifact_ctor_args = ctor_args.iter().map(expr_to_artifact_value).collect::<Result<Vec<_>, _>>()?;
     let compile_opts = CompileOptions { record_debug_infos: true, ..Default::default() };
-    let compiled = compile_contract(&source, &ctor_args, compile_opts)?;
-    let debug_info = compiled.debug_info.clone();
+    let compiled = compile_debug_artifact(&source, &artifact_ctor_args, compile_opts)?;
+    let contract_artifact = compiled.contract(&parsed_contract.name).ok_or("compiled artifact has no contract")?;
     let mut ctor_bytecode_cache = HashMap::<Vec<String>, Vec<u8>>::new();
     let mut ctor_state_cache = HashMap::<Vec<String>, DebugValue>::new();
     let mut explicit_state_cache = HashMap::<String, DebugValue>::new();
-    ctor_bytecode_cache.insert(raw_ctor_args.clone(), compiled.bytecode.clone());
+    ctor_bytecode_cache.insert(raw_ctor_args.clone(), contract_artifact.compiled.bytecode.clone());
     if !parsed_contract.fields.is_empty() {
         let root_state = resolve_state_for_ctor_args(&parsed_contract, &raw_ctor_args, &mut ctor_state_cache)?;
         ctor_state_cache.insert(raw_ctor_args.clone(), root_state);
     }
 
     let selected_name = if selected_name.is_empty() {
-        compiled.abi.first().map(|entry| entry.name.clone()).ok_or("contract has no functions")?
+        contract_artifact.entries.first().map(|entry| entry.name.clone()).ok_or("contract has no functions")?
     } else {
         selected_name
     };
 
-    let covenant_target = resolve_covenant_call_target(&parsed_contract, &compiled, &selected_name);
+    let covenant_target = resolve_covenant_call_target(&parsed_contract, contract_artifact, &selected_name);
     let covenant_binding = covenant_target.as_ref().map(|target| target.binding);
     let enable_covenant_session_mode = covenant_target.is_some();
 
@@ -882,6 +887,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
     let active_input_ctor_raw = tx.inputs[tx.active_input_index].constructor_args.clone().unwrap_or_else(|| raw_ctor_args.clone());
     let active_compiled = compile_contract_for_raw_ctor_args(&source, &parsed_contract, &active_input_ctor_raw)?;
+    let active_contract = active_compiled.contract(&parsed_contract.name).ok_or("compiled artifact has no contract")?;
     let active_is_cov_leader = companion_leader_index.map(|index| index == tx.active_input_index).unwrap_or(true);
     let active_sigscript = if let Some(target) = covenant_target.as_ref() {
         match target.binding {
@@ -897,8 +903,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             )?,
         }
     } else {
-        let typed_args = parse_call_args(&active_compiled.ast, &selected_name, &raw_args)?;
-        active_compiled.build_sig_script(&selected_name, typed_args)?
+        let entry = active_contract.entry(&selected_name).ok_or_else(|| format!("entry '{selected_name}' not found"))?;
+        let typed_args = parse_artifact_args(&active_compiled.abi, active_contract, &entry.params, &raw_args)?;
+        encode_contract_entry_sig_script(&active_compiled.abi, &active_contract.name, &selected_name, &typed_args)?
     };
 
     let mut tx_inputs = Vec::with_capacity(tx.inputs.len());
@@ -943,8 +950,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let active_utxo =
         populated_tx.utxo(tx.active_input_index).ok_or_else(|| format!("missing utxo entry for input {}", tx.active_input_index))?;
     let active_covenant_input_state = input_covenant_states.get(tx.active_input_index).cloned().flatten();
-    let active_lockscript =
-        input_redeem_scripts.get(tx.active_input_index).cloned().flatten().unwrap_or_else(|| compiled.bytecode.clone());
+    let active_lockscript = input_redeem_scripts
+        .get(tx.active_input_index)
+        .cloned()
+        .flatten()
+        .unwrap_or_else(|| active_contract.compiled.bytecode.clone());
     let covenant_input_states = active_utxo.covenant_id.and_then(|covenant_id| {
         let mut values = Vec::new();
         for (input_covenant_id, covenant_input_state) in input_covenant_ids.iter().zip(input_covenant_states.iter()) {
@@ -968,7 +978,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         utxo_entry: active_utxo,
         covenants_ctx: &cov_ctx,
     };
-    let mut session = DebugSession::full(&active_sigscript, &active_lockscript, &source, debug_info, engine)?
+    let active_debug_info = active_compiled.debug_info(&parsed_contract.name).cloned();
+    let mut session = DebugSession::full(&active_sigscript, &active_lockscript, &source, active_debug_info, engine)?
         .with_shadow_tx_context(shadow_tx_context);
     if enable_covenant_session_mode {
         session = session.with_covenant_mode(covenant_param_value, covenant_target);
@@ -997,7 +1008,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     } else {
-        println!("Stepping through {} bytes of bytecode", compiled.bytecode.len());
+        println!("Stepping through {} bytes of bytecode", contract_artifact.compiled.bytecode.len());
         session.run_to_first_executed_statement()?;
         let mut pending_console_output = session.take_console_output();
         let console_output = Vec::new();
@@ -1010,16 +1021,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use silverscript_lang::ast::ArrayDim;
 
     #[test]
     fn state_array_type_requires_one_dynamic_dimension() {
-        let state = || TypeBase::Custom("State".to_string());
+        let state = || TypeArtifact::Struct { name: STATE_TYPE_NAME.to_string() };
 
-        assert!(is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Dynamic] }));
-        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: Vec::new() }));
-        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Fixed(2)] }));
-        assert!(!is_state_array_type(&TypeRef { base: state(), array_dims: vec![ArrayDim::Dynamic, ArrayDim::Dynamic] }));
+        assert!(is_state_array_type(&TypeArtifact::DynamicArray { item: Box::new(state()) }));
+        assert!(!is_state_array_type(&state()));
+        assert!(!is_state_array_type(&TypeArtifact::FixedArray { item: Box::new(state()), len: 2 }));
+        assert!(!is_state_array_type(&TypeArtifact::DynamicArray {
+            item: Box::new(TypeArtifact::DynamicArray { item: Box::new(state()) }),
+        }));
     }
 
     #[test]

--- a/debugger/session/Cargo.toml
+++ b/debugger/session/Cargo.toml
@@ -12,13 +12,16 @@ name = "debugger_session"
 path = "src/lib.rs"
 
 [dependencies]
-silverscript-lang = { path = "../../silverscript-lang" }
+silverscript-abi.workspace = true
+silverscript-debug-artifact.workspace = true
+silverscript-lang.workspace = true
 kaspa-consensus-core.workspace = true
 kaspa-txscript.workspace = true
 kaspa-txscript-errors.workspace = true
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 faster-hex = "0.10"
+thiserror.workspace = true
 
 [dev-dependencies]
 kaspa-addresses.workspace = true

--- a/debugger/session/src/args.rs
+++ b/debugger/session/src/args.rs
@@ -293,28 +293,23 @@ fn parse_artifact_json_value(
     contract: &SilContractArtifact,
 ) -> Result<ArtifactValue, String> {
     match ty {
-        TypeArtifact::Int | TypeArtifact::Temporal => match value {
-            Value::Number(value) => Ok(ArtifactValue::Int(value.as_i64().ok_or_else(|| "invalid int value".to_string())?)),
-            Value::String(value) => Ok(ArtifactValue::Int(parse_int_arg(value)?)),
-            _ => Err(format!("expected {}, got {value}", artifact_type_name(ty))),
-        },
+        TypeArtifact::Int | TypeArtifact::Temporal => {
+            let Value::Number(value) = value else {
+                return Err(format!("expected {}, got {value}", artifact_type_name(ty)));
+            };
+            Ok(ArtifactValue::Int(value.as_i64().ok_or_else(|| "invalid int value".to_string())?))
+        }
         TypeArtifact::Bool => match value {
             Value::Bool(value) => Ok(ArtifactValue::Bool(*value)),
             Value::String(value) if value == "true" || value == "false" => Ok(ArtifactValue::Bool(value == "true")),
             _ => Err(format!("expected bool, got {value}")),
         },
         TypeArtifact::Byte => {
-            let raw = match value {
-                Value::Number(value) => value.to_string(),
-                Value::String(value) => value.clone(),
-                _ => return Err(format!("expected byte, got {value}")),
+            let Value::Number(value) = value else {
+                return Err(format!("expected byte, got {value}"));
             };
-            let bytes = parse_hex_bytes(&raw)?;
-            if let [byte] = bytes.as_slice() {
-                Ok(ArtifactValue::Byte(*byte))
-            } else {
-                Err(format!("byte expects 1 byte, got {}", bytes.len()))
-            }
+            let value = value.as_u64().ok_or_else(|| "invalid byte value".to_string())?;
+            u8::try_from(value).map(ArtifactValue::Byte).map_err(|_| format!("byte expects value in 0..=255, got {value}"))
         }
         TypeArtifact::Bytes | TypeArtifact::FixedBytes { .. } | TypeArtifact::Pubkey | TypeArtifact::Sig | TypeArtifact::Datasig => {
             let Value::String(raw) = value else {
@@ -372,6 +367,26 @@ fn parse_artifact_json_value(
     }
 }
 
+fn parse_raw_artifact_arg(
+    raw: &str,
+    ty: &TypeArtifact,
+    abi: &SilAbiArtifact,
+    contract: &SilContractArtifact,
+) -> Result<ArtifactValue, String> {
+    match ty {
+        TypeArtifact::Int | TypeArtifact::Temporal => parse_int_arg(raw).map(ArtifactValue::Int),
+        TypeArtifact::Byte => {
+            let bytes = parse_hex_bytes(raw)?;
+            if let [byte] = bytes.as_slice() {
+                Ok(ArtifactValue::Byte(*byte))
+            } else {
+                Err(format!("byte expects 1 byte, got {}", bytes.len()))
+            }
+        }
+        _ => parse_artifact_json_value(&Value::String(raw.to_string()), ty, abi, contract),
+    }
+}
+
 fn artifact_byte_len(ty: &TypeArtifact) -> Option<usize> {
     match ty {
         TypeArtifact::FixedBytes { len } => Some(*len),
@@ -413,12 +428,13 @@ pub fn parse_artifact_args(
         .iter()
         .zip(raw_args)
         .map(|(param, raw)| {
-            let value = if raw.starts_with('[') || raw.starts_with('{') {
-                serde_json::from_str(raw).map_err(|err| format!("invalid {} arg '{raw}': {err}", artifact_type_name(&param.ty)))?
+            if raw.starts_with('[') || raw.starts_with('{') {
+                let value = serde_json::from_str(raw)
+                    .map_err(|err| format!("invalid {} arg '{raw}': {err}", artifact_type_name(&param.ty)))?;
+                parse_artifact_json_value(&value, &param.ty, abi, contract)
             } else {
-                Value::String(raw.clone())
-            };
-            parse_artifact_json_value(&value, &param.ty, abi, contract)
+                parse_raw_artifact_arg(raw, &param.ty, abi, contract)
+            }
         })
         .collect()
 }
@@ -475,8 +491,10 @@ pub fn parse_state_value(contract: &ContractAst<'_>, raw_state: &str) -> Result<
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_call_args, parse_ctor_args, parse_state_value};
+    use super::{parse_artifact_args, parse_call_args, parse_ctor_args, parse_state_value};
+    use silverscript_abi::ArtifactValue;
     use silverscript_lang::ast::{ExprKind, parse_contract_ast};
+    use silverscript_lang::compiler::compile_to_sil_abi_artifact;
 
     fn debug_shapes_contract() -> silverscript_lang::ast::ContractAst<'static> {
         parse_contract_ast(
@@ -617,5 +635,49 @@ mod tests {
         assert!(fields.iter().any(|field| field.name == "amount"));
         assert!(fields.iter().any(|field| field.name == "active"));
         assert!(fields.iter().any(|field| field.name == "tag"));
+    }
+
+    #[test]
+    fn parses_json_byte_numbers_as_decimal_and_rejects_strings() {
+        let source = r#"
+            contract Demo() {
+                struct S {
+                    byte marker;
+                }
+
+                entry main(S value) {
+                    require(true);
+                }
+
+                entry scalar(byte marker) {
+                    require(true);
+                }
+            }
+        "#;
+        let abi = compile_to_sil_abi_artifact(source, &[]).expect("contract compiles");
+        let contract = abi.contract("Demo").expect("contract exists");
+        let params = &contract.entry("main").expect("entry exists").params;
+
+        let parse_marker = |raw: &str| -> Result<ArtifactValue, String> {
+            let values = parse_artifact_args(&abi, contract, params, &[raw.to_string()]).expect("structured byte argument parses");
+            let ArtifactValue::Object(fields) = &values[0] else {
+                panic!("expected struct argument");
+            };
+            Ok(fields.get("marker").cloned().expect("marker field exists"))
+        };
+
+        assert_eq!(parse_marker(r#"{"marker":10}"#).unwrap(), ArtifactValue::Byte(10));
+        assert_eq!(parse_marker(r#"{"marker":255}"#).unwrap(), ArtifactValue::Byte(255));
+        assert!(
+            parse_artifact_args(&abi, contract, params, &[r#"{"marker":"10"}"#.to_string()])
+                .expect_err("JSON byte strings are not numeric values")
+                .contains("expected byte")
+        );
+
+        let scalar_params = &contract.entry("scalar").expect("scalar entry exists").params;
+        assert_eq!(
+            parse_artifact_args(&abi, contract, scalar_params, &["10".to_string()]).expect("raw byte argument parses"),
+            vec![ArtifactValue::Byte(0x10)]
+        );
     }
 }

--- a/debugger/session/src/args.rs
+++ b/debugger/session/src/args.rs
@@ -19,7 +19,7 @@ pub fn parse_hex_bytes(raw: &str) -> Result<Vec<u8>, String> {
     if hex_str.is_empty() {
         return Ok(vec![]);
     }
-    let normalized = if hex_str.len() % 2 != 0 { format!("0{hex_str}") } else { hex_str.to_string() };
+    let normalized = if !hex_str.len().is_multiple_of(2) { format!("0{hex_str}") } else { hex_str.to_string() };
     if !normalized.chars().all(|ch| ch.is_ascii_hexdigit()) {
         return Err(format!("invalid hex bytes '{raw}'"));
     }

--- a/debugger/session/src/args.rs
+++ b/debugger/session/src/args.rs
@@ -280,7 +280,7 @@ fn artifact_struct_fields<'a>(
     if contract.runtime_state.source == name {
         return Some(contract.runtime_state.fields.iter().map(|field| (field.name.as_str(), &field.ty)).collect());
     }
-    abi.states
+    abi.structs
         .iter()
         .find(|state| state.name == name)
         .map(|state| state.fields.iter().map(|field| (field.name.as_str(), &field.ty)).collect())

--- a/debugger/session/src/args.rs
+++ b/debugger/session/src/args.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde_json::Value;
+use silverscript_abi::{ArtifactValue, ParamArtifact, SilAbiArtifact, SilContractArtifact, TypeArtifact};
 use silverscript_lang::ast::{ArrayDim, ContractAst, Expr, ExprKind, ParamAst, StateFieldExpr, TypeBase, TypeRef};
 use silverscript_lang::span;
 
@@ -269,6 +270,157 @@ pub fn parse_ctor_args(parsed_contract: &ContractAst<'_>, raw_ctor_args: &[Strin
         return Err(format!("constructor expects {} arguments, got {}", parsed_contract.params.len(), raw_ctor_args.len()));
     }
     parse_params(&parsed_contract.params, &shapes, raw_ctor_args)
+}
+
+fn artifact_struct_fields<'a>(
+    abi: &'a SilAbiArtifact,
+    contract: &'a SilContractArtifact,
+    name: &str,
+) -> Option<Vec<(&'a str, &'a TypeArtifact)>> {
+    if contract.runtime_state.source == name {
+        return Some(contract.runtime_state.fields.iter().map(|field| (field.name.as_str(), &field.ty)).collect());
+    }
+    abi.states
+        .iter()
+        .find(|state| state.name == name)
+        .map(|state| state.fields.iter().map(|field| (field.name.as_str(), &field.ty)).collect())
+}
+
+fn parse_artifact_json_value(
+    value: &Value,
+    ty: &TypeArtifact,
+    abi: &SilAbiArtifact,
+    contract: &SilContractArtifact,
+) -> Result<ArtifactValue, String> {
+    match ty {
+        TypeArtifact::Int | TypeArtifact::Temporal => match value {
+            Value::Number(value) => Ok(ArtifactValue::Int(value.as_i64().ok_or_else(|| "invalid int value".to_string())?)),
+            Value::String(value) => Ok(ArtifactValue::Int(parse_int_arg(value)?)),
+            _ => Err(format!("expected {}, got {value}", artifact_type_name(ty))),
+        },
+        TypeArtifact::Bool => match value {
+            Value::Bool(value) => Ok(ArtifactValue::Bool(*value)),
+            Value::String(value) if value == "true" || value == "false" => Ok(ArtifactValue::Bool(value == "true")),
+            _ => Err(format!("expected bool, got {value}")),
+        },
+        TypeArtifact::Byte => {
+            let raw = match value {
+                Value::Number(value) => value.to_string(),
+                Value::String(value) => value.clone(),
+                _ => return Err(format!("expected byte, got {value}")),
+            };
+            let bytes = parse_hex_bytes(&raw)?;
+            if let [byte] = bytes.as_slice() {
+                Ok(ArtifactValue::Byte(*byte))
+            } else {
+                Err(format!("byte expects 1 byte, got {}", bytes.len()))
+            }
+        }
+        TypeArtifact::Bytes | TypeArtifact::FixedBytes { .. } | TypeArtifact::Pubkey | TypeArtifact::Sig | TypeArtifact::Datasig => {
+            let Value::String(raw) = value else {
+                return Err(format!("expected {}, got {value}", artifact_type_name(ty)));
+            };
+            let bytes = parse_hex_bytes(raw)?;
+            if let Some(expected) = artifact_byte_len(ty)
+                && bytes.len() != expected
+            {
+                return Err(format!("{} expects {expected} bytes, got {}", artifact_type_name(ty), bytes.len()));
+            }
+            Ok(ArtifactValue::Bytes(bytes))
+        }
+        TypeArtifact::Text => match value {
+            Value::String(value) => Ok(ArtifactValue::Text(value.clone())),
+            _ => Err(format!("expected string, got {value}")),
+        },
+        TypeArtifact::FixedArray { item, len } => {
+            let Value::Array(values) = value else {
+                return Err(format!("expected {}, got {value}", artifact_type_name(ty)));
+            };
+            if values.len() != *len {
+                return Err(format!("{} expects {len} elements, got {}", artifact_type_name(ty), values.len()));
+            }
+            Ok(ArtifactValue::Array(
+                values.iter().map(|value| parse_artifact_json_value(value, item, abi, contract)).collect::<Result<Vec<_>, _>>()?,
+            ))
+        }
+        TypeArtifact::DynamicArray { item } => {
+            let Value::Array(values) = value else {
+                return Err(format!("expected {}, got {value}", artifact_type_name(ty)));
+            };
+            Ok(ArtifactValue::Array(
+                values.iter().map(|value| parse_artifact_json_value(value, item, abi, contract)).collect::<Result<Vec<_>, _>>()?,
+            ))
+        }
+        TypeArtifact::Struct { name } => {
+            let Value::Object(values) = value else {
+                return Err(format!("expected struct {name}, got {value}"));
+            };
+            let fields = artifact_struct_fields(abi, contract, name).ok_or_else(|| format!("unknown struct '{name}'"))?;
+            if let Some(extra) = values.keys().find(|field| !fields.iter().any(|(name, _)| name == &field.as_str())) {
+                return Err(format!("unknown struct field '{extra}'"));
+            }
+            Ok(ArtifactValue::Object(
+                fields
+                    .into_iter()
+                    .map(|(name, ty)| {
+                        let value = values.get(name).ok_or_else(|| format!("struct field '{name}' must be initialized"))?;
+                        Ok((name.to_string(), parse_artifact_json_value(value, ty, abi, contract)?))
+                    })
+                    .collect::<Result<_, String>>()?,
+            ))
+        }
+    }
+}
+
+fn artifact_byte_len(ty: &TypeArtifact) -> Option<usize> {
+    match ty {
+        TypeArtifact::FixedBytes { len } => Some(*len),
+        TypeArtifact::Pubkey => Some(32),
+        TypeArtifact::Sig => Some(65),
+        TypeArtifact::Datasig => Some(64),
+        _ => None,
+    }
+}
+
+fn artifact_type_name(ty: &TypeArtifact) -> String {
+    match ty {
+        TypeArtifact::Int => "int".to_string(),
+        TypeArtifact::Temporal => "temporal".to_string(),
+        TypeArtifact::Bool => "bool".to_string(),
+        TypeArtifact::Byte => "byte".to_string(),
+        TypeArtifact::Bytes => "byte[]".to_string(),
+        TypeArtifact::Text => "string".to_string(),
+        TypeArtifact::Pubkey => "pubkey".to_string(),
+        TypeArtifact::Sig => "sig".to_string(),
+        TypeArtifact::Datasig => "datasig".to_string(),
+        TypeArtifact::FixedBytes { len } => format!("byte[{len}]"),
+        TypeArtifact::FixedArray { item, len } => format!("{}[{len}]", artifact_type_name(item)),
+        TypeArtifact::DynamicArray { item } => format!("{}[]", artifact_type_name(item)),
+        TypeArtifact::Struct { name } => name.clone(),
+    }
+}
+
+pub fn parse_artifact_args(
+    abi: &SilAbiArtifact,
+    contract: &SilContractArtifact,
+    params: &[ParamArtifact],
+    raw_args: &[String],
+) -> Result<Vec<ArtifactValue>, String> {
+    if params.len() != raw_args.len() {
+        return Err(format!("function expects {} arguments, got {}", params.len(), raw_args.len()));
+    }
+    params
+        .iter()
+        .zip(raw_args)
+        .map(|(param, raw)| {
+            let value = if raw.starts_with('[') || raw.starts_with('{') {
+                serde_json::from_str(raw).map_err(|err| format!("invalid {} arg '{raw}': {err}", artifact_type_name(&param.ty)))?
+            } else {
+                Value::String(raw.clone())
+            };
+            parse_artifact_json_value(&value, &param.ty, abi, contract)
+        })
+        .collect()
 }
 
 pub fn parse_call_args(contract: &ContractAst<'_>, function_name: &str, raw_args: &[String]) -> Result<Vec<Expr<'static>>, String> {

--- a/debugger/session/src/args.rs
+++ b/debugger/session/src/args.rs
@@ -280,10 +280,7 @@ fn artifact_struct_fields<'a>(
     if contract.runtime_state.source == name {
         return Some(contract.runtime_state.fields.iter().map(|field| (field.name.as_str(), &field.ty)).collect());
     }
-    abi.structs
-        .iter()
-        .find(|state| state.name == name)
-        .map(|state| state.fields.iter().map(|field| (field.name.as_str(), &field.ty)).collect())
+    abi.structs.get(name).map(|state| state.fields.iter().map(|field| (field.name.as_str(), &field.ty)).collect())
 }
 
 fn parse_artifact_json_value(

--- a/debugger/session/src/covenant.rs
+++ b/debugger/session/src/covenant.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
+use silverscript_abi::SilContractArtifact;
 use silverscript_lang::ast::{ContractAst, FunctionAst};
-use silverscript_lang::compiler::CompiledContract;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CovenantBinding {
@@ -74,14 +74,15 @@ impl ResolvedCovenantCallTarget {
 
 pub fn resolve_covenant_call_target<'i>(
     contract: &ContractAst<'i>,
-    compiled: &CompiledContract<'i>,
+    artifact: &SilContractArtifact,
     function_name: &str,
 ) -> Option<ResolvedCovenantCallTarget> {
     let function =
         contract.functions.iter().find(|function| function.name == function_name && is_covenant_source_function(function))?;
 
-    let generated_entrypoint_name = compiled.covenant_decl_entrypoint_name(function_name, true)?.to_string();
-    let nonleader_entrypoint_name = compiled.covenant_decl_entrypoint_name(function_name, false)?.to_string();
+    let generated_entrypoint_name = artifact.cov_decl_to_abi.get(function_name)?.name.clone();
+    let nonleader_entrypoint_name =
+        artifact.delegate_entry_abi.as_ref().map(|entry| entry.name.clone()).unwrap_or_else(|| generated_entrypoint_name.clone());
     let binding = if generated_entrypoint_name == nonleader_entrypoint_name { CovenantBinding::Auth } else { CovenantBinding::Cov };
     let delegate_entrypoint_name = (binding == CovenantBinding::Cov).then_some(nonleader_entrypoint_name);
     let delegate_body = (binding == CovenantBinding::Cov)

--- a/debugger/session/src/covenant.rs
+++ b/debugger/session/src/covenant.rs
@@ -50,10 +50,10 @@ impl ResolvedCovenantCallTarget {
     }
 
     pub fn display_name_for(&self, function_name: &str) -> Option<&str> {
-        if let Some(body) = &self.delegate_body {
-            if body.policy_function_name == function_name {
-                return Some(body.source_name.as_str());
-            }
+        if let Some(body) = &self.delegate_body
+            && body.policy_function_name == function_name
+        {
+            return Some(body.source_name.as_str());
         }
         (self.policy_function_name == function_name || self.matches_generated_name(function_name)).then_some(self.source_name.as_str())
     }

--- a/debugger/session/src/covenant.rs
+++ b/debugger/session/src/covenant.rs
@@ -80,9 +80,8 @@ pub fn resolve_covenant_call_target<'i>(
     let function =
         contract.functions.iter().find(|function| function.name == function_name && is_covenant_source_function(function))?;
 
-    let generated_entrypoint_name = artifact.cov_decl_to_abi.get(function_name)?.name.clone();
-    let nonleader_entrypoint_name =
-        artifact.delegate_entry_abi.as_ref().map(|entry| entry.name.clone()).unwrap_or_else(|| generated_entrypoint_name.clone());
+    let generated_entrypoint_name = artifact.cov_decl_to_abi.get(function_name)?.clone();
+    let nonleader_entrypoint_name = artifact.delegate_entry_abi.clone().unwrap_or_else(|| generated_entrypoint_name.clone());
     let binding = if generated_entrypoint_name == nonleader_entrypoint_name { CovenantBinding::Auth } else { CovenantBinding::Cov };
     let delegate_entrypoint_name = (binding == CovenantBinding::Cov).then_some(nonleader_entrypoint_name);
     let delegate_body = (binding == CovenantBinding::Cov)

--- a/debugger/session/src/presentation.rs
+++ b/debugger/session/src/presentation.rs
@@ -137,10 +137,10 @@ pub fn format_failure_report(report: &FailureReport, format_var: &dyn Fn(&str, &
 
         out.push_str(&format!("{pad} |\n"));
 
-        if line_idx > 0 {
-            if let Some(prev) = source_lines.get(line_idx - 1) {
-                out.push_str(&format!("{:>w$} | {prev}\n", span.line - 1));
-            }
+        if line_idx > 0
+            && let Some(prev) = source_lines.get(line_idx - 1)
+        {
+            out.push_str(&format!("{:>w$} | {prev}\n", span.line - 1));
         }
 
         if let Some(line_text) = source_lines.get(line_idx) {

--- a/debugger/session/src/session.rs
+++ b/debugger/session/src/session.rs
@@ -7,6 +7,8 @@ use kaspa_txscript::covenants::CovenantsContext;
 use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::{DynOpcodeImplementation, EngineCtx, EngineFlags, TxScriptEngine, parse_script};
 use serde::{Deserialize, Serialize};
+use silverscript_debug_artifact::SilDebugArtifact;
+use thiserror::Error;
 
 use silverscript_lang::ast::{
     ContractAst, Expr, ExprKind, StateFieldExpr, TypeBase, TypeRef, UnarySuffixKind, parse_contract_ast, parse_expression_ast,
@@ -28,6 +30,16 @@ pub type DebugTx<'a> = PopulatedTransaction<'a>;
 pub type DebugReused = SigHashReusedValuesUnsync;
 pub type DebugOpcode<'a> = DynOpcodeImplementation<DebugTx<'a>, DebugReused>;
 pub type DebugEngine<'a> = TxScriptEngine<'a, DebugTx<'a>, DebugReused>;
+
+#[derive(Debug, Error)]
+pub enum DebugArtifactSessionError {
+    #[error("debug artifact has no contract '{0}'")]
+    MissingContract(String),
+    #[error("debug artifact has no debug information for contract '{0}'")]
+    MissingDebugInfo(String),
+    #[error(transparent)]
+    Script(#[from] kaspa_txscript_errors::TxScriptError),
+}
 
 #[derive(Clone, Copy)]
 pub struct ShadowTxContext<'a> {
@@ -196,6 +208,21 @@ type ShadowResolution<'i> = (ShadowBindings, EvalEnv<'i>, StackBindings, EvalTyp
 
 impl<'a, 'i> DebugSession<'a, 'i> {
     // --- Session construction + stepping ---
+
+    /// Creates a debug session from one contract in a debug artifact.
+    pub fn from_artifact(
+        sigscript: &[u8],
+        artifact: &'i SilDebugArtifact<'i>,
+        contract_name: &str,
+        engine: DebugEngine<'a>,
+    ) -> Result<Self, DebugArtifactSessionError> {
+        let contract =
+            artifact.contract(contract_name).ok_or_else(|| DebugArtifactSessionError::MissingContract(contract_name.to_string()))?;
+        let debug_info = artifact
+            .debug_info(contract_name)
+            .ok_or_else(|| DebugArtifactSessionError::MissingDebugInfo(contract_name.to_string()))?;
+        Ok(Self::full(sigscript, &contract.compiled.bytecode, &debug_info.source, Some(debug_info.clone()), engine)?)
+    }
 
     /// Creates a debug session simulating a full transaction spend.
     /// Executes sigscript first to seed the stack, then debugs the compiled bytecode.

--- a/debugger/session/src/session.rs
+++ b/debugger/session/src/session.rs
@@ -439,11 +439,11 @@ impl<'a, 'i> DebugSession<'a, 'i> {
                 return Ok(None);
             }
             let offset = self.current_byte_offset();
-            if self.engine.is_executing() {
-                if let Some(index) = self.initial_step_index_for_offset(offset, None) {
-                    self.mark_step_executed(index);
-                    return Ok(Some(self.state()));
-                }
+            if self.engine.is_executing()
+                && let Some(index) = self.initial_step_index_for_offset(offset, None)
+            {
+                self.mark_step_executed(index);
+                return Ok(Some(self.state()));
             }
             if self.step_opcode()?.is_none() {
                 return Ok(None);
@@ -461,10 +461,10 @@ impl<'a, 'i> DebugSession<'a, 'i> {
             if self.step_into()?.is_none() {
                 return Ok(None);
             }
-            if let Some(step) = self.current_timeline_step() {
-                if self.step_hits_breakpoint(step) {
-                    return Ok(Some(self.state()));
-                }
+            if let Some(step) = self.current_timeline_step()
+                && self.step_hits_breakpoint(step)
+            {
+                return Ok(Some(self.state()));
             }
         }
     }
@@ -1336,18 +1336,16 @@ impl<'a, 'i> DebugSession<'a, 'i> {
     }
 
     fn steppable_step_index_for_offset(&self, offset: usize, min_sequence: Option<u32>) -> Option<usize> {
-        if let Some(index) = self.current_step_index {
-            if let Some(step) = self.step_at_order(index) {
-                if !self.is_post_inline_call_source(step) {
-                    if let Some(boundary_index) = self.find_steppable_step_index(|candidate| {
-                        candidate.bytecode_start == offset
-                            && step.bytecode_end == offset
-                            && min_sequence.is_none_or(|min_sequence| candidate.sequence >= min_sequence)
-                    }) {
-                        return Some(boundary_index);
-                    }
-                }
-            }
+        if let Some(index) = self.current_step_index
+            && let Some(step) = self.step_at_order(index)
+            && !self.is_post_inline_call_source(step)
+            && let Some(boundary_index) = self.find_steppable_step_index(|candidate| {
+                candidate.bytecode_start == offset
+                    && step.bytecode_end == offset
+                    && min_sequence.is_none_or(|min_sequence| candidate.sequence >= min_sequence)
+            })
+        {
+            return Some(boundary_index);
         }
 
         self.find_steppable_step_index(|step| {
@@ -1405,19 +1403,19 @@ impl<'a, 'i> DebugSession<'a, 'i> {
     fn next_steppable_step_index(&self, from: Option<usize>, predicate: impl Fn(&DebugStep<'i>) -> bool) -> Option<usize> {
         let start = from.map(|index| index.saturating_add(1)).unwrap_or(0);
         let min_sequence = from.and_then(|index| self.step_at_order(index).map(|step| step.sequence));
-        if let Some(index) = from {
-            if let Some(step) = self.step_at_order(index) {
-                if matches!(step.kind, StepKind::InlineCallEnter { .. }) {
-                    if let Some(index) = self.find_post_inline_source_after(step, min_sequence, true, &predicate) {
-                        return Some(index);
-                    }
-                }
+        if let Some(index) = from
+            && let Some(step) = self.step_at_order(index)
+        {
+            if matches!(step.kind, StepKind::InlineCallEnter { .. })
+                && let Some(index) = self.find_post_inline_source_after(step, min_sequence, true, &predicate)
+            {
+                return Some(index);
+            }
 
-                if matches!(step.kind, StepKind::InlineCallEnter { .. }) || self.is_post_inline_call_source(step) {
-                    if let Some(index) = self.find_post_inline_source_after(step, min_sequence, false, &predicate) {
-                        return Some(index);
-                    }
-                }
+            if (matches!(step.kind, StepKind::InlineCallEnter { .. }) || self.is_post_inline_call_source(step))
+                && let Some(index) = self.find_post_inline_source_after(step, min_sequence, false, &predicate)
+            {
+                return Some(index);
             }
         }
         for index in start..self.step_order.len() {
@@ -1900,10 +1898,10 @@ impl<'a, 'i> DebugSession<'a, 'i> {
 
 /// Decodes raw bytes into a typed debug value based on the type name.
 fn decode_value_by_type(type_name: &str, bytes: Vec<u8>) -> Result<DebugValue, String> {
-    if let Some(element_type) = type_name.strip_suffix("[]") {
-        if let Some(element_size) = fixed_array_element_size(element_type) {
-            return decode_known_width_array(type_name, bytes, element_type, element_size);
-        }
+    if let Some(element_type) = type_name.strip_suffix("[]")
+        && let Some(element_size) = fixed_array_element_size(element_type)
+    {
+        return decode_known_width_array(type_name, bytes, element_type, element_size);
     }
 
     match type_name {
@@ -1922,7 +1920,7 @@ fn decode_known_width_array(type_name: &str, bytes: Vec<u8>, element_type: &str,
     if element_size == 0 {
         return Err(format!("array element type '{type_name}' has zero width"));
     }
-    if bytes.len() % element_size != 0 {
+    if !bytes.len().is_multiple_of(element_size) {
         return Err(format!("encoded value for '{type_name}' has invalid length {}", bytes.len()));
     }
 

--- a/debugger/session/tests/debug_session_tests.rs
+++ b/debugger/session/tests/debug_session_tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::error::Error;
 
 use kaspa_consensus_core::Hash;
@@ -19,9 +19,35 @@ use debugger_session::{
     format_value,
     session::{DebugSession, DebugValue, ShadowTxContext},
 };
-use silverscript_lang::ast::{Expr, parse_contract_ast, parse_type_ref};
-use silverscript_lang::compiler::{CompileOptions, compile_contract, struct_object};
+use silverscript_abi::{ArtifactValue, SilContractArtifact, encode_contract_entry_sig_script};
+use silverscript_debug_artifact::{SilDebugArtifact, compile_contract};
+use silverscript_lang::ast::parse_contract_ast;
+use silverscript_lang::compiler::CompileOptions;
 use silverscript_lang::debug_info::StepKind;
+
+fn single_contract<'a>(artifact: &'a SilDebugArtifact<'_>) -> &'a SilContractArtifact {
+    let [contract] = artifact.abi.contracts.as_slice() else {
+        panic!("expected exactly one contract");
+    };
+    contract
+}
+
+fn bytecode<'a>(artifact: &'a SilDebugArtifact<'_>) -> &'a [u8] {
+    &single_contract(artifact).compiled.bytecode
+}
+
+fn encode_entry_sig_script(
+    artifact: &SilDebugArtifact<'_>,
+    entry_name: &str,
+    args: &[ArtifactValue],
+) -> Result<Vec<u8>, silverscript_abi::CodecError> {
+    let contract = single_contract(artifact);
+    encode_contract_entry_sig_script(&artifact.abi, &contract.name, entry_name, args)
+}
+
+fn artifact_object(fields: impl IntoIterator<Item = (&'static str, ArtifactValue)>) -> ArtifactValue {
+    fields.into_iter().map(|(name, value)| (name.to_string(), value)).collect::<BTreeMap<_, _>>().into()
+}
 
 const IF_STATEMENT_CONTRACT: &str = r#"pragma silverscript ^0.1.0;
 
@@ -47,21 +73,15 @@ fn with_session<F>(mut f: F) -> Result<(), Box<dyn Error>>
 where
     F: FnMut(&mut DebugSession<'_, '_>) -> Result<(), Box<dyn Error>>,
 {
-    with_session_for_source(
-        IF_STATEMENT_CONTRACT,
-        vec![Expr::int(3), Expr::int(10)],
-        "hello",
-        vec![Expr::int(5), Expr::int(5)],
-        &mut f,
-    )
+    with_session_for_source(IF_STATEMENT_CONTRACT, vec![3.into(), 10.into()], "hello", vec![5.into(), 5.into()], &mut f)
 }
 
 // Generic harness that compiles a contract and boots a debugger session for a selected function call.
 fn with_session_for_source<F>(
     source: &str,
-    ctor_args: Vec<Expr<'static>>,
+    ctor_args: Vec<ArtifactValue>,
     function_name: &str,
-    function_args: Vec<Expr<'static>>,
+    function_args: Vec<ArtifactValue>,
     mut f: F,
 ) -> Result<(), Box<dyn Error>>
 where
@@ -73,7 +93,6 @@ where
     // Compile with debug metadata enabled so line steps and variable updates are available.
     let compile_opts = CompileOptions { record_debug_infos: true, ..Default::default() };
     let compiled = compile_contract(source, &ctor_args, compile_opts)?;
-    let debug_info = compiled.debug_info.clone();
 
     let sig_cache = Cache::new(10_000);
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -90,8 +109,8 @@ where
     assert_eq!(entry.params.len(), function_args.len());
 
     // Seed the stack with sigscript arguments, then execute the bytecode in debug mode.
-    let sigscript = compiled.build_sig_script(function_name, function_args)?;
-    let mut session = DebugSession::full(&sigscript, &compiled.bytecode, source, debug_info, engine)?;
+    let sigscript = encode_entry_sig_script(&compiled, function_name, &function_args)?;
+    let mut session = DebugSession::from_artifact(&sigscript, &compiled, &parsed_contract.name, engine)?;
 
     f(&mut session)
 }
@@ -125,7 +144,7 @@ contract ConsoleStep() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "inspect", vec![Expr::int(2), Expr::int(3)], |session| {
+    with_session_for_source(source, vec![], "inspect", vec![2.into(), 3.into()], |session| {
         session.run_to_first_executed_statement()?;
         assert_eq!(session.take_console_output(), vec!["sum 5"]);
 
@@ -180,7 +199,7 @@ contract BP() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(1)], |session| {
+    with_session_for_source(source, vec![], "main", vec![1.into()], |session| {
         session.run_to_first_executed_statement()?;
         // Line 8 is inside a multiline `require(...)` span and should still be hit.
         assert!(session.add_breakpoint(8), "expected breakpoint line to be valid");
@@ -206,7 +225,7 @@ contract Shadow(int x) {
 }
 "#;
 
-    with_session_for_source(source, vec![Expr::int(7)], "main", vec![Expr::int(3)], |session| {
+    with_session_for_source(source, vec![7.into()], "main", vec![3.into()], |session| {
         session.run_to_first_executed_statement()?;
 
         // Function param `x` should shadow constructor constant `x` in visible debugger variables.
@@ -235,7 +254,7 @@ contract ShadowMath(int fee) {
 }
 "#;
 
-    with_session_for_source(source, vec![Expr::int(2)], "main", vec![Expr::int(3)], |session| {
+    with_session_for_source(source, vec![2.into()], "main", vec![3.into()], |session| {
         session.run_to_first_executed_statement()?;
 
         session.step_over()?;
@@ -266,7 +285,7 @@ contract FieldOffset(int c) {
 }
 "#;
 
-    with_session_for_source(source, vec![Expr::int(2)], "main", vec![Expr::int(5)], |session| {
+    with_session_for_source(source, vec![2.into()], "main", vec![5.into()], |session| {
         session.run_to_first_executed_statement()?;
 
         let a = session.variable_by_name("a")?;
@@ -292,7 +311,7 @@ contract FieldMath(int c) {
 }
 "#;
 
-    with_session_for_source(source, vec![Expr::int(2)], "main", vec![Expr::int(5)], |session| {
+    with_session_for_source(source, vec![2.into()], "main", vec![5.into()], |session| {
         session.run_to_first_executed_statement()?;
 
         for _ in 0..4 {
@@ -322,7 +341,7 @@ contract Virtuals() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(3)], |session| {
+    with_session_for_source(source, vec![], "main", vec![3.into()], |session| {
         session.run_to_first_executed_statement()?;
         let first = session.current_step().ok_or("missing first location")?;
         assert!(matches!(first.kind, StepKind::Source {}));
@@ -352,7 +371,7 @@ contract OpcodeCursor() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(3)], |session| {
+    with_session_for_source(source, vec![], "main", vec![3.into()], |session| {
         session.run_to_first_executed_statement()?;
         let start = session.current_span().ok_or("missing start span")?;
         assert_eq!(start.line, 5);
@@ -389,7 +408,7 @@ contract VirtualBp() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(3)], |session| {
+    with_session_for_source(source, vec![], "main", vec![3.into()], |session| {
         session.run_to_first_executed_statement()?;
         assert!(session.add_breakpoint(6), "line with assignment should be a valid breakpoint");
         let hit = session.continue_to_breakpoint()?;
@@ -413,7 +432,7 @@ contract LocalVars() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(3)], |session| {
+    with_session_for_source(source, vec![], "main", vec![3.into()], |session| {
         session.run_to_first_executed_statement()?;
         assert!(session.variable_by_name("x").is_err(), "x should not exist before its statement executes");
 
@@ -460,7 +479,7 @@ contract InlineCalls() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(3)], |session| {
+    with_session_for_source(source, vec![], "main", vec![3.into()], |session| {
         session.run_to_first_executed_statement()?;
         let start = session.current_step().ok_or("missing start step")?;
         assert_eq!(start.span.line, 10);
@@ -473,7 +492,7 @@ contract InlineCalls() {
         Ok(())
     })?;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(3)], |session| {
+    with_session_for_source(source, vec![], "main", vec![3.into()], |session| {
         session.run_to_first_executed_statement()?;
         session.step_into()?;
         let mut in_callee = session.current_span().ok_or("missing span in callee")?;
@@ -513,7 +532,7 @@ contract Repeat() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(0)], |session| {
+    with_session_for_source(source, vec![], "main", vec![0.into()], |session| {
         session.run_to_first_executed_statement()?;
         let start = session.current_span().ok_or("missing start span")?;
         assert_eq!(start.line, 10, "first source step should be caller line, not callee internals");
@@ -539,7 +558,7 @@ contract Repeat() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(0)], |session| {
+    with_session_for_source(source, vec![], "main", vec![0.into()], |session| {
         session.run_to_first_executed_statement()?;
 
         let mut lines = vec![session.current_span().ok_or("missing initial span")?.line];
@@ -621,7 +640,7 @@ contract DebugPoC(int const) {
 }
 "#;
 
-    with_session_for_source(source, vec![Expr::int(0)], "main", vec![Expr::int(0), Expr::int(0)], |session| {
+    with_session_for_source(source, vec![0.into()], "main", vec![0.into(), 0.into()], |session| {
         session.run_to_first_executed_statement()?;
 
         let initial = session.current_step().ok_or("missing initial location")?;
@@ -667,7 +686,7 @@ contract InlineParams() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(4)], |session| {
+    with_session_for_source(source, vec![], "main", vec![4.into()], |session| {
         session.run_to_first_executed_statement()?;
 
         let mut saw_inline_param = false;
@@ -709,7 +728,7 @@ contract InlineEval() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(4)], |session| {
+    with_session_for_source(source, vec![], "main", vec![4.into()], |session| {
         session.run_to_first_executed_statement()?;
         assert!(session.add_breakpoint(6), "expected inline callee line to accept a breakpoint");
 
@@ -748,7 +767,7 @@ contract ScopeKinds(int init_amount) {
 }
 "#;
 
-    with_session_for_source(source, vec![Expr::int(7)], "main", vec![Expr::int(3)], |session| {
+    with_session_for_source(source, vec![7.into()], "main", vec![3.into()], |session| {
         session.run_to_first_executed_statement()?;
 
         let vars = session.list_variables()?;
@@ -786,23 +805,17 @@ contract StepVisibility(int init_amount) {
 }
 "#;
 
-    with_session_for_source(
-        source,
-        vec![Expr::int(7)],
-        "inspect",
-        vec![Expr::int(3), Expr::array(parse_type_ref("int[]")?, vec![Expr::int(4)])],
-        |session| {
-            session.run_to_first_executed_statement()?;
-            session.current_span().ok_or("missing starting span")?;
+    with_session_for_source(source, vec![7.into()], "inspect", vec![3.into(), ArtifactValue::Array(vec![4.into()])], |session| {
+        session.run_to_first_executed_statement()?;
+        session.current_span().ok_or("missing starting span")?;
 
-            session.step_over()?;
-            session.current_span().ok_or("missing span after step")?;
+        session.step_over()?;
+        session.current_span().ok_or("missing span after step")?;
 
-            let base = session.variable_by_name("base")?;
-            assert_eq!(format_value(&base.type_name, &base.value), "11");
-            Ok(())
-        },
-    )
+        let base = session.variable_by_name("base")?;
+        assert_eq!(format_value(&base.type_name, &base.value), "11");
+        Ok(())
+    })
 }
 
 #[test]
@@ -828,47 +841,41 @@ contract ShiftedBindings() {
 }
 "#;
 
-    with_session_for_source(
-        source,
-        vec![],
-        "inspect",
-        vec![Expr::int(3), Expr::array(parse_type_ref("int[]")?, vec![Expr::int(4), Expr::int(5)])],
-        |session| {
-            session.run_to_first_executed_statement()?;
+    with_session_for_source(source, vec![], "inspect", vec![3.into(), ArtifactValue::Array(vec![4.into(), 5.into()])], |session| {
+        session.run_to_first_executed_statement()?;
 
-            session.step_over()?;
-            let call_line = session.current_span().ok_or("missing inline-call span")?.line;
+        session.step_over()?;
+        let call_line = session.current_span().ok_or("missing inline-call span")?.line;
 
-            for _ in 0..6 {
-                if session.current_span().is_some_and(|span| span.line > call_line) {
-                    break;
-                }
-                if session.step_over()?.is_none() {
-                    break;
-                }
+        for _ in 0..6 {
+            if session.current_span().is_some_and(|span| span.line > call_line) {
+                break;
             }
+            if session.step_over()?.is_none() {
+                break;
+            }
+        }
 
-            let current_line = session.current_span().ok_or("missing post-call span")?.line;
-            assert!(current_line > call_line, "expected to step past inline call");
+        let current_line = session.current_span().ok_or("missing post-call span")?.line;
+        assert!(current_line > call_line, "expected to step past inline call");
 
-            let amount = session.variable_by_name("amount")?;
-            assert_eq!(format_value(&amount.type_name, &amount.value), "11");
+        let amount = session.variable_by_name("amount")?;
+        assert_eq!(format_value(&amount.type_name, &amount.value), "11");
 
-            let delta = session.variable_by_name("delta")?;
-            assert_eq!(format_value(&delta.type_name, &delta.value), "3");
+        let delta = session.variable_by_name("delta")?;
+        assert_eq!(format_value(&delta.type_name, &delta.value), "3");
 
-            let values = session.variable_by_name("values")?;
-            assert_eq!(format_value(&values.type_name, &values.value), "[4, 5]");
+        let values = session.variable_by_name("values")?;
+        assert_eq!(format_value(&values.type_name, &values.value), "[4, 5]");
 
-            let base = session.variable_by_name("base")?;
-            assert_eq!(format_value(&base.type_name, &base.value), "15");
+        let base = session.variable_by_name("base")?;
+        assert_eq!(format_value(&base.type_name, &base.value), "15");
 
-            let after = session.variable_by_name("after")?;
-            assert_eq!(format_value(&after.type_name, &after.value), "20");
+        let after = session.variable_by_name("after")?;
+        assert_eq!(format_value(&after.type_name, &after.value), "20");
 
-            Ok(())
-        },
-    )
+        Ok(())
+    })
 }
 
 #[test]
@@ -891,7 +898,7 @@ contract StructuredEvalState() {
         source,
         vec![],
         "inspect",
-        vec![struct_object("State", vec![("amount", Expr::int(5)), ("active", Expr::bool(true)), ("tag", Expr::bytes(vec![0xaa]))])],
+        vec![artifact_object([("amount", 5.into()), ("active", true.into()), ("tag", vec![0xaau8].into())])],
         |session| {
             session.run_to_first_executed_statement()?;
 
@@ -930,13 +937,10 @@ contract StructuredEvalStateArray() {
         source,
         vec![],
         "inspect",
-        vec![Expr::array(
-            parse_type_ref("State[]")?,
-            vec![
-                struct_object("State", vec![("amount", Expr::int(5)), ("active", Expr::bool(true)), ("tag", Expr::bytes(vec![0xaa]))]),
-                struct_object("State", vec![("amount", Expr::int(7)), ("active", Expr::bool(true)), ("tag", Expr::bytes(vec![0xaa]))]),
-            ],
-        )],
+        vec![ArtifactValue::Array(vec![
+            artifact_object([("amount", 5.into()), ("active", true.into()), ("tag", vec![0xaau8].into())]),
+            artifact_object([("amount", 7.into()), ("active", true.into()), ("tag", vec![0xaau8].into())]),
+        ])],
         |session| {
             session.run_to_first_executed_statement()?;
 
@@ -983,7 +987,7 @@ contract StructuredEvalPair() {
         source,
         vec![],
         "inspect",
-        vec![struct_object("Pair", vec![("amount", Expr::int(9)), ("code", Expr::bytes(vec![0x12, 0x34]))])],
+        vec![artifact_object([("amount", 9.into()), ("code", vec![0x12u8, 0x34].into())])],
         |session| {
             session.run_to_first_executed_statement()?;
 
@@ -1028,7 +1032,7 @@ contract InlineStructuredEval() {
         source,
         vec![],
         "inspect",
-        vec![struct_object("State", vec![("amount", Expr::int(5)), ("active", Expr::bool(true)), ("tag", Expr::bytes(vec![0xaa]))])],
+        vec![artifact_object([("amount", 5.into()), ("active", true.into()), ("tag", vec![0xaau8].into())])],
         |session| {
             session.run_to_first_executed_statement()?;
 
@@ -1079,16 +1083,15 @@ contract MissingStructuredSource() {
 "#;
 
     let compile_opts = CompileOptions { record_debug_infos: true, ..Default::default() };
-    let compiled = compile_contract(source, &[], compile_opts)?;
-    let mut debug_info = compiled.debug_info.clone().ok_or("missing debug info")?;
-    debug_info.source.clear();
+    let mut compiled = compile_contract(source, &[], compile_opts)?;
+    compiled.contract_debug_info.get_mut("MissingStructuredSource").ok_or("missing debug info")?.source.clear();
 
     let sig_cache = Cache::new(10_000);
     let reused_values = SigHashReusedValuesUnsync::new();
     let ctx = EngineCtx::new(&sig_cache).with_reused(&reused_values);
     let engine = debugger_session::session::DebugEngine::new(ctx, EngineFlags { covenants_enabled: true, ..Default::default() });
-    let sigscript = compiled.build_sig_script("inspect", vec![struct_object("State", vec![("amount", Expr::int(7))])])?;
-    let mut session = DebugSession::full(&sigscript, &compiled.bytecode, "", Some(debug_info), engine)?;
+    let sigscript = encode_entry_sig_script(&compiled, "inspect", &[artifact_object([("amount", 7.into())])])?;
+    let mut session = DebugSession::from_artifact(&sigscript, &compiled, "MissingStructuredSource", engine)?;
 
     session.run_to_first_executed_statement()?;
     let (type_name, value) = session.evaluate_expression("next.amount")?;
@@ -1119,7 +1122,7 @@ contract NestedArgs() {
 }
 "#;
 
-    with_session_for_source(source, vec![], "main", vec![Expr::int(0)], |session| {
+    with_session_for_source(source, vec![], "main", vec![0.into()], |session| {
         session.run_to_first_executed_statement()?;
         let start = session.current_step().ok_or("missing start step")?;
         assert_eq!(start.span.line, 15);
@@ -1639,8 +1642,7 @@ contract CovLocal() {
 
     let compile_opts = CompileOptions { record_debug_infos: true, ..Default::default() };
     let compiled = compile_contract(source, &[], compile_opts)?;
-    let debug_info = compiled.debug_info.clone();
-    let sigscript = compiled.build_sig_script("main", vec![])?;
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[])?;
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([0x44u8; 32]), index: 0 },
@@ -1653,7 +1655,7 @@ contract CovLocal() {
 
     let covenant_id = Hash::from_bytes([0x11u8; 32]);
     let utxo_entry =
-        UtxoEntry::new(1000, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), Some(covenant_id));
+        UtxoEntry::new(1000, ScriptPublicKey::new(0, bytecode(&compiled).to_vec().into()), 0, tx.is_coinbase(), Some(covenant_id));
     let populated_tx = PopulatedTransaction::new(&tx, vec![utxo_entry]);
     let cov_ctx = CovenantsContext::from_tx(&populated_tx)?;
 
@@ -1673,8 +1675,7 @@ contract CovLocal() {
     let shadow_ctx =
         ShadowTxContext { tx: &populated_tx, input: input_ref, input_index: 0, utxo_entry: utxo_ref, covenants_ctx: &cov_ctx };
 
-    let mut session =
-        DebugSession::full(&sigscript, &compiled.bytecode, source, debug_info, engine)?.with_shadow_tx_context(shadow_ctx);
+    let mut session = DebugSession::from_artifact(&sigscript, &compiled, "CovLocal", engine)?.with_shadow_tx_context(shadow_ctx);
     session.run_to_first_executed_statement()?;
 
     for _ in 0..4 {
@@ -1704,8 +1705,7 @@ contract CovEval() {
 
     let compile_opts = CompileOptions { record_debug_infos: true, ..Default::default() };
     let compiled = compile_contract(source, &[], compile_opts)?;
-    let debug_info = compiled.debug_info.clone();
-    let sigscript = compiled.build_sig_script("main", vec![])?;
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[])?;
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([0x44u8; 32]), index: 0 },
@@ -1718,7 +1718,7 @@ contract CovEval() {
 
     let covenant_id = Hash::from_bytes([0x22u8; 32]);
     let utxo_entry =
-        UtxoEntry::new(1000, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), Some(covenant_id));
+        UtxoEntry::new(1000, ScriptPublicKey::new(0, bytecode(&compiled).to_vec().into()), 0, tx.is_coinbase(), Some(covenant_id));
     let populated_tx = PopulatedTransaction::new(&tx, vec![utxo_entry]);
     let cov_ctx = CovenantsContext::from_tx(&populated_tx)?;
 
@@ -1739,8 +1739,7 @@ contract CovEval() {
     let shadow_ctx =
         ShadowTxContext { tx: &populated_tx, input: input_ref, input_index: 0, utxo_entry: utxo_ref, covenants_ctx: &cov_ctx };
 
-    let mut session =
-        DebugSession::full(&sigscript, &compiled.bytecode, source, debug_info, engine)?.with_shadow_tx_context(shadow_ctx);
+    let mut session = DebugSession::from_artifact(&sigscript, &compiled, "CovEval", engine)?.with_shadow_tx_context(shadow_ctx);
     session.run_to_first_executed_statement()?;
 
     let (type_name, value) = session.evaluate_expression("OpInputCovenantId(this.activeInputIndex)")?;
@@ -1777,7 +1776,8 @@ fn covenant_debugger_resolves_overridden_public_entrypoint_names() -> Result<(),
 
     let parsed = parse_contract_ast(source)?;
     let compiled = compile_contract(source, &[], CompileOptions::default())?;
-    let target = resolve_covenant_call_target(&parsed, &compiled, "transferPolicy").ok_or("missing covenant call target")?;
+    let target =
+        resolve_covenant_call_target(&parsed, single_contract(&compiled), "transferPolicy").ok_or("missing covenant call target")?;
 
     assert_eq!(target.generated_entrypoint_name, "transfer");
     assert_eq!(target.generated_entrypoint_name_for(true), "transfer");
@@ -1788,7 +1788,7 @@ fn covenant_debugger_resolves_overridden_public_entrypoint_names() -> Result<(),
     assert_eq!(delegate_body.source_name, "authorizeDelegate");
     assert_eq!(delegate_body.policy_function_name, "__covenant_delegate_policy_authorizeDelegate");
     assert_eq!(target.display_name_for(&delegate_body.policy_function_name), Some("authorizeDelegate"));
-    assert!(resolve_covenant_call_target(&parsed, &compiled, "authorizeDelegate").is_none());
+    assert!(resolve_covenant_call_target(&parsed, single_contract(&compiled), "authorizeDelegate").is_none());
     Ok(())
 }
 
@@ -1823,11 +1823,11 @@ contract Routed() {
     let parsed_contract = parse_contract_ast(source)?;
     let compile_opts = CompileOptions { record_debug_infos: true, ..Default::default() };
     let compiled = compile_contract(source, &[], compile_opts)?;
-    let target = resolve_covenant_call_target(&parsed_contract, &compiled, "transferPolicy").ok_or("missing covenant call target")?;
-    let delegate_sigscript =
-        compiled.build_sig_script(&target.generated_entrypoint_name_for(false), vec![Expr::dynamic_bytes(vec![7])])?;
+    let target = resolve_covenant_call_target(&parsed_contract, single_contract(&compiled), "transferPolicy")
+        .ok_or("missing covenant call target")?;
+    let delegate_sigscript = encode_entry_sig_script(&compiled, &target.generated_entrypoint_name_for(false), &[vec![7u8].into()])?;
     let mut input_sigscript = delegate_sigscript.clone();
-    input_sigscript.extend_from_slice(&push_redeem_script(&compiled.bytecode));
+    input_sigscript.extend_from_slice(&push_redeem_script(bytecode(&compiled)));
 
     let inputs = vec![
         TransactionInput {
@@ -1847,8 +1847,8 @@ contract Routed() {
     let tx = Transaction::new(1, inputs, vec![output], 0, Default::default(), 0, vec![]);
     let covenant_id = Hash::from_bytes([0x88u8; 32]);
     let utxos = vec![
-        UtxoEntry::new(1000, pay_to_script_hash_script(&compiled.bytecode), 0, tx.is_coinbase(), Some(covenant_id)),
-        UtxoEntry::new(1000, pay_to_script_hash_script(&compiled.bytecode), 0, tx.is_coinbase(), Some(covenant_id)),
+        UtxoEntry::new(1000, pay_to_script_hash_script(bytecode(&compiled)), 0, tx.is_coinbase(), Some(covenant_id)),
+        UtxoEntry::new(1000, pay_to_script_hash_script(bytecode(&compiled)), 0, tx.is_coinbase(), Some(covenant_id)),
     ];
     let populated_tx = PopulatedTransaction::new(&tx, utxos);
     let cov_ctx = CovenantsContext::from_tx(&populated_tx)?;
@@ -1868,7 +1868,7 @@ contract Routed() {
     );
     let shadow_ctx =
         ShadowTxContext { tx: &populated_tx, input: input_ref, input_index: 1, utxo_entry: utxo_ref, covenants_ctx: &cov_ctx };
-    let mut session = DebugSession::full(&delegate_sigscript, &compiled.bytecode, source, compiled.debug_info.clone(), engine)?
+    let mut session = DebugSession::from_artifact(&delegate_sigscript, &compiled, "Routed", engine)?
         .with_shadow_tx_context(shadow_ctx)
         .with_covenant_mode(None, Some(target));
 
@@ -1911,20 +1911,18 @@ contract CovDebugDemo(int initial_value) {
 
     let parsed_contract = parse_contract_ast(source)?;
     let compile_opts = CompileOptions { record_debug_infos: true, ..Default::default() };
-    let compiled0 = compile_contract(source, &[Expr::int(10)], compile_opts)?;
-    let compiled1 = compile_contract(source, &[Expr::int(20)], compile_opts)?;
-    let leader_args = vec![Expr::array(
-        parse_type_ref("State[]")?,
-        vec![struct_object("State", vec![("value", Expr::int(30))]), struct_object("State", vec![("value", Expr::int(40))])],
-    )];
-    let leader_target =
-        resolve_covenant_call_target(&parsed_contract, &compiled0, "rebalance").ok_or("missing covenant call target")?;
-    let leader_sigscript = compiled0.build_sig_script(&leader_target.generated_entrypoint_name, leader_args)?;
+    let compiled0 = compile_contract(source, &[10.into()], compile_opts)?;
+    let compiled1 = compile_contract(source, &[20.into()], compile_opts)?;
+    let leader_args =
+        vec![ArtifactValue::Array(vec![artifact_object([("value", 30.into())]), artifact_object([("value", 40.into())])])];
+    let leader_target = resolve_covenant_call_target(&parsed_contract, single_contract(&compiled0), "rebalance")
+        .ok_or("missing covenant call target")?;
+    let leader_sigscript = encode_entry_sig_script(&compiled0, &leader_target.generated_entrypoint_name, &leader_args)?;
     let mut leader_input_sigscript = leader_sigscript.clone();
-    leader_input_sigscript.extend_from_slice(&push_redeem_script(&compiled0.bytecode));
-    let delegate_sigscript = compiled1.build_sig_script(&leader_target.generated_entrypoint_name_for(false), vec![])?;
+    leader_input_sigscript.extend_from_slice(&push_redeem_script(bytecode(&compiled0)));
+    let delegate_sigscript = encode_entry_sig_script(&compiled1, &leader_target.generated_entrypoint_name_for(false), &[])?;
     let mut delegate_input_sigscript = delegate_sigscript.clone();
-    delegate_input_sigscript.extend_from_slice(&push_redeem_script(&compiled1.bytecode));
+    delegate_input_sigscript.extend_from_slice(&push_redeem_script(bytecode(&compiled1)));
 
     let covenant_id = Hash::from_bytes([0x33u8; 32]);
     let inputs = vec![
@@ -1941,25 +1939,25 @@ contract CovDebugDemo(int initial_value) {
             compute_commit: SigopCount(0).into(),
         },
     ];
-    let next0 = compile_contract(source, &[Expr::int(30)], compile_opts)?;
-    let next1 = compile_contract(source, &[Expr::int(40)], compile_opts)?;
+    let next0 = compile_contract(source, &[30.into()], compile_opts)?;
+    let next1 = compile_contract(source, &[40.into()], compile_opts)?;
     let outputs = vec![
         TransactionOutput {
             value: 1000,
-            script_public_key: pay_to_script_hash_script(&next0.bytecode),
+            script_public_key: pay_to_script_hash_script(bytecode(&next0)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id }),
         },
         TransactionOutput {
             value: 1000,
-            script_public_key: pay_to_script_hash_script(&next1.bytecode),
+            script_public_key: pay_to_script_hash_script(bytecode(&next1)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id }),
         },
     ];
     let tx = Transaction::new(1, inputs, outputs, 0, Default::default(), 0, vec![]);
 
     let utxos = vec![
-        UtxoEntry::new(1000, pay_to_script_hash_script(&compiled0.bytecode), 0, tx.is_coinbase(), Some(covenant_id)),
-        UtxoEntry::new(1000, pay_to_script_hash_script(&compiled1.bytecode), 0, tx.is_coinbase(), Some(covenant_id)),
+        UtxoEntry::new(1000, pay_to_script_hash_script(bytecode(&compiled0)), 0, tx.is_coinbase(), Some(covenant_id)),
+        UtxoEntry::new(1000, pay_to_script_hash_script(bytecode(&compiled1)), 0, tx.is_coinbase(), Some(covenant_id)),
     ];
     let populated_tx = PopulatedTransaction::new(&tx, utxos);
     let cov_ctx = CovenantsContext::from_tx(&populated_tx)?;
@@ -1981,7 +1979,7 @@ contract CovDebugDemo(int initial_value) {
     let shadow_ctx =
         ShadowTxContext { tx: &populated_tx, input: input_ref, input_index: 0, utxo_entry: utxo_ref, covenants_ctx: &cov_ctx };
 
-    let mut session = DebugSession::full(&leader_sigscript, &compiled0.bytecode, source, compiled0.debug_info.clone(), engine)?
+    let mut session = DebugSession::from_artifact(&leader_sigscript, &compiled0, "CovDebugDemo", engine)?
         .with_shadow_tx_context(shadow_ctx)
         .with_covenant_mode(Some(DebugValue::Array(vec![covenant_debug_value(10), covenant_debug_value(20)])), Some(leader_target));
 

--- a/debugger/session/tests/debug_session_tests.rs
+++ b/debugger/session/tests/debug_session_tests.rs
@@ -694,13 +694,11 @@ contract InlineParams() {
         let mut saw_inline_param = false;
         for _ in 0..8 {
             let in_callee = session.call_stack().iter().any(|name| name == "add1");
-            if in_callee {
-                if let Ok(x) = session.variable_by_name("x") {
-                    let rendered = format_value(&x.type_name, &x.value);
-                    assert_eq!(rendered, "4", "inline param x should reflect caller-provided value");
-                    saw_inline_param = true;
-                    break;
-                }
+            if in_callee && let Ok(x) = session.variable_by_name("x") {
+                let rendered = format_value(&x.type_name, &x.value);
+                assert_eq!(rendered, "4", "inline param x should reflect caller-provided value");
+                saw_inline_param = true;
+                break;
             }
             if session.step_into()?.is_none() {
                 break;
@@ -1191,11 +1189,11 @@ contract LoopStepOver() {
 
         let mut saw_first_iteration = false;
         for _ in 0..8 {
-            if let Ok(i) = session.variable_by_name("i") {
-                if format_value(&i.type_name, &i.value) == "0" {
-                    saw_first_iteration = true;
-                    break;
-                }
+            if let Ok(i) = session.variable_by_name("i")
+                && format_value(&i.type_name, &i.value) == "0"
+            {
+                saw_first_iteration = true;
+                break;
             }
             session.step_over()?.ok_or("expected to reach first loop iteration")?;
         }
@@ -1208,11 +1206,11 @@ contract LoopStepOver() {
 
         let mut saw_second_iteration = false;
         for _ in 0..8 {
-            if let Ok(i) = session.variable_by_name("i") {
-                if format_value(&i.type_name, &i.value) == "1" {
-                    saw_second_iteration = true;
-                    break;
-                }
+            if let Ok(i) = session.variable_by_name("i")
+                && format_value(&i.type_name, &i.value) == "1"
+            {
+                saw_second_iteration = true;
+                break;
             }
             if session.step_over()?.is_none() {
                 break;

--- a/debugger/session/tests/debug_session_tests.rs
+++ b/debugger/session/tests/debug_session_tests.rs
@@ -26,7 +26,7 @@ use silverscript_lang::compiler::CompileOptions;
 use silverscript_lang::debug_info::StepKind;
 
 fn single_contract<'a>(artifact: &'a SilDebugArtifact<'_>) -> &'a SilContractArtifact {
-    let [contract] = artifact.abi.contracts.as_slice() else {
+    let Some(contract) = artifact.abi.contracts.values().next().filter(|_| artifact.abi.contracts.len() == 1) else {
         panic!("expected exactly one contract");
     };
     contract
@@ -41,8 +41,10 @@ fn encode_entry_sig_script(
     entry_name: &str,
     args: &[ArtifactValue],
 ) -> Result<Vec<u8>, silverscript_abi::CodecError> {
-    let contract = single_contract(artifact);
-    encode_contract_entry_sig_script(&artifact.abi, &contract.name, entry_name, args)
+    let Some((contract_name, _)) = artifact.abi.contracts.first_key_value().filter(|_| artifact.abi.contracts.len() == 1) else {
+        panic!("expected exactly one contract");
+    };
+    encode_contract_entry_sig_script(&artifact.abi, contract_name, entry_name, args)
 }
 
 fn artifact_object(fields: impl IntoIterator<Item = (&'static str, ArtifactValue)>) -> ArtifactValue {

--- a/debugger/session/tests/debug_session_tests.rs
+++ b/debugger/session/tests/debug_session_tests.rs
@@ -82,9 +82,12 @@ where
     let flags = EngineFlags { covenants_enabled: true, ..Default::default() };
     let engine = debugger_session::session::DebugEngine::new(ctx, flags);
 
-    let entry = compiled.entry_by_name(function_name).ok_or_else(|| format!("function '{function_name}' not found"))?;
-
-    assert_eq!(entry.inputs.len(), function_args.len());
+    let entry = parsed_contract
+        .functions
+        .iter()
+        .find(|function| function.entrypoint && function.name == function_name)
+        .ok_or_else(|| format!("function '{function_name}' not found"))?;
+    assert_eq!(entry.params.len(), function_args.len());
 
     // Seed the stack with sigscript arguments, then execute the bytecode in debug mode.
     let sigscript = compiled.build_sig_script(function_name, function_args)?;

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -111,7 +111,6 @@ The output is a portable `SilAbiArtifact` JSON document containing:
 You can also compile contracts programmatically using the SilverScript Rust library:
 
 ```rust
-use silverscript_abi::decode_hex;
 use silverscript_lang::compiler::sil_abi_artifact;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -127,10 +126,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     // Constructor arguments (x = 100)
     let artifact = sil_abi_artifact(source, &[100.into()])?;
-    let contract = artifact.contract("MyContract").expect("contract exists");
+    let (contract_name, contract) = artifact.contracts.get_key_value("MyContract").expect("contract exists");
 
-    println!("Contract name: {}", contract.name);
-    println!("Bytecode length: {} bytes", decode_hex(&contract.compiled.script_hex)?.len());
+    println!("Contract name: {contract_name}");
+    println!("Bytecode length: {} bytes", contract.compiled.bytecode.len());
     println!("Entries: {:?}", contract.entries);
     
     Ok(())

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -111,8 +111,8 @@ The output is a portable `SilAbiArtifact` JSON document containing:
 You can also compile contracts programmatically using the SilverScript Rust library:
 
 ```rust
-use silverscript_lang::compiler::{compile_contract, CompileOptions};
-use silverscript_lang::ast::Expr;
+use silverscript_abi::decode_hex;
+use silverscript_lang::compiler::sil_abi_artifact;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let source = r#"
@@ -126,16 +126,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     "#;
     
     // Constructor arguments (x = 100)
-    let constructor_args = vec![Expr::Int(100)];
-    
-    // Compile with default options
-    let options = CompileOptions::default();
-    let compiled = compile_contract(source, &constructor_args, options)?;
-    
-    println!("Contract name: {}", compiled.contract_name);
-    println!("Compiler version: {}", compiled.compiler_version);
-    println!("Bytecode length: {} bytes", compiled.bytecode.len());
-    println!("ABI: {:?}", compiled.abi);
+    let artifact = sil_abi_artifact(source, &[100.into()])?;
+    let contract = artifact.contract("MyContract").expect("contract exists");
+
+    println!("Contract name: {}", contract.name);
+    println!("Bytecode length: {} bytes", decode_hex(&contract.compiled.script_hex)?.len());
+    println!("Entries: {:?}", contract.entries);
     
     Ok(())
 }
@@ -146,7 +142,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 After compiling a contract, you can build signature scripts for its entries:
 
 ```rust
-use silverscript_lang::ast::Expr;
+use silverscript_abi::encode_contract_entry_sig_script;
+use silverscript_lang::compiler::sil_abi_artifact;
 
 let source = r#"
     pragma silverscript ^0.1.0;
@@ -166,31 +163,34 @@ let source = r#"
 let sender_pk = vec![3u8; 32];
 let recipient_pk = vec![4u8; 32];
 let timeout = 1640000000000i64;
-let compiled = compile_contract(
+let artifact = sil_abi_artifact(
     source,
-    &[sender_pk.into(), recipient_pk.into(), Expr::temporal(timeout)],
-    CompileOptions::default()
+    &[sender_pk.into(), recipient_pk.into(), timeout.into()],
 )?;
 
 // Build sigscript for multiple entrypoints
 let sig = vec![5u8; 65];
 
 // For the 'transfer' entrypoint
-let transfer_sigscript = compiled.build_sig_script(
+let transfer_sigscript = encode_contract_entry_sig_script(
+    &artifact,
+    "TransferWithTimeout",
     "transfer",
-    vec![sig.clone().into()]
+    &[sig.clone().into()],
 )?;
 // transfer_sigscript contains: <signature> <4-byte KCC-01 dispatch tag>
 
 // For the 'reclaim' entrypoint
-let reclaim_sigscript = compiled.build_sig_script(
+let reclaim_sigscript = encode_contract_entry_sig_script(
+    &artifact,
+    "TransferWithTimeout",
     "reclaim",
-    vec![sig.into()]
+    &[sig.into()],
 )?;
 // reclaim_sigscript contains: <signature> <4-byte KCC-01 dispatch tag>
 ```
 
-The `build_sig_script` method automatically:
+`encode_contract_entry_sig_script` automatically:
 - Validates argument count and types
 - Encodes arguments properly for the Kaspa script stack
 - Appends the KCC-01 function-signature dispatch tag

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -91,21 +91,20 @@ If your contract has constructor parameters, you can provide their values via a 
 silverc contract.sil --constructor-args args.json
 ```
 
-The `args.json` file should contain an array of constructor argument expressions. For example:
+The `args.json` file should contain an array of portable ABI values. For example:
 
 ```json
 [
-  {"kind": "byte[]", "data": [1, 2, 3, 4]},
-  {"kind": "int", "data": 12345}
+  {"kind": "bytes", "value": [1, 2, 3, 4]},
+  {"kind": "int", "value": 12345}
 ]
 ```
 
-The compiled JSON output includes:
-- `contract_name`: The name of the contract
-- `compiler_version`: The SilverScript compiler version that produced the artifact
-- `bytecode`: The compiled bytecode (as an array of bytes)
-- `ast`: The abstract syntax tree of the parsed contract
-- `abi`: An array of entries with their parameter types
+The output is a portable `SilAbiArtifact` JSON document containing:
+
+- `schema_version`: The portable ABI schema version
+- `states`: Struct definitions referenced by contract inputs and runtime state
+- `contracts`: The compiled contract, its entries, dispatch tags, script, template hash, and state span
 
 ### Programmatic Compilation
 

--- a/silverscript-abi/Cargo.toml
+++ b/silverscript-abi/Cargo.toml
@@ -9,9 +9,10 @@ blake3 = { workspace = true }
 faster-hex = { workspace = true }
 kaspa-txscript = { workspace = true }
 serde = { workspace = true }
+serde_bytes = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-serde_json = { workspace = true }
 # Keep the Sil compiler test-only; production ABI code must not depend on it.
 silverscript-lang = { workspace = true }

--- a/silverscript-abi/Cargo.toml
+++ b/silverscript-abi/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "silverscript-abi"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.94.0"
+
+[dependencies]
+blake3 = { workspace = true }
+faster-hex = { workspace = true }
+kaspa-txscript = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+# Keep the Sil compiler test-only; production ABI code must not depend on it.
+silverscript-lang = { workspace = true }

--- a/silverscript-abi/Cargo.toml
+++ b/silverscript-abi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "silverscript-abi"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.94.0"
+rust-version.workspace = true
 
 [dependencies]
 blake3 = { workspace = true }

--- a/silverscript-abi/src/json.rs
+++ b/silverscript-abi/src/json.rs
@@ -1,0 +1,184 @@
+//! JSON formatting for portable Sil artifacts.
+
+use std::io::{self, Write};
+
+use serde::Serialize;
+use serde_json::ser::{Formatter, PrettyFormatter};
+
+const BYTES_PER_LINE: usize = 64;
+const INDENT: &[u8] = b"  ";
+
+/// Serialize a value as readable JSON while keeping byte arrays compact.
+pub fn to_pretty_json<T>(value: &T) -> serde_json::Result<String>
+where
+    T: ?Sized + Serialize,
+{
+    let mut output = Vec::new();
+    let formatter = ByteArrayPrettyFormatter::new();
+    let mut serializer = serde_json::Serializer::with_formatter(&mut output, formatter);
+    value.serialize(&mut serializer)?;
+    Ok(String::from_utf8(output).expect("the JSON serializer emits UTF-8"))
+}
+
+struct ByteArrayPrettyFormatter<'a> {
+    inner: PrettyFormatter<'a>,
+    depth: usize,
+    indent: &'a [u8],
+}
+
+impl ByteArrayPrettyFormatter<'static> {
+    fn new() -> Self {
+        Self { inner: PrettyFormatter::with_indent(INDENT), depth: 0, indent: INDENT }
+    }
+}
+
+macro_rules! delegate {
+    ($name:ident $(, $arg:ident: $ty:ty)*) => {
+        fn $name<W>(&mut self, writer: &mut W, $($arg: $ty),*) -> io::Result<()>
+        where
+            W: ?Sized + Write,
+        {
+            self.inner.$name(writer, $($arg),*)
+        }
+    };
+}
+
+impl Formatter for ByteArrayPrettyFormatter<'_> {
+    delegate!(begin_array_value, first: bool);
+    delegate!(end_array_value);
+    delegate!(begin_object_key, first: bool);
+    delegate!(begin_object_value);
+    delegate!(end_object_value);
+
+    // Keep byte arrays compact without changing ordinary array formatting.
+    fn write_byte_array<W>(&mut self, writer: &mut W, bytes: &[u8]) -> io::Result<()>
+    where
+        W: ?Sized + Write,
+    {
+        if bytes.len() <= BYTES_PER_LINE {
+            writer.write_all(b"[")?;
+            write_bytes(writer, bytes)?;
+            return writer.write_all(b"]");
+        }
+
+        writer.write_all(b"[")?;
+        for (index, chunk) in bytes.chunks(BYTES_PER_LINE).enumerate() {
+            writer.write_all(b"\n")?;
+            write_indent(writer, self.depth + 1, self.indent)?;
+            write_bytes(writer, chunk)?;
+            if index + 1 < bytes.len().div_ceil(BYTES_PER_LINE) {
+                writer.write_all(b",")?;
+            }
+        }
+        writer.write_all(b"\n")?;
+        write_indent(writer, self.depth, self.indent)?;
+        writer.write_all(b"]")
+    }
+
+    // Delegate ordinary formatting while mirroring PrettyFormatter's container depth.
+    fn begin_array<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + Write,
+    {
+        self.depth += 1;
+        self.inner.begin_array(writer)
+    }
+
+    fn end_array<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + Write,
+    {
+        self.depth -= 1;
+        self.inner.end_array(writer)
+    }
+
+    fn begin_object<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + Write,
+    {
+        self.depth += 1;
+        self.inner.begin_object(writer)
+    }
+
+    fn end_object<W>(&mut self, writer: &mut W) -> io::Result<()>
+    where
+        W: ?Sized + Write,
+    {
+        self.depth -= 1;
+        self.inner.end_object(writer)
+    }
+}
+
+fn write_bytes<W>(writer: &mut W, bytes: &[u8]) -> io::Result<()>
+where
+    W: ?Sized + Write,
+{
+    for (index, byte) in bytes.iter().enumerate() {
+        if index > 0 {
+            writer.write_all(b", ")?;
+        }
+        write!(writer, "{byte}")?;
+    }
+    Ok(())
+}
+
+fn write_indent<W>(writer: &mut W, depth: usize, indent: &[u8]) -> io::Result<()>
+where
+    W: ?Sized + Write,
+{
+    for _ in 0..depth {
+        writer.write_all(indent)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+
+    use super::to_pretty_json;
+
+    #[derive(Serialize)]
+    struct Bytes(#[serde(with = "serde_bytes")] Vec<u8>);
+
+    #[derive(Serialize)]
+    struct Fixture {
+        empty: Bytes,
+        exact_line: Bytes,
+        wrapped: Bytes,
+        nested: Vec<Bytes>,
+        ordinary: Vec<u16>,
+    }
+
+    #[test]
+    fn formats_byte_arrays_without_compacting_ordinary_arrays() {
+        let fixture = Fixture {
+            empty: Bytes(Vec::new()),
+            exact_line: Bytes((0..64).collect()),
+            wrapped: Bytes((0..65).collect()),
+            nested: vec![Bytes(vec![7, 8, 9])],
+            ordinary: vec![1, 2, 3],
+        };
+
+        let json = to_pretty_json(&fixture).expect("fixture serializes");
+        assert_eq!(
+            json,
+            r#"{
+  "empty": [],
+  "exact_line": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63],
+  "wrapped": [
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63,
+    64
+  ],
+  "nested": [
+    [7, 8, 9]
+  ],
+  "ordinary": [
+    1,
+    2,
+    3
+  ]
+}"#
+        );
+    }
+}

--- a/silverscript-abi/src/lib.rs
+++ b/silverscript-abi/src/lib.rs
@@ -113,7 +113,7 @@ pub struct ArtifactVersionError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct StateArtifact {
+pub struct StructArtifact {
     pub name: String,
     pub fields: Vec<FieldArtifact>,
 }
@@ -193,7 +193,7 @@ impl TypeArtifact {
 pub struct SilAbiArtifact {
     pub schema_version: u32,
     pub compiler_version: String,
-    pub states: Vec<StateArtifact>,
+    pub structs: Vec<StructArtifact>,
     pub contracts: Vec<SilContractArtifact>,
 }
 
@@ -555,11 +555,11 @@ pub fn decode_runtime_state_script(
 pub fn encode_struct_payload(
     abi: &SilAbiArtifact,
     contract: &SilContractArtifact,
-    state_name: &str,
+    struct_name: &str,
     values: &BTreeMap<String, ArtifactValue>,
 ) -> CodecResult<Vec<u8>> {
     let ctx = TypeContext::new(abi, contract);
-    encode_struct_fields_payload(ctx.state(state_name)?, values)
+    encode_struct_fields_payload(ctx.struct_by_name(struct_name)?, values)
 }
 
 pub fn decode_hex(hex: &str) -> CodecResult<Vec<u8>> {
@@ -651,15 +651,15 @@ fn entry_params(entry: &SilEntryArtifact) -> Vec<(&str, &TypeArtifact)> {
 }
 
 struct TypeContext<'a> {
-    states: BTreeMap<&'a str, &'a StateArtifact>,
-    runtime_state: StateArtifact,
+    structs: BTreeMap<&'a str, &'a StructArtifact>,
+    runtime_state: StructArtifact,
 }
 
 impl<'a> TypeContext<'a> {
     fn new(abi: &'a SilAbiArtifact, contract: &'a SilContractArtifact) -> Self {
         Self {
-            states: abi.states.iter().map(|state| (state.name.as_str(), state)).collect(),
-            runtime_state: StateArtifact {
+            structs: abi.structs.iter().map(|structure| (structure.name.as_str(), structure)).collect(),
+            runtime_state: StructArtifact {
                 name: "State".to_string(),
                 fields: contract
                     .runtime_state
@@ -671,11 +671,11 @@ impl<'a> TypeContext<'a> {
         }
     }
 
-    fn state(&self, name: &str) -> CodecResult<&StateArtifact> {
+    fn struct_by_name(&self, name: &str) -> CodecResult<&StructArtifact> {
         if name == "State" {
             return Ok(&self.runtime_state);
         }
-        self.states.get(name).copied().ok_or_else(|| CodecError::UnknownStruct(name.to_string()))
+        self.structs.get(name).copied().ok_or_else(|| CodecError::UnknownStruct(name.to_string()))
     }
 }
 
@@ -693,7 +693,7 @@ fn push_sig_arg(
     match ty {
         TypeArtifact::Struct { name: struct_name } => {
             let fields = object_fields(value)?;
-            push_struct_fields(builder, ctx, ctx.state(struct_name)?, fields)
+            push_struct_fields(builder, ctx, ctx.struct_by_name(struct_name)?, fields)
         }
         TypeArtifact::FixedArray { item, len } if matches!(item.as_ref(), TypeArtifact::Struct { .. }) => {
             push_struct_array_fields(builder, ctx, item, Some(*len), value)
@@ -735,11 +735,11 @@ fn push_sig_arg(
 fn push_struct_fields(
     builder: &mut ScriptBuilder,
     ctx: &TypeContext<'_>,
-    state: &StateArtifact,
+    structure: &StructArtifact,
     fields: &BTreeMap<String, ArtifactValue>,
 ) -> CodecResult<()> {
-    assert_no_extra_fields(fields, &state.fields)?;
-    for field in &state.fields {
+    assert_no_extra_fields(fields, &structure.fields)?;
+    for field in &structure.fields {
         let value = fields.get(&field.name).ok_or_else(|| CodecError::MissingField(field.name.clone()))?;
         push_sig_arg(builder, ctx, &field.name, &field.ty, value)?;
     }
@@ -756,7 +756,7 @@ fn push_struct_array_fields(
     let TypeArtifact::Struct { name } = item else {
         return Err(CodecError::UnsupportedType(type_name(item)));
     };
-    let state = ctx.state(name)?;
+    let structure = ctx.struct_by_name(name)?;
     let values = expect_array(value)?;
     if let Some(expected) = expected_len {
         require_len(name, expected, values.len())?;
@@ -765,11 +765,11 @@ fn push_struct_array_fields(
     let mut object_values = Vec::with_capacity(values.len());
     for value in values {
         let fields = object_fields(value)?;
-        assert_no_extra_fields(fields, &state.fields)?;
+        assert_no_extra_fields(fields, &structure.fields)?;
         object_values.push(fields);
     }
 
-    for field in &state.fields {
+    for field in &structure.fields {
         let mut field_values = Vec::with_capacity(object_values.len());
         for object in &object_values {
             field_values.push(object.get(&field.name).ok_or_else(|| CodecError::MissingField(field.name.clone()))?.clone());
@@ -794,10 +794,10 @@ fn encode_state_payload(name: &str, ty: &TypeArtifact, value: &ArtifactValue) ->
     }
 }
 
-fn encode_struct_fields_payload(state: &StateArtifact, fields: &BTreeMap<String, ArtifactValue>) -> CodecResult<Vec<u8>> {
-    assert_no_extra_fields(fields, &state.fields)?;
+fn encode_struct_fields_payload(structure: &StructArtifact, fields: &BTreeMap<String, ArtifactValue>) -> CodecResult<Vec<u8>> {
+    assert_no_extra_fields(fields, &structure.fields)?;
     let mut out = Vec::new();
-    for field in &state.fields {
+    for field in &structure.fields {
         let value = fields.get(&field.name).ok_or_else(|| CodecError::MissingField(field.name.clone()))?;
         out.extend(encode_state_payload(&field.name, &field.ty, value)?);
     }
@@ -1298,7 +1298,7 @@ mod tests {
     #[test]
     fn encodes_struct_payload_without_push_framing() {
         let mut abi = tiny_sil_abi();
-        abi.states.push(StateArtifact {
+        abi.structs.push(StructArtifact {
             name: "Memory".to_string(),
             fields: vec![
                 FieldArtifact { name: "hunger".to_string(), ty: TypeArtifact::Int },
@@ -1322,7 +1322,7 @@ mod tests {
         {
           "schema_version": 1,
           "compiler_version": "0.1.0",
-          "states": [
+          "structs": [
             {
               "name": "FooState",
               "fields": [{ "name": "count", "type": { "kind": "int" } }]
@@ -1424,7 +1424,7 @@ mod tests {
         SilAbiArtifact {
             schema_version: 1,
             compiler_version: "0.1.0".to_string(),
-            states: Vec::new(),
+            structs: Vec::new(),
             contracts: vec![SilContractArtifact {
                 name: "Foo".to_string(),
                 source_path: "sil/Foo.sil".to_string(),

--- a/silverscript-abi/src/lib.rs
+++ b/silverscript-abi/src/lib.rs
@@ -192,6 +192,7 @@ impl TypeArtifact {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SilAbiArtifact {
     pub schema_version: u32,
+    pub compiler_version: String,
     pub states: Vec<StateArtifact>,
     pub contracts: Vec<SilContractArtifact>,
 }
@@ -268,12 +269,28 @@ pub struct SilEntryArtifact {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CompiledContractArtifact {
+    pub bytecode: Vec<u8>,
+    // TODO: Remove `script_hex` once all artifact consumers use `bytecode`.
     pub script_hex: String,
+    pub template_hash: [u8; 32],
+    // TODO: Remove `template_hash_hex` once all artifact consumers use `template_hash`.
     pub template_hash_hex: String,
     pub state_span: StateSpanArtifact,
 }
 
 impl CompiledContractArtifact {
+    #[cfg(test)]
+    fn set_bytecode(&mut self, bytecode: Vec<u8>) {
+        self.script_hex = encode_hex(&bytecode);
+        self.bytecode = bytecode;
+    }
+
+    #[cfg(test)]
+    fn set_template_hash(&mut self, template_hash: [u8; 32]) {
+        self.template_hash_hex = encode_hex(&template_hash);
+        self.template_hash = template_hash;
+    }
+
     /// Split decoded script bytes into the template prefix, runtime state, and
     /// template suffix declared by this artifact.
     pub fn script_parts<'a>(&self, script: &'a [u8]) -> Option<(&'a [u8], &'a [u8], &'a [u8])> {
@@ -289,7 +306,7 @@ pub struct CompiledTemplateArtifact {
     pub hash_hex: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StateSpanArtifact {
     pub offset: usize,
     pub len: usize,
@@ -301,6 +318,10 @@ pub enum SilAbiVerificationError {
     Version(#[from] ArtifactVersionError),
     #[error("contract `{contract}` has invalid compiled {field} hex: {message}")]
     InvalidCompiledHex { contract: String, field: &'static str, message: String },
+    #[error("contract `{contract}` bytecode does not match its script_hex encoding")]
+    BytecodeMismatch { contract: String },
+    #[error("contract `{contract}` template hash does not match its template_hash_hex encoding")]
+    TemplateHashEncodingMismatch { contract: String },
     #[error("contract `{contract}` has state span offset {offset} length {len}, but its compiled script has {script_len} bytes")]
     InvalidStateSpan { contract: String, offset: usize, len: usize, script_len: usize },
     #[error("contract `{contract}` runtime state field `{field}` has unsupported type `{ty}`")]
@@ -329,6 +350,66 @@ pub enum ArtifactValue {
     Text(String),
     Array(Vec<ArtifactValue>),
     Object(BTreeMap<String, ArtifactValue>),
+}
+
+impl From<i64> for ArtifactValue {
+    fn from(value: i64) -> Self {
+        Self::Int(value)
+    }
+}
+
+impl From<i32> for ArtifactValue {
+    fn from(value: i32) -> Self {
+        Self::Int(i64::from(value))
+    }
+}
+
+impl From<bool> for ArtifactValue {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<u8> for ArtifactValue {
+    fn from(value: u8) -> Self {
+        Self::Byte(value)
+    }
+}
+
+impl From<Vec<u8>> for ArtifactValue {
+    fn from(value: Vec<u8>) -> Self {
+        Self::Bytes(value)
+    }
+}
+
+impl From<Vec<i64>> for ArtifactValue {
+    fn from(value: Vec<i64>) -> Self {
+        Self::Array(value.into_iter().map(Self::Int).collect())
+    }
+}
+
+impl From<String> for ArtifactValue {
+    fn from(value: String) -> Self {
+        Self::Text(value)
+    }
+}
+
+impl From<&str> for ArtifactValue {
+    fn from(value: &str) -> Self {
+        Self::Text(value.to_string())
+    }
+}
+
+impl From<Vec<ArtifactValue>> for ArtifactValue {
+    fn from(value: Vec<ArtifactValue>) -> Self {
+        Self::Array(value)
+    }
+}
+
+impl From<BTreeMap<String, ArtifactValue>> for ArtifactValue {
+    fn from(value: BTreeMap<String, ArtifactValue>) -> Self {
+        Self::Object(value)
+    }
 }
 
 #[derive(Debug, Error, Clone, PartialEq)]
@@ -478,6 +559,9 @@ fn verify_compiled_contract(contract: &SilContractArtifact) -> std::result::Resu
         })
     };
     let script = decode("script", &contract.compiled.script_hex)?;
+    if script != contract.compiled.bytecode {
+        return Err(SilAbiVerificationError::BytecodeMismatch { contract: contract.name.clone() });
+    }
     let found_hash = decode("template hash", &contract.compiled.template_hash_hex)?;
 
     let mut entries_by_tag = BTreeMap::<DispatchTag, &str>::new();
@@ -523,9 +607,12 @@ fn verify_compiled_contract(contract: &SilContractArtifact) -> std::result::Resu
     if found_hash.len() != 32 {
         return Err(SilAbiVerificationError::InvalidTemplateHashLength { contract: contract.name.clone(), len: found_hash.len() });
     }
+    if found_hash != contract.compiled.template_hash {
+        return Err(SilAbiVerificationError::TemplateHashEncodingMismatch { contract: contract.name.clone() });
+    }
 
     let expected_hash = template_hash(prefix, suffix);
-    if found_hash != expected_hash {
+    if contract.compiled.template_hash != expected_hash {
         return Err(SilAbiVerificationError::TemplateHashMismatch {
             contract: contract.name.clone(),
             expected: encode_hex(&expected_hash),
@@ -975,6 +1062,27 @@ fn type_name(ty: &TypeArtifact) -> String {
 mod tests {
     use super::*;
 
+    #[test]
+    fn artifact_values_support_ergonomic_from_conversions() {
+        let values: Vec<ArtifactValue> = vec![1.into(), vec![2u8; 4].into(), true.into(), 3u8.into(), "ready".into()];
+        assert_eq!(
+            values,
+            vec![
+                ArtifactValue::Int(1),
+                ArtifactValue::Bytes(vec![2; 4]),
+                ArtifactValue::Bool(true),
+                ArtifactValue::Byte(3),
+                ArtifactValue::Text("ready".to_string()),
+            ]
+        );
+        assert_eq!(ArtifactValue::from(vec![ArtifactValue::Int(1)]), ArtifactValue::Array(vec![ArtifactValue::Int(1)]));
+        assert_eq!(ArtifactValue::from(vec![1i64, 2]), ArtifactValue::Array(vec![ArtifactValue::Int(1), ArtifactValue::Int(2)]));
+        assert_eq!(
+            ArtifactValue::from(BTreeMap::from([("value".to_string(), ArtifactValue::Int(1))])),
+            ArtifactValue::Object(BTreeMap::from([("value".to_string(), ArtifactValue::Int(1))]))
+        );
+    }
+
     // Locks the ABI copy to Sil's canonical implementation. Ideally, Sil will
     // expose this from a small shared core crate instead of requiring a copy.
     #[test]
@@ -1006,20 +1114,28 @@ mod tests {
             encode_runtime_state_script(&contract.runtime_state, &BTreeMap::from([("value".to_string(), ArtifactValue::Byte(2))]))
                 .expect("state encodes");
         let suffix = [0xbb, 0xcc];
-        contract.compiled.script_hex = encode_hex(&[prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
-        contract.compiled.template_hash_hex = encode_hex(&template_hash(&prefix, &suffix));
+        contract.compiled.set_bytecode([prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
+        contract.compiled.set_template_hash(template_hash(&prefix, &suffix));
         contract.compiled.state_span = StateSpanArtifact { offset: prefix.len(), len: state.len() };
 
         abi.verify().expect("compiled template matches its contract script");
 
-        abi.contracts[0].compiled.template_hash_hex = "00".repeat(32);
+        abi.contracts[0].compiled.bytecode.push(0xff);
+        assert_eq!(abi.verify(), Err(SilAbiVerificationError::BytecodeMismatch { contract: "Foo".to_string() }));
+        abi.contracts[0].compiled.bytecode.pop();
+
+        abi.contracts[0].compiled.template_hash[0] ^= 0xff;
+        assert_eq!(abi.verify(), Err(SilAbiVerificationError::TemplateHashEncodingMismatch { contract: "Foo".to_string() }));
+        abi.contracts[0].compiled.template_hash[0] ^= 0xff;
+
+        abi.contracts[0].compiled.set_template_hash([0; 32]);
         assert!(matches!(
             abi.verify(),
             Err(SilAbiVerificationError::TemplateHashMismatch { ref contract, .. }) if contract == "Foo"
         ));
 
-        abi.contracts[0].compiled.template_hash_hex = encode_hex(&template_hash(&prefix, &suffix));
-        abi.contracts[0].compiled.script_hex = encode_hex(&[&[0xff], state.as_slice(), suffix.as_slice()].concat());
+        abi.contracts[0].compiled.set_template_hash(template_hash(&prefix, &suffix));
+        abi.contracts[0].compiled.set_bytecode([&[0xff], state.as_slice(), suffix.as_slice()].concat());
         assert!(matches!(
             abi.verify(),
             Err(SilAbiVerificationError::TemplateHashMismatch { ref contract, .. }) if contract == "Foo"
@@ -1056,10 +1172,10 @@ mod tests {
             encode_runtime_state_script(&contract.runtime_state, &BTreeMap::from([("value".to_string(), ArtifactValue::Byte(2))]))
                 .expect("state encodes");
         let suffix = [0xbb];
-        contract.compiled.script_hex = encode_hex(&[prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
+        contract.compiled.set_bytecode([prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
 
         contract.compiled.state_span = StateSpanArtifact { offset: 0, len: prefix.len() + state.len() };
-        contract.compiled.template_hash_hex = encode_hex(&template_hash(&[], &suffix));
+        contract.compiled.set_template_hash(template_hash(&[], &suffix));
         assert!(matches!(
             abi.verify(),
             Err(SilAbiVerificationError::InvalidRuntimeStateEncoding { ref contract, .. }) if contract == "Foo"
@@ -1067,7 +1183,7 @@ mod tests {
 
         let contract = &mut abi.contracts[0];
         contract.compiled.state_span = StateSpanArtifact { offset: prefix.len(), len: state.len() - 1 };
-        contract.compiled.template_hash_hex = encode_hex(&template_hash(&prefix, &[state[state.len() - 1], suffix[0]]));
+        contract.compiled.set_template_hash(template_hash(&prefix, &[state[state.len() - 1], suffix[0]]));
         assert!(matches!(
             abi.verify(),
             Err(SilAbiVerificationError::InvalidRuntimeStateEncoding { ref contract, .. }) if contract == "Foo"
@@ -1082,8 +1198,8 @@ mod tests {
         let prefix = [0xaa];
         let state = [OP_PUSH_DATA_1, 1, 2];
         let suffix = [0xbb];
-        contract.compiled.script_hex = encode_hex(&[prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
-        contract.compiled.template_hash_hex = encode_hex(&template_hash(&prefix, &suffix));
+        contract.compiled.set_bytecode([prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
+        contract.compiled.set_template_hash(template_hash(&prefix, &suffix));
         contract.compiled.state_span = StateSpanArtifact { offset: prefix.len(), len: state.len() };
         assert_eq!(abi.verify(), Err(SilAbiVerificationError::NonCanonicalRuntimeStateEncoding { contract: "Foo".to_string() }));
 
@@ -1181,6 +1297,7 @@ mod tests {
         let json = r#"
         {
           "schema_version": 1,
+          "compiler_version": "0.1.0",
           "states": [
             {
               "name": "FooState",
@@ -1203,8 +1320,10 @@ mod tests {
                 }
               ],
               "compiled": {
+                "bytecode": [0],
                 "script_hex": "00",
-                "template_hash_hex": "00",
+                "template_hash": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                "template_hash_hex": "0000000000000000000000000000000000000000000000000000000000000000",
                 "state_span": { "offset": 0, "len": 1 }
               }
             }
@@ -1214,6 +1333,7 @@ mod tests {
 
         let abi: SilAbiArtifact = serde_json::from_str(json).expect("sil abi should deserialize");
         abi.check_schema_version().expect("sil abi schema version should be supported");
+        assert_eq!(abi.contract("Foo").expect("contract exists").compiled.bytecode, vec![0]);
         assert_eq!(
             abi.contract("Foo").and_then(|contract| contract.entry("step")).map(|entry| entry.dispatch_tag),
             Some(DispatchTag::from([0x2c, 0x49, 0xed, 0x65]))
@@ -1224,6 +1344,11 @@ mod tests {
         );
         let serialized = serde_json::to_value(&abi).expect("Sil ABI artifact serializes");
         assert_eq!(serialized["contracts"][0]["entries"][0]["dispatch_tag"], "2c49ed65");
+        assert_eq!(serialized["contracts"][0]["compiled"]["bytecode"], serde_json::json!([0]));
+        assert_eq!(
+            serialized["contracts"][0]["compiled"]["template_hash"],
+            serde_json::to_value([0u8; 32]).expect("template hash serializes")
+        );
     }
 
     #[test]
@@ -1274,6 +1399,7 @@ mod tests {
     fn tiny_sil_abi() -> SilAbiArtifact {
         SilAbiArtifact {
             schema_version: 1,
+            compiler_version: "0.1.0".to_string(),
             states: Vec::new(),
             contracts: vec![SilContractArtifact {
                 name: "Foo".to_string(),
@@ -1299,7 +1425,9 @@ mod tests {
                 cov_decl_to_abi: BTreeMap::new(),
                 delegate_entry_abi: None,
                 compiled: CompiledContractArtifact {
+                    bytecode: Vec::new(),
                     script_hex: String::new(),
+                    template_hash: [0; 32],
                     template_hash_hex: String::new(),
                     state_span: StateSpanArtifact { offset: 0, len: 0 },
                 },

--- a/silverscript-abi/src/lib.rs
+++ b/silverscript-abi/src/lib.rs
@@ -245,6 +245,12 @@ impl SilContractArtifact {
     pub fn auth_decl_entry(&self, name: &str) -> Option<&SilEntryArtifact> {
         self.cov_decl_to_abi.get(name)
     }
+
+    /// Resolve a source covenant declaration to its public entrypoint.
+    pub fn covenant_decl_entry(&self, name: &str, is_leader: bool) -> Option<&SilEntryArtifact> {
+        let leader = self.cov_decl_to_abi.get(name)?;
+        if is_leader || self.delegate_entry_abi.is_none() { Some(leader) } else { self.delegate_entry_abi.as_ref() }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -462,6 +468,24 @@ pub fn encode_contract_entry_sig_script(
         .iter()
         .find(|entry| entry.name == entry_name)
         .ok_or_else(|| CodecError::UnknownEntry { contract: contract_name.to_string(), entry: entry_name.to_string() })?;
+    encode_entry_sig_script(abi, contract, entry, args)
+}
+
+pub fn encode_contract_covenant_decl_sig_script(
+    abi: &SilAbiArtifact,
+    contract_name: &str,
+    declaration_name: &str,
+    is_leader: bool,
+    args: &[ArtifactValue],
+) -> CodecResult<Vec<u8>> {
+    let contract = abi
+        .contracts
+        .iter()
+        .find(|contract| contract.name == contract_name)
+        .ok_or_else(|| CodecError::UnknownContract(contract_name.to_string()))?;
+    let entry = contract
+        .covenant_decl_entry(declaration_name, is_leader)
+        .ok_or_else(|| CodecError::UnknownEntry { contract: contract_name.to_string(), entry: declaration_name.to_string() })?;
     encode_entry_sig_script(abi, contract, entry, args)
 }
 

--- a/silverscript-abi/src/lib.rs
+++ b/silverscript-abi/src/lib.rs
@@ -225,12 +225,24 @@ pub struct SilContractArtifact {
     pub source_path: String,
     pub runtime_state: RuntimeStateArtifact,
     pub entries: Vec<SilEntryArtifact>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub cov_decl_to_abi: BTreeMap<String, SilEntryArtifact>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delegate_entry_abi: Option<SilEntryArtifact>,
     pub compiled: CompiledContractArtifact,
 }
 
 impl SilContractArtifact {
     pub fn entry(&self, name: &str) -> Option<&SilEntryArtifact> {
         self.entries.iter().find(|entry| entry.name == name)
+    }
+
+    pub fn cov_binding_leader_decl_entry(&self, name: &str) -> Option<&SilEntryArtifact> {
+        self.cov_decl_to_abi.get(name)
+    }
+
+    pub fn auth_decl_entry(&self, name: &str) -> Option<&SilEntryArtifact> {
+        self.cov_decl_to_abi.get(name)
     }
 }
 
@@ -1284,6 +1296,8 @@ mod tests {
                         params: Vec::new(),
                     },
                 ],
+                cov_decl_to_abi: BTreeMap::new(),
+                delegate_entry_abi: None,
                 compiled: CompiledContractArtifact {
                     script_hex: String::new(),
                     template_hash_hex: String::new(),

--- a/silverscript-abi/src/lib.rs
+++ b/silverscript-abi/src/lib.rs
@@ -1648,7 +1648,7 @@ mod tests {
     #[test]
     fn pretty_json_wraps_byte_arrays_at_fixed_boundaries() {
         let mut abi = tiny_sil_abi();
-        abi.contracts[0].compiled.bytecode = (0..=64).collect();
+        abi.contracts.get_mut("Foo").unwrap().compiled.bytecode = (0..=64).collect();
 
         let json = to_pretty_json(&abi).expect("Sil ABI artifact serializes");
         let lines = json.lines().collect::<Vec<_>>();
@@ -1659,7 +1659,7 @@ mod tests {
         assert!(lines.iter().any(|line| line.trim_start().starts_with(r#""template_hash": [0, 0, 0"#)));
 
         let decoded: SilAbiArtifact = serde_json::from_str(&json).expect("Sil ABI artifact deserializes");
-        assert_eq!(decoded.contracts[0].compiled.bytecode, (0..=64).collect::<Vec<_>>());
+        assert_eq!(decoded.contracts["Foo"].compiled.bytecode, (0..=64).collect::<Vec<_>>());
     }
 
     #[test]

--- a/silverscript-abi/src/lib.rs
+++ b/silverscript-abi/src/lib.rs
@@ -1,0 +1,1299 @@
+//! Portable ABI and codec data for generated Silverscript contracts.
+//!
+//! This crate owns only bytecode-facing facts: contract scripts, entrypoint
+//! dispatch tags and parameters, runtime state field order, structural field types,
+//! template state spans and hashes, and the codec for encoding those values.
+//!
+//! It must not know why a field exists. Argent coordination semantics such as
+//! hidden template fields, route-family tables, route roots, observed actors,
+//! witness purposes, and any future covenant-routing meaning belong in the
+//! outer `argent-artifact` crate. Keep that boundary sharp so this ABI can be
+//! replaced by a native Silverscript portable artifact later.
+
+use std::collections::BTreeMap;
+
+use blake3::Hasher as Blake3Hasher;
+use kaspa_txscript::{
+    EngineFlags, deserialize_i64 as deserialize_script_i64,
+    opcodes::codes::{
+        Op0 as OP_0, Op1 as OP_1, Op1Negate as OP_1_NEGATE, Op16 as OP_16, OpData1 as OP_DATA_1, OpData75 as OP_DATA_75,
+        OpPushData1 as OP_PUSH_DATA_1, OpPushData2 as OP_PUSH_DATA_2, OpPushData4 as OP_PUSH_DATA_4,
+    },
+    script_builder::{ScriptBuilder, ScriptBuilderError},
+    serialize_i64 as serialize_script_i64,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
+
+pub const SIL_ABI_SCHEMA_VERSION: u32 = 1;
+const TEMPLATE_PART_LENGTH_BYTES: usize = 8;
+
+/// A Sil entrypoint's fixed-width signature dispatch tag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DispatchTag([u8; 4]);
+
+impl DispatchTag {
+    /// Borrow the four bytes placed in the entry signature script.
+    pub const fn as_bytes(&self) -> &[u8; 4] {
+        &self.0
+    }
+
+    /// Return the four bytes placed in the entry signature script.
+    pub const fn into_bytes(self) -> [u8; 4] {
+        self.0
+    }
+
+    /// Parse the eight-character representation stored in portable artifacts.
+    pub fn from_hex(hex: &str) -> Result<Self, DispatchTagParseError> {
+        if hex.len() != 8 {
+            return Err(DispatchTagParseError::InvalidLength(hex.len()));
+        }
+
+        let mut bytes = [0; 4];
+        faster_hex::hex_decode(hex.as_bytes(), &mut bytes).map_err(|err| DispatchTagParseError::InvalidHex(err.to_string()))?;
+        Ok(Self(bytes))
+    }
+
+    /// Encode the tag using the portable artifact's lowercase hex form.
+    pub fn to_hex(&self) -> String {
+        encode_hex(&self.0)
+    }
+}
+
+impl From<[u8; 4]> for DispatchTag {
+    fn from(bytes: [u8; 4]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl Serialize for DispatchTag {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for DispatchTag {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let hex = String::deserialize(deserializer)?;
+        Self::from_hex(&hex).map_err(serde::de::Error::custom)
+    }
+}
+
+/// An invalid portable dispatch-tag representation.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum DispatchTagParseError {
+    #[error("dispatch tag must contain exactly 8 hexadecimal characters, found {0}")]
+    InvalidLength(usize),
+    #[error("invalid dispatch tag hex: {0}")]
+    InvalidHex(String),
+}
+
+/// Calculate the canonical hash of a state-bearing Silverscript template.
+pub fn template_hash(prefix: &[u8], suffix: &[u8]) -> [u8; 32] {
+    let prefix_len = i64::try_from(prefix.len()).unwrap();
+    let suffix_len = i64::try_from(suffix.len()).unwrap();
+    let encoded_prefix_len = serialize_script_i64(prefix_len, Some(TEMPLATE_PART_LENGTH_BYTES)).unwrap();
+    let encoded_suffix_len = serialize_script_i64(suffix_len, Some(TEMPLATE_PART_LENGTH_BYTES)).unwrap();
+
+    Blake3Hasher::new().update(&encoded_prefix_len).update(prefix).update(&encoded_suffix_len).update(suffix).finalize().into()
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+#[error("unsupported {artifact} schema version {found}; expected {supported}")]
+pub struct ArtifactVersionError {
+    pub artifact: &'static str,
+    pub supported: u32,
+    pub found: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateArtifact {
+    pub name: String,
+    pub fields: Vec<FieldArtifact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldArtifact {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: TypeArtifact,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ParamArtifact {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: TypeArtifact,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TypeArtifact {
+    Int,
+    Temporal,
+    Bool,
+    Byte,
+    Bytes,
+    #[serde(rename = "string")]
+    Text,
+    Pubkey,
+    Sig,
+    Datasig,
+    FixedBytes {
+        len: usize,
+    },
+    FixedArray {
+        item: Box<TypeArtifact>,
+        len: usize,
+    },
+    DynamicArray {
+        item: Box<TypeArtifact>,
+    },
+    Struct {
+        name: String,
+    },
+}
+
+impl TypeArtifact {
+    pub fn from_parts(name: &str, array_len: Option<usize>) -> Self {
+        match (name, array_len) {
+            ("byte", Some(len)) => Self::FixedBytes { len },
+            (_, Some(len)) => Self::FixedArray { item: Box::new(Self::scalar(name)), len },
+            (_, None) => Self::scalar(name),
+        }
+    }
+
+    pub fn dynamic_array(item: Self) -> Self {
+        Self::DynamicArray { item: Box::new(item) }
+    }
+
+    fn scalar(name: &str) -> Self {
+        match name {
+            "int" => Self::Int,
+            "temporal" => Self::Temporal,
+            "bool" => Self::Bool,
+            "byte" => Self::Byte,
+            "bytes" => Self::Bytes,
+            "string" => Self::Text,
+            "pubkey" => Self::Pubkey,
+            "sig" => Self::Sig,
+            "datasig" => Self::Datasig,
+            _ => Self::Struct { name: name.to_string() },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SilAbiArtifact {
+    pub schema_version: u32,
+    pub states: Vec<StateArtifact>,
+    pub contracts: Vec<SilContractArtifact>,
+}
+
+impl SilAbiArtifact {
+    pub fn check_schema_version(&self) -> std::result::Result<(), ArtifactVersionError> {
+        if self.schema_version == SIL_ABI_SCHEMA_VERSION {
+            Ok(())
+        } else {
+            Err(ArtifactVersionError { artifact: "Sil ABI artifact", supported: SIL_ABI_SCHEMA_VERSION, found: self.schema_version })
+        }
+    }
+
+    /// Verify each compiled script, runtime-state span, and template hash.
+    pub fn verify(&self) -> std::result::Result<(), SilAbiVerificationError> {
+        self.check_schema_version()?;
+        for contract in &self.contracts {
+            verify_compiled_contract(contract)?;
+        }
+        Ok(())
+    }
+
+    pub fn contract(&self, name: &str) -> Option<&SilContractArtifact> {
+        self.contracts.iter().find(|contract| contract.name == name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SilContractArtifact {
+    pub name: String,
+    pub source_path: String,
+    pub runtime_state: RuntimeStateArtifact,
+    pub entries: Vec<SilEntryArtifact>,
+    pub compiled: CompiledContractArtifact,
+}
+
+impl SilContractArtifact {
+    pub fn entry(&self, name: &str) -> Option<&SilEntryArtifact> {
+        self.entries.iter().find(|entry| entry.name == name)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeStateArtifact {
+    pub source: String,
+    pub fields: Vec<RuntimeFieldArtifact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeFieldArtifact {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub ty: TypeArtifact,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SilEntryArtifact {
+    pub name: String,
+    pub dispatch_tag: DispatchTag,
+    pub params: Vec<ParamArtifact>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompiledContractArtifact {
+    pub script_hex: String,
+    pub template_hash_hex: String,
+    pub state_span: StateSpanArtifact,
+}
+
+impl CompiledContractArtifact {
+    /// Split decoded script bytes into the template prefix, runtime state, and
+    /// template suffix declared by this artifact.
+    pub fn script_parts<'a>(&self, script: &'a [u8]) -> Option<(&'a [u8], &'a [u8], &'a [u8])> {
+        let state_end = self.state_span.offset.checked_add(self.state_span.len)?;
+        Some((script.get(..self.state_span.offset)?, script.get(self.state_span.offset..state_end)?, script.get(state_end..)?))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompiledTemplateArtifact {
+    pub prefix_hex: String,
+    pub suffix_hex: String,
+    pub hash_hex: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StateSpanArtifact {
+    pub offset: usize,
+    pub len: usize,
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum SilAbiVerificationError {
+    #[error(transparent)]
+    Version(#[from] ArtifactVersionError),
+    #[error("contract `{contract}` has invalid compiled {field} hex: {message}")]
+    InvalidCompiledHex { contract: String, field: &'static str, message: String },
+    #[error("contract `{contract}` has state span offset {offset} length {len}, but its compiled script has {script_len} bytes")]
+    InvalidStateSpan { contract: String, offset: usize, len: usize, script_len: usize },
+    #[error("contract `{contract}` runtime state field `{field}` has unsupported type `{ty}`")]
+    UnsupportedRuntimeStateType { contract: String, field: String, ty: String },
+    #[error("contract `{contract}` state span does not encode its runtime state: {message}")]
+    InvalidRuntimeStateEncoding { contract: String, message: String },
+    #[error("contract `{contract}` state span is not canonically encoded")]
+    NonCanonicalRuntimeStateEncoding { contract: String },
+    #[error("contract `{contract}` template hash must contain 32 bytes, found {len}")]
+    InvalidTemplateHashLength { contract: String, len: usize },
+    #[error("contract `{contract}` template hash mismatch: expected `{expected}`, found `{found}`")]
+    TemplateHashMismatch { contract: String, expected: String, found: String },
+    #[error("contract `{contract}` entries `{first}` and `{second}` have the same dispatch tag `{tag}`")]
+    DispatchTagCollision { contract: String, first: String, second: String, tag: String },
+}
+
+pub type CodecResult<T> = std::result::Result<T, CodecError>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum ArtifactValue {
+    Int(i64),
+    Bool(bool),
+    Byte(u8),
+    Bytes(Vec<u8>),
+    Text(String),
+    Array(Vec<ArtifactValue>),
+    Object(BTreeMap<String, ArtifactValue>),
+}
+
+#[derive(Debug, Error, Clone, PartialEq)]
+pub enum CodecError {
+    #[error("unknown contract `{0}`")]
+    UnknownContract(String),
+    #[error("unknown entry `{contract}::{entry}`")]
+    UnknownEntry { contract: String, entry: String },
+    #[error("unknown struct `{0}`")]
+    UnknownStruct(String),
+    #[error("entry `{entry}` expects {expected} arguments, got {actual}")]
+    WrongArgumentCount { entry: String, expected: usize, actual: usize },
+    #[error("missing field `{0}`")]
+    MissingField(String),
+    #[error("unknown field `{0}`")]
+    UnknownField(String),
+    #[error("duplicate field `{0}`")]
+    DuplicateField(String),
+    #[error("expected {expected}, got {actual}")]
+    TypeMismatch { expected: String, actual: String },
+    #[error("unsupported artifact type `{0}`")]
+    UnsupportedType(String),
+    #[error("`{name}` expects {expected} bytes, got {actual}")]
+    InvalidLength { name: String, expected: usize, actual: usize },
+    #[error("number {value} does not fit in {size} bytes")]
+    InvalidNumber { value: i64, size: usize },
+    #[error("invalid hex: {0}")]
+    InvalidHex(#[from] faster_hex::Error),
+    #[error("script builder error: {0}")]
+    ScriptBuilder(#[from] ScriptBuilderError),
+    #[error("invalid push-only script: {0}")]
+    InvalidPush(String),
+    #[error("state script has {len} trailing bytes at offset {offset}")]
+    TrailingStateBytes { offset: usize, len: usize },
+}
+
+pub fn encode_contract_entry_sig_script(
+    abi: &SilAbiArtifact,
+    contract_name: &str,
+    entry_name: &str,
+    args: &[ArtifactValue],
+) -> CodecResult<Vec<u8>> {
+    let contract = abi
+        .contracts
+        .iter()
+        .find(|contract| contract.name == contract_name)
+        .ok_or_else(|| CodecError::UnknownContract(contract_name.to_string()))?;
+    let entry = contract
+        .entries
+        .iter()
+        .find(|entry| entry.name == entry_name)
+        .ok_or_else(|| CodecError::UnknownEntry { contract: contract_name.to_string(), entry: entry_name.to_string() })?;
+    encode_entry_sig_script(abi, contract, entry, args)
+}
+
+pub fn encode_entry_sig_script(
+    abi: &SilAbiArtifact,
+    contract: &SilContractArtifact,
+    entry: &SilEntryArtifact,
+    args: &[ArtifactValue],
+) -> CodecResult<Vec<u8>> {
+    let params = entry_params(entry);
+    if params.len() != args.len() {
+        return Err(CodecError::WrongArgumentCount {
+            entry: format!("{}::{}", contract.name, entry.name),
+            expected: params.len(),
+            actual: args.len(),
+        });
+    }
+
+    let ctx = TypeContext::new(abi, contract);
+    let mut builder = script_builder();
+    for ((name, ty), value) in params.iter().zip(args) {
+        push_sig_arg(&mut builder, &ctx, name, ty, value)?;
+    }
+    builder.add_data(entry.dispatch_tag.as_bytes())?;
+    Ok(builder.drain())
+}
+
+pub fn encode_runtime_state_script(
+    runtime_state: &RuntimeStateArtifact,
+    values: &BTreeMap<String, ArtifactValue>,
+) -> CodecResult<Vec<u8>> {
+    for name in values.keys() {
+        if runtime_state.fields.iter().all(|field| &field.name != name) {
+            return Err(CodecError::UnknownField(name.clone()));
+        }
+    }
+
+    let mut builder = script_builder();
+    for field in &runtime_state.fields {
+        let value = values.get(&field.name).ok_or_else(|| CodecError::MissingField(field.name.clone()))?;
+        let payload = encode_state_payload(&field.name, &field.ty, value)?;
+        builder.add_data_with_push_opcode(&payload)?;
+    }
+    Ok(builder.drain())
+}
+
+pub fn decode_runtime_state_script(
+    runtime_state: &RuntimeStateArtifact,
+    state_script: &[u8],
+) -> CodecResult<BTreeMap<String, ArtifactValue>> {
+    let pushes = parse_pushes(state_script)?;
+    if pushes.len() < runtime_state.fields.len() {
+        return Err(CodecError::InvalidPush(format!("expected {} state pushes, got {}", runtime_state.fields.len(), pushes.len())));
+    }
+    if pushes.len() > runtime_state.fields.len() {
+        let offset = pushes[runtime_state.fields.len()].0;
+        return Err(CodecError::TrailingStateBytes { offset, len: state_script.len() - offset });
+    }
+
+    let mut values = BTreeMap::new();
+    for (field, (_, payload)) in runtime_state.fields.iter().zip(pushes) {
+        values.insert(field.name.clone(), decode_state_payload(&field.name, &field.ty, &payload)?);
+    }
+    Ok(values)
+}
+
+pub fn encode_struct_payload(
+    abi: &SilAbiArtifact,
+    contract: &SilContractArtifact,
+    state_name: &str,
+    values: &BTreeMap<String, ArtifactValue>,
+) -> CodecResult<Vec<u8>> {
+    let ctx = TypeContext::new(abi, contract);
+    encode_struct_fields_payload(ctx.state(state_name)?, values)
+}
+
+pub fn decode_hex(hex: &str) -> CodecResult<Vec<u8>> {
+    let mut bytes = vec![0; hex.len() / 2];
+    faster_hex::hex_decode(hex.as_bytes(), &mut bytes)?;
+    Ok(bytes)
+}
+
+pub fn encode_hex(bytes: &[u8]) -> String {
+    let mut out = vec![0; bytes.len() * 2];
+    faster_hex::hex_encode(bytes, &mut out).expect("hex output buffer is exactly twice the input length");
+    String::from_utf8(out).expect("hex is always valid ascii")
+}
+
+fn verify_compiled_contract(contract: &SilContractArtifact) -> std::result::Result<(), SilAbiVerificationError> {
+    let decode = |field, value| {
+        decode_hex(value).map_err(|err| SilAbiVerificationError::InvalidCompiledHex {
+            contract: contract.name.clone(),
+            field,
+            message: err.to_string(),
+        })
+    };
+    let script = decode("script", &contract.compiled.script_hex)?;
+    let found_hash = decode("template hash", &contract.compiled.template_hash_hex)?;
+
+    let mut entries_by_tag = BTreeMap::<DispatchTag, &str>::new();
+    for entry in &contract.entries {
+        let tag = entry.dispatch_tag;
+        if let Some(first) = entries_by_tag.insert(tag, &entry.name) {
+            return Err(SilAbiVerificationError::DispatchTagCollision {
+                contract: contract.name.clone(),
+                first: first.to_string(),
+                second: entry.name.clone(),
+                tag: tag.to_hex(),
+            });
+        }
+    }
+
+    let span = &contract.compiled.state_span;
+    let Some((prefix, state_script, suffix)) = contract.compiled.script_parts(&script) else {
+        return Err(SilAbiVerificationError::InvalidStateSpan {
+            contract: contract.name.clone(),
+            offset: span.offset,
+            len: span.len,
+            script_len: script.len(),
+        });
+    };
+    for field in &contract.runtime_state.fields {
+        if fixed_payload_len(&field.ty).is_none() {
+            return Err(SilAbiVerificationError::UnsupportedRuntimeStateType {
+                contract: contract.name.clone(),
+                field: field.name.clone(),
+                ty: type_name(&field.ty),
+            });
+        }
+    }
+    let state_values = decode_runtime_state_script(&contract.runtime_state, state_script).map_err(|err| {
+        SilAbiVerificationError::InvalidRuntimeStateEncoding { contract: contract.name.clone(), message: err.to_string() }
+    })?;
+    let canonical_state = encode_runtime_state_script(&contract.runtime_state, &state_values).map_err(|err| {
+        SilAbiVerificationError::InvalidRuntimeStateEncoding { contract: contract.name.clone(), message: err.to_string() }
+    })?;
+    if canonical_state != state_script {
+        return Err(SilAbiVerificationError::NonCanonicalRuntimeStateEncoding { contract: contract.name.clone() });
+    }
+    if found_hash.len() != 32 {
+        return Err(SilAbiVerificationError::InvalidTemplateHashLength { contract: contract.name.clone(), len: found_hash.len() });
+    }
+
+    let expected_hash = template_hash(prefix, suffix);
+    if found_hash != expected_hash {
+        return Err(SilAbiVerificationError::TemplateHashMismatch {
+            contract: contract.name.clone(),
+            expected: encode_hex(&expected_hash),
+            found: contract.compiled.template_hash_hex.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn entry_params(entry: &SilEntryArtifact) -> Vec<(&str, &TypeArtifact)> {
+    entry.params.iter().map(|param| (param.name.as_str(), &param.ty)).collect()
+}
+
+struct TypeContext<'a> {
+    states: BTreeMap<&'a str, &'a StateArtifact>,
+    runtime_state: StateArtifact,
+}
+
+impl<'a> TypeContext<'a> {
+    fn new(abi: &'a SilAbiArtifact, contract: &'a SilContractArtifact) -> Self {
+        Self {
+            states: abi.states.iter().map(|state| (state.name.as_str(), state)).collect(),
+            runtime_state: StateArtifact {
+                name: "State".to_string(),
+                fields: contract
+                    .runtime_state
+                    .fields
+                    .iter()
+                    .map(|field| FieldArtifact { name: field.name.clone(), ty: field.ty.clone() })
+                    .collect(),
+            },
+        }
+    }
+
+    fn state(&self, name: &str) -> CodecResult<&StateArtifact> {
+        if name == "State" {
+            return Ok(&self.runtime_state);
+        }
+        self.states.get(name).copied().ok_or_else(|| CodecError::UnknownStruct(name.to_string()))
+    }
+}
+
+fn script_builder() -> ScriptBuilder {
+    ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() })
+}
+
+fn push_sig_arg(
+    builder: &mut ScriptBuilder,
+    ctx: &TypeContext<'_>,
+    name: &str,
+    ty: &TypeArtifact,
+    value: &ArtifactValue,
+) -> CodecResult<()> {
+    match ty {
+        TypeArtifact::Struct { name: struct_name } => {
+            let fields = object_fields(value)?;
+            push_struct_fields(builder, ctx, ctx.state(struct_name)?, fields)
+        }
+        TypeArtifact::FixedArray { item, len } if matches!(item.as_ref(), TypeArtifact::Struct { .. }) => {
+            push_struct_array_fields(builder, ctx, item, Some(*len), value)
+        }
+        TypeArtifact::DynamicArray { item } if matches!(item.as_ref(), TypeArtifact::Struct { .. }) => {
+            push_struct_array_fields(builder, ctx, item, None, value)
+        }
+        TypeArtifact::Int | TypeArtifact::Temporal => push_i64(builder, expect_int(value)?),
+        TypeArtifact::Bool => push_i64(builder, i64::from(expect_bool(value)?)),
+        TypeArtifact::Byte => {
+            push_data(builder, &[expect_byte(value)?])?;
+            Ok(())
+        }
+        TypeArtifact::Bytes => {
+            push_data(builder, expect_bytes(value)?)?;
+            Ok(())
+        }
+        TypeArtifact::Text => {
+            push_data(builder, expect_text(value)?.as_bytes())?;
+            Ok(())
+        }
+        TypeArtifact::Pubkey => push_fixed_bytes(builder, name, value, 32),
+        TypeArtifact::Sig => push_fixed_bytes(builder, name, value, 65),
+        TypeArtifact::Datasig => push_fixed_bytes(builder, name, value, 64),
+        TypeArtifact::FixedBytes { len } => push_fixed_bytes(builder, name, value, *len),
+        TypeArtifact::FixedArray { item, len } => {
+            let payload = encode_array_payload(name, item, Some(*len), value)?;
+            push_data(builder, &payload)?;
+            Ok(())
+        }
+        TypeArtifact::DynamicArray { item } => {
+            let payload = encode_array_payload(name, item, None, value)?;
+            push_data(builder, &payload)?;
+            Ok(())
+        }
+    }
+}
+
+fn push_struct_fields(
+    builder: &mut ScriptBuilder,
+    ctx: &TypeContext<'_>,
+    state: &StateArtifact,
+    fields: &BTreeMap<String, ArtifactValue>,
+) -> CodecResult<()> {
+    assert_no_extra_fields(fields, &state.fields)?;
+    for field in &state.fields {
+        let value = fields.get(&field.name).ok_or_else(|| CodecError::MissingField(field.name.clone()))?;
+        push_sig_arg(builder, ctx, &field.name, &field.ty, value)?;
+    }
+    Ok(())
+}
+
+fn push_struct_array_fields(
+    builder: &mut ScriptBuilder,
+    ctx: &TypeContext<'_>,
+    item: &TypeArtifact,
+    expected_len: Option<usize>,
+    value: &ArtifactValue,
+) -> CodecResult<()> {
+    let TypeArtifact::Struct { name } = item else {
+        return Err(CodecError::UnsupportedType(type_name(item)));
+    };
+    let state = ctx.state(name)?;
+    let values = expect_array(value)?;
+    if let Some(expected) = expected_len {
+        require_len(name, expected, values.len())?;
+    }
+
+    let mut object_values = Vec::with_capacity(values.len());
+    for value in values {
+        let fields = object_fields(value)?;
+        assert_no_extra_fields(fields, &state.fields)?;
+        object_values.push(fields);
+    }
+
+    for field in &state.fields {
+        let mut field_values = Vec::with_capacity(object_values.len());
+        for object in &object_values {
+            field_values.push(object.get(&field.name).ok_or_else(|| CodecError::MissingField(field.name.clone()))?.clone());
+        }
+        push_sig_arg(
+            builder,
+            ctx,
+            &field.name,
+            &TypeArtifact::DynamicArray { item: Box::new(field.ty.clone()) },
+            &ArtifactValue::Array(field_values),
+        )?;
+    }
+    Ok(())
+}
+
+fn encode_state_payload(name: &str, ty: &TypeArtifact, value: &ArtifactValue) -> CodecResult<Vec<u8>> {
+    match ty {
+        TypeArtifact::Bytes => Ok(expect_bytes(value)?.to_vec()),
+        TypeArtifact::Text => Ok(expect_text(value)?.as_bytes().to_vec()),
+        TypeArtifact::DynamicArray { item } => encode_array_payload(name, item, None, value),
+        _ => encode_fixed_payload(name, ty, value),
+    }
+}
+
+fn encode_struct_fields_payload(state: &StateArtifact, fields: &BTreeMap<String, ArtifactValue>) -> CodecResult<Vec<u8>> {
+    assert_no_extra_fields(fields, &state.fields)?;
+    let mut out = Vec::new();
+    for field in &state.fields {
+        let value = fields.get(&field.name).ok_or_else(|| CodecError::MissingField(field.name.clone()))?;
+        out.extend(encode_state_payload(&field.name, &field.ty, value)?);
+    }
+    Ok(out)
+}
+
+fn decode_state_payload(name: &str, ty: &TypeArtifact, payload: &[u8]) -> CodecResult<ArtifactValue> {
+    match ty {
+        TypeArtifact::Int | TypeArtifact::Temporal => {
+            require_len(name, 8, payload.len())?;
+            Ok(ArtifactValue::Int(deserialize_fixed_i64(payload)?))
+        }
+        TypeArtifact::Bool => {
+            require_len(name, 1, payload.len())?;
+            match payload[0] {
+                0 => Ok(ArtifactValue::Bool(false)),
+                1 => Ok(ArtifactValue::Bool(true)),
+                value => Err(CodecError::TypeMismatch { expected: "bool byte 0 or 1".to_string(), actual: value.to_string() }),
+            }
+        }
+        TypeArtifact::Byte => {
+            require_len(name, 1, payload.len())?;
+            Ok(ArtifactValue::Byte(payload[0]))
+        }
+        TypeArtifact::Bytes => Ok(ArtifactValue::Bytes(payload.to_vec())),
+        TypeArtifact::Text => String::from_utf8(payload.to_vec())
+            .map(ArtifactValue::Text)
+            .map_err(|err| CodecError::TypeMismatch { expected: "utf-8 string".to_string(), actual: err.to_string() }),
+        TypeArtifact::Pubkey => decode_fixed_bytes(name, payload, 32),
+        TypeArtifact::Sig => decode_fixed_bytes(name, payload, 65),
+        TypeArtifact::Datasig => decode_fixed_bytes(name, payload, 64),
+        TypeArtifact::FixedBytes { len } => decode_fixed_bytes(name, payload, *len),
+        TypeArtifact::FixedArray { item, len } => decode_array_payload(name, item, Some(*len), payload),
+        TypeArtifact::DynamicArray { item } => decode_array_payload(name, item, None, payload),
+        TypeArtifact::Struct { name } => Err(CodecError::UnsupportedType(format!("state struct {name}"))),
+    }
+}
+
+fn decode_fixed_bytes(name: &str, payload: &[u8], expected: usize) -> CodecResult<ArtifactValue> {
+    require_len(name, expected, payload.len())?;
+    Ok(ArtifactValue::Bytes(payload.to_vec()))
+}
+
+fn decode_array_payload(name: &str, item: &TypeArtifact, expected_len: Option<usize>, payload: &[u8]) -> CodecResult<ArtifactValue> {
+    let item_len = fixed_payload_len(item).ok_or_else(|| CodecError::UnsupportedType(type_name(item)))?;
+    if item_len == 0 || !payload.len().is_multiple_of(item_len) {
+        return Err(CodecError::InvalidLength { name: name.to_string(), expected: item_len, actual: payload.len() });
+    }
+    let actual_len = payload.len() / item_len;
+    if let Some(expected) = expected_len {
+        require_len(name, expected, actual_len)?;
+    }
+    payload
+        .chunks_exact(item_len)
+        .map(|chunk| decode_state_payload(name, item, chunk))
+        .collect::<CodecResult<Vec<_>>>()
+        .map(ArtifactValue::Array)
+}
+
+fn encode_array_payload(name: &str, item: &TypeArtifact, expected_len: Option<usize>, value: &ArtifactValue) -> CodecResult<Vec<u8>> {
+    if matches!(item, TypeArtifact::Struct { .. }) {
+        return Err(CodecError::UnsupportedType(type_name(item)));
+    }
+    let values = expect_array(value)?;
+    if let Some(expected) = expected_len {
+        require_len(name, expected, values.len())?;
+    }
+    let mut out = Vec::new();
+    for value in values {
+        out.extend(encode_fixed_payload(name, item, value)?);
+    }
+    Ok(out)
+}
+
+fn encode_fixed_payload(name: &str, ty: &TypeArtifact, value: &ArtifactValue) -> CodecResult<Vec<u8>> {
+    match ty {
+        TypeArtifact::Int | TypeArtifact::Temporal => serialize_fixed_i64(expect_int(value)?, 8),
+        TypeArtifact::Bool => Ok(vec![u8::from(expect_bool(value)?)]),
+        TypeArtifact::Byte => Ok(vec![expect_byte(value)?]),
+        TypeArtifact::Pubkey => fixed_bytes(name, value, 32),
+        TypeArtifact::Sig => fixed_bytes(name, value, 65),
+        TypeArtifact::Datasig => fixed_bytes(name, value, 64),
+        TypeArtifact::FixedBytes { len } => fixed_bytes(name, value, *len),
+        TypeArtifact::FixedArray { item, len } => encode_array_payload(name, item, Some(*len), value),
+        TypeArtifact::Bytes | TypeArtifact::Text | TypeArtifact::DynamicArray { .. } | TypeArtifact::Struct { .. } => {
+            Err(CodecError::UnsupportedType(type_name(ty)))
+        }
+    }
+}
+
+fn fixed_payload_len(ty: &TypeArtifact) -> Option<usize> {
+    match ty {
+        TypeArtifact::Int | TypeArtifact::Temporal => Some(8),
+        TypeArtifact::Bool => Some(1),
+        TypeArtifact::Byte => Some(1),
+        TypeArtifact::Pubkey => Some(32),
+        TypeArtifact::Sig => Some(65),
+        TypeArtifact::Datasig => Some(64),
+        TypeArtifact::FixedBytes { len } => Some(*len),
+        TypeArtifact::FixedArray { item, len } => fixed_payload_len(item).and_then(|item_len| item_len.checked_mul(*len)),
+        TypeArtifact::Bytes | TypeArtifact::Text | TypeArtifact::DynamicArray { .. } | TypeArtifact::Struct { .. } => None,
+    }
+}
+
+fn push_fixed_bytes(builder: &mut ScriptBuilder, name: &str, value: &ArtifactValue, expected: usize) -> CodecResult<()> {
+    let bytes = fixed_bytes(name, value, expected)?;
+    push_data(builder, &bytes)?;
+    Ok(())
+}
+
+fn fixed_bytes(name: &str, value: &ArtifactValue, expected: usize) -> CodecResult<Vec<u8>> {
+    let bytes = expect_bytes(value)?;
+    require_len(name, expected, bytes.len())?;
+    Ok(bytes.to_vec())
+}
+
+fn push_i64(builder: &mut ScriptBuilder, value: i64) -> CodecResult<()> {
+    if value == i64::MIN {
+        return Err(CodecError::InvalidNumber { value, size: 8 });
+    }
+    builder.add_i64(value)?;
+    Ok(())
+}
+
+fn push_data(builder: &mut ScriptBuilder, data: &[u8]) -> CodecResult<()> {
+    builder.add_data(data)?;
+    Ok(())
+}
+
+fn parse_pushes(script: &[u8]) -> CodecResult<Vec<(usize, Vec<u8>)>> {
+    let mut pushes = Vec::new();
+    let mut offset = 0;
+    while offset < script.len() {
+        let start = offset;
+        let opcode = script[offset];
+        offset += 1;
+        let len = match opcode {
+            OP_0 => {
+                pushes.push((start, Vec::new()));
+                continue;
+            }
+            OP_DATA_1..=OP_DATA_75 => opcode as usize,
+            OP_PUSH_DATA_1 => {
+                let bytes = read_len(script, &mut offset, 1)?;
+                bytes[0] as usize
+            }
+            OP_PUSH_DATA_2 => {
+                let bytes = read_len(script, &mut offset, 2)?;
+                u16::from_le_bytes([bytes[0], bytes[1]]) as usize
+            }
+            OP_PUSH_DATA_4 => {
+                let bytes = read_len(script, &mut offset, 4)?;
+                u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize
+            }
+            OP_1_NEGATE | OP_1..=OP_16 => {
+                return Err(CodecError::InvalidPush(format!("small-int opcode {opcode:#x} is not valid in state span")));
+            }
+            _ => return Err(CodecError::InvalidPush(format!("opcode {opcode:#x} is not a push-data opcode"))),
+        };
+        let data = read_len(script, &mut offset, len)?.to_vec();
+        pushes.push((start, data));
+    }
+    Ok(pushes)
+}
+
+fn read_len<'a>(script: &'a [u8], offset: &mut usize, len: usize) -> CodecResult<&'a [u8]> {
+    let end = offset.checked_add(len).ok_or_else(|| CodecError::InvalidPush("push length overflow".to_string()))?;
+    if end > script.len() {
+        return Err(CodecError::InvalidPush(format!(
+            "push at offset {} needs {} bytes, only {} remain",
+            *offset,
+            len,
+            script.len().saturating_sub(*offset)
+        )));
+    }
+    let bytes = &script[*offset..end];
+    *offset = end;
+    Ok(bytes)
+}
+
+fn serialize_fixed_i64(value: i64, size: usize) -> CodecResult<Vec<u8>> {
+    serialize_script_i64(value, Some(size)).map(|bytes| bytes.into_vec()).map_err(|_| CodecError::InvalidNumber { value, size })
+}
+
+fn deserialize_fixed_i64(bytes: &[u8]) -> CodecResult<i64> {
+    deserialize_script_i64(bytes, false).map_err(|err| CodecError::InvalidPush(err.to_string()))
+}
+
+fn expect_int(value: &ArtifactValue) -> CodecResult<i64> {
+    match value {
+        ArtifactValue::Int(value) => Ok(*value),
+        other => type_mismatch("int", other),
+    }
+}
+
+fn expect_bool(value: &ArtifactValue) -> CodecResult<bool> {
+    match value {
+        ArtifactValue::Bool(value) => Ok(*value),
+        other => type_mismatch("bool", other),
+    }
+}
+
+fn expect_byte(value: &ArtifactValue) -> CodecResult<u8> {
+    match value {
+        ArtifactValue::Byte(value) => Ok(*value),
+        other => type_mismatch("byte", other),
+    }
+}
+
+fn expect_bytes(value: &ArtifactValue) -> CodecResult<&[u8]> {
+    match value {
+        ArtifactValue::Bytes(value) => Ok(value),
+        other => type_mismatch("bytes", other),
+    }
+}
+
+fn expect_text(value: &ArtifactValue) -> CodecResult<&str> {
+    match value {
+        ArtifactValue::Text(value) => Ok(value),
+        other => type_mismatch("string", other),
+    }
+}
+
+fn expect_array(value: &ArtifactValue) -> CodecResult<&[ArtifactValue]> {
+    match value {
+        ArtifactValue::Array(value) => Ok(value),
+        other => type_mismatch("array", other),
+    }
+}
+
+fn object_fields(value: &ArtifactValue) -> CodecResult<&BTreeMap<String, ArtifactValue>> {
+    match value {
+        ArtifactValue::Object(fields) => Ok(fields),
+        other => type_mismatch("object", other),
+    }
+}
+
+fn type_mismatch<T>(expected: &str, actual: &ArtifactValue) -> CodecResult<T> {
+    Err(CodecError::TypeMismatch { expected: expected.to_string(), actual: value_name(actual).to_string() })
+}
+
+fn value_name(value: &ArtifactValue) -> &'static str {
+    match value {
+        ArtifactValue::Int(_) => "int",
+        ArtifactValue::Bool(_) => "bool",
+        ArtifactValue::Byte(_) => "byte",
+        ArtifactValue::Bytes(_) => "bytes",
+        ArtifactValue::Text(_) => "string",
+        ArtifactValue::Array(_) => "array",
+        ArtifactValue::Object(_) => "object",
+    }
+}
+
+fn assert_no_extra_fields(fields: &BTreeMap<String, ArtifactValue>, expected: &[FieldArtifact]) -> CodecResult<()> {
+    for name in fields.keys() {
+        if expected.iter().all(|field| &field.name != name) {
+            return Err(CodecError::UnknownField(name.clone()));
+        }
+    }
+    Ok(())
+}
+
+fn require_len(name: &str, expected: usize, actual: usize) -> CodecResult<()> {
+    if expected == actual { Ok(()) } else { Err(CodecError::InvalidLength { name: name.to_string(), expected, actual }) }
+}
+
+fn type_name(ty: &TypeArtifact) -> String {
+    match ty {
+        TypeArtifact::Int => "int".to_string(),
+        TypeArtifact::Temporal => "temporal".to_string(),
+        TypeArtifact::Bool => "bool".to_string(),
+        TypeArtifact::Byte => "byte".to_string(),
+        TypeArtifact::Bytes => "bytes".to_string(),
+        TypeArtifact::Text => "string".to_string(),
+        TypeArtifact::Pubkey => "pubkey".to_string(),
+        TypeArtifact::Sig => "sig".to_string(),
+        TypeArtifact::Datasig => "datasig".to_string(),
+        TypeArtifact::FixedBytes { len } => format!("byte[{len}]"),
+        TypeArtifact::FixedArray { item, len } => format!("{}[{len}]", type_name(item)),
+        TypeArtifact::DynamicArray { item } => format!("{}[]", type_name(item)),
+        TypeArtifact::Struct { name } => name.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Locks the ABI copy to Sil's canonical implementation. Ideally, Sil will
+    // expose this from a small shared core crate instead of requiring a copy.
+    #[test]
+    fn template_hash_matches_silverscript() {
+        let cases: &[(&[u8], &[u8])] = &[(b"", b""), (b"a", b"bc"), (b"ab", b"c"), (&[0, 1, 2, 3], &[0xff, 0x80, 0x40])];
+
+        for (prefix, suffix) in cases {
+            assert_eq!(template_hash(prefix, suffix), silverscript_lang::template::template_hash(prefix, suffix));
+        }
+
+        let kcc1_vectors: &[(&[u8], &[u8], &str)] = &[
+            (&[], &[], "e572dff82304700b856a555ac3a4558d0df3646a3727816500270a93c66aac1e"),
+            (b"a", b"bc", "405e183e2494cdbe2df89349cc0ffa5b77fb885ad97a1d5660ecd0692ef8142a"),
+            (b"ab", b"c", "a0968c014f3fc7bd1a7d9a8d1ad1177eb379bd2f05e56309eb4e20347c5e7eba"),
+            (&[0x00, 0xff], &[0x10, 0x00, 0x80], "6616a66757315de0221cb2acba729113cebde31f8d3ca7fa93878a0584b96905"),
+        ];
+        for (prefix, suffix, expected) in kcc1_vectors {
+            assert_eq!(encode_hex(&template_hash(prefix, suffix)), *expected);
+        }
+    }
+
+    #[test]
+    fn verifies_compiled_contract_against_its_script() {
+        let mut abi = tiny_sil_abi();
+        let contract = &mut abi.contracts[0];
+        let prefix = [0xaa];
+        contract.runtime_state.fields = vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
+        let state =
+            encode_runtime_state_script(&contract.runtime_state, &BTreeMap::from([("value".to_string(), ArtifactValue::Byte(2))]))
+                .expect("state encodes");
+        let suffix = [0xbb, 0xcc];
+        contract.compiled.script_hex = encode_hex(&[prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
+        contract.compiled.template_hash_hex = encode_hex(&template_hash(&prefix, &suffix));
+        contract.compiled.state_span = StateSpanArtifact { offset: prefix.len(), len: state.len() };
+
+        abi.verify().expect("compiled template matches its contract script");
+
+        abi.contracts[0].compiled.template_hash_hex = "00".repeat(32);
+        assert!(matches!(
+            abi.verify(),
+            Err(SilAbiVerificationError::TemplateHashMismatch { ref contract, .. }) if contract == "Foo"
+        ));
+
+        abi.contracts[0].compiled.template_hash_hex = encode_hex(&template_hash(&prefix, &suffix));
+        abi.contracts[0].compiled.script_hex = encode_hex(&[&[0xff], state.as_slice(), suffix.as_slice()].concat());
+        assert!(matches!(
+            abi.verify(),
+            Err(SilAbiVerificationError::TemplateHashMismatch { ref contract, .. }) if contract == "Foo"
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_dispatch_tags_during_deserialization() {
+        let wrong_length = serde_json::from_str::<DispatchTag>(r#""00""#).expect_err("short tag should fail");
+        assert!(wrong_length.to_string().contains("exactly 8 hexadecimal characters"));
+
+        let invalid_hex = serde_json::from_str::<DispatchTag>(r#""zzzzzzzz""#).expect_err("invalid hex should fail");
+        assert!(invalid_hex.to_string().contains("invalid dispatch tag hex"));
+    }
+
+    #[test]
+    fn rejects_colliding_dispatch_tags() {
+        let mut abi = tiny_sil_abi();
+        abi.contracts[0].entries[1].dispatch_tag = abi.contracts[0].entries[0].dispatch_tag;
+        assert!(matches!(
+            abi.verify(),
+            Err(SilAbiVerificationError::DispatchTagCollision { ref contract, ref first, ref second, .. })
+                if contract == "Foo" && first == "step" && second == "other"
+        ));
+    }
+
+    #[test]
+    fn rejects_state_spans_that_do_not_match_the_runtime_state() {
+        let mut abi = tiny_sil_abi();
+        let contract = &mut abi.contracts[0];
+        contract.runtime_state.fields = vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
+        let prefix = [0xaa];
+        let state =
+            encode_runtime_state_script(&contract.runtime_state, &BTreeMap::from([("value".to_string(), ArtifactValue::Byte(2))]))
+                .expect("state encodes");
+        let suffix = [0xbb];
+        contract.compiled.script_hex = encode_hex(&[prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
+
+        contract.compiled.state_span = StateSpanArtifact { offset: 0, len: prefix.len() + state.len() };
+        contract.compiled.template_hash_hex = encode_hex(&template_hash(&[], &suffix));
+        assert!(matches!(
+            abi.verify(),
+            Err(SilAbiVerificationError::InvalidRuntimeStateEncoding { ref contract, .. }) if contract == "Foo"
+        ));
+
+        let contract = &mut abi.contracts[0];
+        contract.compiled.state_span = StateSpanArtifact { offset: prefix.len(), len: state.len() - 1 };
+        contract.compiled.template_hash_hex = encode_hex(&template_hash(&prefix, &[state[state.len() - 1], suffix[0]]));
+        assert!(matches!(
+            abi.verify(),
+            Err(SilAbiVerificationError::InvalidRuntimeStateEncoding { ref contract, .. }) if contract == "Foo"
+        ));
+    }
+
+    #[test]
+    fn rejects_noncanonical_and_variable_runtime_state_encodings() {
+        let mut abi = tiny_sil_abi();
+        let contract = &mut abi.contracts[0];
+        contract.runtime_state.fields = vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
+        let prefix = [0xaa];
+        let state = [OP_PUSH_DATA_1, 1, 2];
+        let suffix = [0xbb];
+        contract.compiled.script_hex = encode_hex(&[prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
+        contract.compiled.template_hash_hex = encode_hex(&template_hash(&prefix, &suffix));
+        contract.compiled.state_span = StateSpanArtifact { offset: prefix.len(), len: state.len() };
+        assert_eq!(abi.verify(), Err(SilAbiVerificationError::NonCanonicalRuntimeStateEncoding { contract: "Foo".to_string() }));
+
+        abi.contracts[0].runtime_state.fields[0].ty = TypeArtifact::Bytes;
+        assert_eq!(
+            abi.verify(),
+            Err(SilAbiVerificationError::UnsupportedRuntimeStateType {
+                contract: "Foo".to_string(),
+                field: "value".to_string(),
+                ty: "bytes".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn encodes_sigscript_arguments_canonically() {
+        let artifact = tiny_sil_abi();
+        let sigscript = encode_contract_entry_sig_script(
+            &artifact,
+            "Foo",
+            "step",
+            &[ArtifactValue::Int(17), ArtifactValue::Bytes(vec![1, 2, 3, 4]), ArtifactValue::Bool(true), ArtifactValue::Byte(1)],
+        )
+        .expect("sigscript encodes");
+
+        assert_eq!(encode_hex(&sigscript), "011104010203045151042c49ed65");
+    }
+
+    #[test]
+    fn encodes_temporal_values_with_integer_payloads() {
+        assert_eq!(TypeArtifact::from_parts("temporal", None), TypeArtifact::Temporal);
+        assert_eq!(serde_json::to_value(TypeArtifact::Temporal).unwrap(), serde_json::json!({ "kind": "temporal" }));
+
+        let mut artifact = tiny_sil_abi();
+        artifact.contracts[0].entries[1].params =
+            vec![param("at", TypeArtifact::Temporal), param("history", TypeArtifact::dynamic_array(TypeArtifact::Temporal))];
+        let history = ArtifactValue::Array(vec![ArtifactValue::Int(1), ArtifactValue::Int(-2)]);
+        let sigscript = encode_contract_entry_sig_script(&artifact, "Foo", "other", &[ArtifactValue::Int(-5), history.clone()])
+            .expect("temporal arguments encode");
+        let pushes = parse_pushes(&sigscript).expect("signature script contains only data pushes");
+        assert_eq!(
+            pushes.iter().map(|(_, data)| data.clone()).collect::<Vec<_>>(),
+            vec![
+                vec![0x85],
+                [serialize_fixed_i64(1, 8).unwrap(), serialize_fixed_i64(-2, 8).unwrap()].concat(),
+                vec![0xde, 0xad, 0xbe, 0xef],
+            ]
+        );
+
+        let runtime_state = RuntimeStateArtifact {
+            source: "ClockState".to_string(),
+            fields: vec![
+                RuntimeFieldArtifact { name: "at".to_string(), ty: TypeArtifact::Temporal },
+                RuntimeFieldArtifact {
+                    name: "history".to_string(),
+                    ty: TypeArtifact::FixedArray { item: Box::new(TypeArtifact::Temporal), len: 2 },
+                },
+            ],
+        };
+        let values = BTreeMap::from([("at".to_string(), ArtifactValue::Int(-5)), ("history".to_string(), history)]);
+        let encoded = encode_runtime_state_script(&runtime_state, &values).expect("temporal state encodes");
+        assert_eq!(decode_runtime_state_script(&runtime_state, &encoded).expect("temporal state decodes"), values);
+    }
+
+    #[test]
+    fn hex_helpers_use_faster_hex_and_report_invalid_input() {
+        assert_eq!(decode_hex("01110401020304515100").expect("hex decodes"), vec![1, 17, 4, 1, 2, 3, 4, 81, 81, 0]);
+        assert!(matches!(decode_hex("abc"), Err(CodecError::InvalidHex(_))));
+        assert!(matches!(decode_hex("zz"), Err(CodecError::InvalidHex(_))));
+    }
+
+    #[test]
+    fn encodes_struct_payload_without_push_framing() {
+        let mut abi = tiny_sil_abi();
+        abi.states.push(StateArtifact {
+            name: "Memory".to_string(),
+            fields: vec![
+                FieldArtifact { name: "hunger".to_string(), ty: TypeArtifact::Int },
+                FieldArtifact { name: "tag".to_string(), ty: TypeArtifact::FixedBytes { len: 2 } },
+            ],
+        });
+        let values = BTreeMap::from([
+            ("hunger".to_string(), ArtifactValue::Int(17)),
+            ("tag".to_string(), ArtifactValue::Bytes(vec![0xaa, 0xbb])),
+        ]);
+
+        let payload = encode_struct_payload(&abi, abi.contract("Foo").expect("contract exists"), "Memory", &values)
+            .expect("struct payload encodes");
+
+        assert_eq!(encode_hex(&payload), "1100000000000000aabb");
+    }
+
+    #[test]
+    fn deserializes_sil_abi_without_argent_coordination_metadata() {
+        let json = r#"
+        {
+          "schema_version": 1,
+          "states": [
+            {
+              "name": "FooState",
+              "fields": [{ "name": "count", "type": { "kind": "int" } }]
+            }
+          ],
+          "contracts": [
+            {
+              "name": "Foo",
+              "source_path": "sil/Foo.sil",
+              "runtime_state": {
+                "source": "FooState",
+                "fields": [{ "name": "count", "type": { "kind": "int" } }]
+              },
+              "entries": [
+                {
+                  "name": "step",
+                  "dispatch_tag": "2c49ed65",
+                  "params": [{ "name": "amount", "type": { "kind": "int" } }]
+                }
+              ],
+              "compiled": {
+                "script_hex": "00",
+                "template_hash_hex": "00",
+                "state_span": { "offset": 0, "len": 1 }
+              }
+            }
+          ]
+        }
+        "#;
+
+        let abi: SilAbiArtifact = serde_json::from_str(json).expect("sil abi should deserialize");
+        abi.check_schema_version().expect("sil abi schema version should be supported");
+        assert_eq!(
+            abi.contract("Foo").and_then(|contract| contract.entry("step")).map(|entry| entry.dispatch_tag),
+            Some(DispatchTag::from([0x2c, 0x49, 0xed, 0x65]))
+        );
+        assert_eq!(
+            abi.contract("Foo").and_then(|contract| contract.entry("step")).map(|entry| entry.params[0].name.as_str()),
+            Some("amount")
+        );
+        let serialized = serde_json::to_value(&abi).expect("Sil ABI artifact serializes");
+        assert_eq!(serialized["contracts"][0]["entries"][0]["dispatch_tag"], "2c49ed65");
+    }
+
+    #[test]
+    fn rejects_sigscript_ints_that_do_not_fit_silverscript_script_number() {
+        let artifact = tiny_sil_abi();
+        let err = encode_contract_entry_sig_script(
+            &artifact,
+            "Foo",
+            "step",
+            &[ArtifactValue::Int(i64::MIN), ArtifactValue::Bytes(vec![1, 2, 3, 4]), ArtifactValue::Bool(true), ArtifactValue::Byte(1)],
+        )
+        .expect_err("i64::MIN needs 9 bytes and should match txscript rejection");
+
+        assert_eq!(err, CodecError::InvalidNumber { value: i64::MIN, size: 8 });
+    }
+
+    #[test]
+    fn round_trips_runtime_state_script() {
+        let runtime_state = RuntimeStateArtifact {
+            source: "FooState".to_string(),
+            fields: vec![
+                RuntimeFieldArtifact { name: "gen__foo_template".to_string(), ty: TypeArtifact::FixedBytes { len: 32 } },
+                RuntimeFieldArtifact { name: "count".to_string(), ty: TypeArtifact::Int },
+                RuntimeFieldArtifact { name: "flag".to_string(), ty: TypeArtifact::Bool },
+            ],
+        };
+        let values = BTreeMap::from([
+            ("gen__foo_template".to_string(), ArtifactValue::Bytes(vec![7; 32])),
+            ("count".to_string(), ArtifactValue::Int(-5)),
+            ("flag".to_string(), ArtifactValue::Bool(true)),
+        ]);
+
+        let encoded = encode_runtime_state_script(&runtime_state, &values).expect("state encodes");
+        let decoded = decode_runtime_state_script(&runtime_state, &encoded).expect("state decodes");
+
+        assert_eq!(encode_hex(&encoded), format!("20{}0805000000000000800101", "07".repeat(32)));
+        assert_eq!(decoded, values);
+        assert_eq!(encode_runtime_state_script(&runtime_state, &decoded).expect("state re-encodes"), encoded);
+
+        let mut extra = values;
+        extra.insert("extra".to_string(), ArtifactValue::Int(1));
+        assert_eq!(
+            encode_runtime_state_script(&runtime_state, &extra).expect_err("extra fields should be rejected"),
+            CodecError::UnknownField("extra".to_string())
+        );
+    }
+
+    fn tiny_sil_abi() -> SilAbiArtifact {
+        SilAbiArtifact {
+            schema_version: 1,
+            states: Vec::new(),
+            contracts: vec![SilContractArtifact {
+                name: "Foo".to_string(),
+                source_path: "sil/Foo.sil".to_string(),
+                runtime_state: RuntimeStateArtifact { source: "FooState".to_string(), fields: Vec::new() },
+                entries: vec![
+                    SilEntryArtifact {
+                        name: "step".to_string(),
+                        dispatch_tag: DispatchTag::from([0x2c, 0x49, 0xed, 0x65]),
+                        params: vec![
+                            param("n", TypeArtifact::Int),
+                            param("hash", TypeArtifact::FixedBytes { len: 4 }),
+                            param("flag", TypeArtifact::Bool),
+                            param("b", TypeArtifact::Byte),
+                        ],
+                    },
+                    SilEntryArtifact {
+                        name: "other".to_string(),
+                        dispatch_tag: DispatchTag::from([0xde, 0xad, 0xbe, 0xef]),
+                        params: Vec::new(),
+                    },
+                ],
+                compiled: CompiledContractArtifact {
+                    script_hex: String::new(),
+                    template_hash_hex: String::new(),
+                    state_span: StateSpanArtifact { offset: 0, len: 0 },
+                },
+            }],
+        }
+    }
+
+    fn param(name: &str, ty: TypeArtifact) -> ParamArtifact {
+        ParamArtifact { name: name.to_string(), ty }
+    }
+}

--- a/silverscript-abi/src/lib.rs
+++ b/silverscript-abi/src/lib.rs
@@ -114,7 +114,6 @@ pub struct ArtifactVersionError {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StructArtifact {
-    pub name: String,
     pub fields: Vec<FieldArtifact>,
 }
 
@@ -193,8 +192,8 @@ impl TypeArtifact {
 pub struct SilAbiArtifact {
     pub schema_version: u32,
     pub compiler_version: String,
-    pub structs: Vec<StructArtifact>,
-    pub contracts: Vec<SilContractArtifact>,
+    pub structs: BTreeMap<String, StructArtifact>,
+    pub contracts: BTreeMap<String, SilContractArtifact>,
 }
 
 impl SilAbiArtifact {
@@ -209,47 +208,46 @@ impl SilAbiArtifact {
     /// Verify each compiled script, runtime-state span, and template hash.
     pub fn verify(&self) -> std::result::Result<(), SilAbiVerificationError> {
         self.check_schema_version()?;
-        for contract in &self.contracts {
-            verify_compiled_contract(self, contract)?;
+        for (contract_name, contract) in &self.contracts {
+            verify_compiled_contract(self, contract_name, contract)?;
         }
         Ok(())
     }
 
     pub fn contract(&self, name: &str) -> Option<&SilContractArtifact> {
-        self.contracts.iter().find(|contract| contract.name == name)
+        self.contracts.get(name)
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SilContractArtifact {
-    pub name: String,
     pub source_path: String,
     pub runtime_state: RuntimeStateArtifact,
-    pub entries: Vec<SilEntryArtifact>,
+    pub entries: BTreeMap<String, SilEntryArtifact>,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub cov_decl_to_abi: BTreeMap<String, SilEntryArtifact>,
+    pub cov_decl_to_abi: BTreeMap<String, String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub delegate_entry_abi: Option<SilEntryArtifact>,
+    pub delegate_entry_abi: Option<String>,
     pub compiled: CompiledContractArtifact,
 }
 
 impl SilContractArtifact {
     pub fn entry(&self, name: &str) -> Option<&SilEntryArtifact> {
-        self.entries.iter().find(|entry| entry.name == name)
+        self.entries.get(name)
     }
 
     pub fn cov_binding_leader_decl_entry(&self, name: &str) -> Option<&SilEntryArtifact> {
-        self.cov_decl_to_abi.get(name)
+        self.entries.get(self.cov_decl_to_abi.get(name)?)
     }
 
     pub fn auth_decl_entry(&self, name: &str) -> Option<&SilEntryArtifact> {
-        self.cov_decl_to_abi.get(name)
+        self.entries.get(self.cov_decl_to_abi.get(name)?)
     }
 
     /// Resolve a source covenant declaration to its public entrypoint.
     pub fn covenant_decl_entry(&self, name: &str, is_leader: bool) -> Option<&SilEntryArtifact> {
-        let leader = self.cov_decl_to_abi.get(name)?;
-        if is_leader || self.delegate_entry_abi.is_none() { Some(leader) } else { self.delegate_entry_abi.as_ref() }
+        let leader = self.entries.get(self.cov_decl_to_abi.get(name)?)?;
+        if is_leader || self.delegate_entry_abi.is_none() { Some(leader) } else { self.entries.get(self.delegate_entry_abi.as_ref()?) }
     }
 }
 
@@ -268,7 +266,6 @@ pub struct RuntimeFieldArtifact {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SilEntryArtifact {
-    pub name: String,
     pub dispatch_tag: DispatchTag,
     pub params: Vec<ParamArtifact>,
 }
@@ -276,27 +273,11 @@ pub struct SilEntryArtifact {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CompiledContractArtifact {
     pub bytecode: Vec<u8>,
-    // TODO: Remove `script_hex` once all artifact consumers use `bytecode`.
-    pub script_hex: String,
     pub template_hash: [u8; 32],
-    // TODO: Remove `template_hash_hex` once all artifact consumers use `template_hash`.
-    pub template_hash_hex: String,
     pub state_span: StateSpanArtifact,
 }
 
 impl CompiledContractArtifact {
-    #[cfg(test)]
-    fn set_bytecode(&mut self, bytecode: Vec<u8>) {
-        self.script_hex = encode_hex(&bytecode);
-        self.bytecode = bytecode;
-    }
-
-    #[cfg(test)]
-    fn set_template_hash(&mut self, template_hash: [u8; 32]) {
-        self.template_hash_hex = encode_hex(&template_hash);
-        self.template_hash = template_hash;
-    }
-
     /// Split decoded script bytes into the template prefix, runtime state, and
     /// template suffix declared by this artifact.
     pub fn script_parts<'a>(&self, script: &'a [u8]) -> Option<(&'a [u8], &'a [u8], &'a [u8])> {
@@ -307,9 +288,9 @@ impl CompiledContractArtifact {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CompiledTemplateArtifact {
-    pub prefix_hex: String,
-    pub suffix_hex: String,
-    pub hash_hex: String,
+    pub prefix: Vec<u8>,
+    pub suffix: Vec<u8>,
+    pub hash: [u8; 32],
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -322,12 +303,6 @@ pub struct StateSpanArtifact {
 pub enum SilAbiVerificationError {
     #[error(transparent)]
     Version(#[from] ArtifactVersionError),
-    #[error("contract `{contract}` has invalid compiled {field} hex: {message}")]
-    InvalidCompiledHex { contract: String, field: &'static str, message: String },
-    #[error("contract `{contract}` bytecode does not match its script_hex encoding")]
-    BytecodeMismatch { contract: String },
-    #[error("contract `{contract}` template hash does not match its template_hash_hex encoding")]
-    TemplateHashEncodingMismatch { contract: String },
     #[error("contract `{contract}` has state span offset {offset} length {len}, but its compiled script has {script_len} bytes")]
     InvalidStateSpan { contract: String, offset: usize, len: usize, script_len: usize },
     #[error("contract `{contract}` runtime state field `{field}` has unsupported type `{ty}`")]
@@ -336,12 +311,12 @@ pub enum SilAbiVerificationError {
     InvalidRuntimeStateEncoding { contract: String, message: String },
     #[error("contract `{contract}` state span is not canonically encoded")]
     NonCanonicalRuntimeStateEncoding { contract: String },
-    #[error("contract `{contract}` template hash must contain 32 bytes, found {len}")]
-    InvalidTemplateHashLength { contract: String, len: usize },
     #[error("contract `{contract}` template hash mismatch: expected `{expected}`, found `{found}`")]
     TemplateHashMismatch { contract: String, expected: String, found: String },
     #[error("contract `{contract}` entries `{first}` and `{second}` have the same dispatch tag `{tag}`")]
     DispatchTagCollision { contract: String, first: String, second: String, tag: String },
+    #[error("contract `{contract}` metadata references unknown entry `{entry}`")]
+    UnknownEntryReference { contract: String, entry: String },
 }
 
 pub type CodecResult<T> = std::result::Result<T, CodecError>;
@@ -458,17 +433,12 @@ pub fn encode_contract_entry_sig_script(
     entry_name: &str,
     args: &[ArtifactValue],
 ) -> CodecResult<Vec<u8>> {
-    let contract = abi
-        .contracts
-        .iter()
-        .find(|contract| contract.name == contract_name)
-        .ok_or_else(|| CodecError::UnknownContract(contract_name.to_string()))?;
+    let contract = abi.contracts.get(contract_name).ok_or_else(|| CodecError::UnknownContract(contract_name.to_string()))?;
     let entry = contract
         .entries
-        .iter()
-        .find(|entry| entry.name == entry_name)
+        .get(entry_name)
         .ok_or_else(|| CodecError::UnknownEntry { contract: contract_name.to_string(), entry: entry_name.to_string() })?;
-    encode_entry_sig_script(abi, contract, entry, args)
+    encode_entry_sig_script(abi, contract_name, contract, entry_name, entry, args)
 }
 
 pub fn encode_contract_covenant_decl_sig_script(
@@ -478,27 +448,32 @@ pub fn encode_contract_covenant_decl_sig_script(
     is_leader: bool,
     args: &[ArtifactValue],
 ) -> CodecResult<Vec<u8>> {
-    let contract = abi
-        .contracts
-        .iter()
-        .find(|contract| contract.name == contract_name)
-        .ok_or_else(|| CodecError::UnknownContract(contract_name.to_string()))?;
+    let contract = abi.contracts.get(contract_name).ok_or_else(|| CodecError::UnknownContract(contract_name.to_string()))?;
+    let entry_name = if is_leader || contract.delegate_entry_abi.is_none() {
+        contract.cov_decl_to_abi.get(declaration_name)
+    } else {
+        contract.delegate_entry_abi.as_ref()
+    }
+    .ok_or_else(|| CodecError::UnknownEntry { contract: contract_name.to_string(), entry: declaration_name.to_string() })?;
     let entry = contract
-        .covenant_decl_entry(declaration_name, is_leader)
+        .entries
+        .get(entry_name)
         .ok_or_else(|| CodecError::UnknownEntry { contract: contract_name.to_string(), entry: declaration_name.to_string() })?;
-    encode_entry_sig_script(abi, contract, entry, args)
+    encode_entry_sig_script(abi, contract_name, contract, entry_name, entry, args)
 }
 
 pub fn encode_entry_sig_script(
     abi: &SilAbiArtifact,
+    contract_name: &str,
     contract: &SilContractArtifact,
+    entry_name: &str,
     entry: &SilEntryArtifact,
     args: &[ArtifactValue],
 ) -> CodecResult<Vec<u8>> {
     let params = entry_params(entry);
     if params.len() != args.len() {
         return Err(CodecError::WrongArgumentCount {
-            entry: format!("{}::{}", contract.name, entry.name),
+            entry: format!("{contract_name}::{entry_name}"),
             expected: params.len(),
             actual: args.len(),
         });
@@ -578,11 +553,7 @@ fn flatten_state_types(abi: &SilAbiArtifact, ty: &TypeArtifact) -> CodecResult<V
                 if !visiting.insert(name.clone()) {
                     return Err(CodecError::UnsupportedType(format!("cyclic struct {name}")));
                 }
-                let structure = abi
-                    .structs
-                    .iter()
-                    .find(|structure| structure.name == *name)
-                    .ok_or_else(|| CodecError::UnknownStruct(name.clone()))?;
+                let structure = abi.structs.get(name).ok_or_else(|| CodecError::UnknownStruct(name.clone()))?;
                 let mut leaves = Vec::new();
                 for field in &structure.fields {
                     leaves.extend(flatten(abi, &field.ty, visiting)?);
@@ -631,11 +602,7 @@ fn flatten_state_value(
                 if !visiting.insert(struct_name.clone()) {
                     return Err(CodecError::UnsupportedType(format!("cyclic struct {struct_name}")));
                 }
-                let structure = abi
-                    .structs
-                    .iter()
-                    .find(|structure| structure.name == *struct_name)
-                    .ok_or_else(|| CodecError::UnknownStruct(struct_name.clone()))?;
+                let structure = abi.structs.get(struct_name).ok_or_else(|| CodecError::UnknownStruct(struct_name.clone()))?;
                 let fields = object_fields(value)?;
                 assert_no_extra_fields(fields, &structure.fields)?;
                 let mut leaves = Vec::new();
@@ -713,11 +680,7 @@ fn reconstruct_state_value(
 ) -> CodecResult<(ArtifactValue, usize)> {
     match ty {
         TypeArtifact::Struct { name: struct_name } => {
-            let structure = abi
-                .structs
-                .iter()
-                .find(|structure| structure.name == *struct_name)
-                .ok_or_else(|| CodecError::UnknownStruct(struct_name.clone()))?;
+            let structure = abi.structs.get(struct_name).ok_or_else(|| CodecError::UnknownStruct(struct_name.clone()))?;
             let mut fields = BTreeMap::new();
             let mut consumed = 0;
             for field in &structure.fields {
@@ -802,37 +765,39 @@ pub fn encode_hex(bytes: &[u8]) -> String {
     String::from_utf8(out).expect("hex is always valid ascii")
 }
 
-fn verify_compiled_contract(abi: &SilAbiArtifact, contract: &SilContractArtifact) -> std::result::Result<(), SilAbiVerificationError> {
-    let decode = |field, value| {
-        decode_hex(value).map_err(|err| SilAbiVerificationError::InvalidCompiledHex {
-            contract: contract.name.clone(),
-            field,
-            message: err.to_string(),
-        })
-    };
-    let script = decode("script", &contract.compiled.script_hex)?;
-    if script != contract.compiled.bytecode {
-        return Err(SilAbiVerificationError::BytecodeMismatch { contract: contract.name.clone() });
+fn verify_compiled_contract(
+    abi: &SilAbiArtifact,
+    contract_name: &str,
+    contract: &SilContractArtifact,
+) -> std::result::Result<(), SilAbiVerificationError> {
+    let script = &contract.compiled.bytecode;
+
+    for entry_name in contract.cov_decl_to_abi.values().chain(contract.delegate_entry_abi.iter()) {
+        if !contract.entries.contains_key(entry_name) {
+            return Err(SilAbiVerificationError::UnknownEntryReference {
+                contract: contract_name.to_string(),
+                entry: entry_name.clone(),
+            });
+        }
     }
-    let found_hash = decode("template hash", &contract.compiled.template_hash_hex)?;
 
     let mut entries_by_tag = BTreeMap::<DispatchTag, &str>::new();
-    for entry in &contract.entries {
+    for (entry_name, entry) in &contract.entries {
         let tag = entry.dispatch_tag;
-        if let Some(first) = entries_by_tag.insert(tag, &entry.name) {
+        if let Some(first) = entries_by_tag.insert(tag, entry_name) {
             return Err(SilAbiVerificationError::DispatchTagCollision {
-                contract: contract.name.clone(),
+                contract: contract_name.to_string(),
                 first: first.to_string(),
-                second: entry.name.clone(),
+                second: entry_name.clone(),
                 tag: tag.to_hex(),
             });
         }
     }
 
     let span = &contract.compiled.state_span;
-    let Some((prefix, state_script, suffix)) = contract.compiled.script_parts(&script) else {
+    let Some((prefix, state_script, suffix)) = contract.compiled.script_parts(script) else {
         return Err(SilAbiVerificationError::InvalidStateSpan {
-            contract: contract.name.clone(),
+            contract: contract_name.to_string(),
             offset: span.offset,
             len: span.len,
             script_len: script.len(),
@@ -841,34 +806,27 @@ fn verify_compiled_contract(abi: &SilAbiArtifact, contract: &SilContractArtifact
     for field in &contract.runtime_state.fields {
         if !is_supported_runtime_state_type(abi, &field.ty) {
             return Err(SilAbiVerificationError::UnsupportedRuntimeStateType {
-                contract: contract.name.clone(),
+                contract: contract_name.to_string(),
                 field: field.name.clone(),
                 ty: type_name(&field.ty),
             });
         }
     }
     let state_values = decode_runtime_state_script(abi, &contract.runtime_state, state_script).map_err(|err| {
-        SilAbiVerificationError::InvalidRuntimeStateEncoding { contract: contract.name.clone(), message: err.to_string() }
+        SilAbiVerificationError::InvalidRuntimeStateEncoding { contract: contract_name.to_string(), message: err.to_string() }
     })?;
     let canonical_state = encode_runtime_state_script(abi, &contract.runtime_state, &state_values).map_err(|err| {
-        SilAbiVerificationError::InvalidRuntimeStateEncoding { contract: contract.name.clone(), message: err.to_string() }
+        SilAbiVerificationError::InvalidRuntimeStateEncoding { contract: contract_name.to_string(), message: err.to_string() }
     })?;
     if canonical_state != state_script {
-        return Err(SilAbiVerificationError::NonCanonicalRuntimeStateEncoding { contract: contract.name.clone() });
+        return Err(SilAbiVerificationError::NonCanonicalRuntimeStateEncoding { contract: contract_name.to_string() });
     }
-    if found_hash.len() != 32 {
-        return Err(SilAbiVerificationError::InvalidTemplateHashLength { contract: contract.name.clone(), len: found_hash.len() });
-    }
-    if found_hash != contract.compiled.template_hash {
-        return Err(SilAbiVerificationError::TemplateHashEncodingMismatch { contract: contract.name.clone() });
-    }
-
     let expected_hash = template_hash(prefix, suffix);
     if contract.compiled.template_hash != expected_hash {
         return Err(SilAbiVerificationError::TemplateHashMismatch {
-            contract: contract.name.clone(),
+            contract: contract_name.to_string(),
             expected: encode_hex(&expected_hash),
-            found: contract.compiled.template_hash_hex.clone(),
+            found: encode_hex(&contract.compiled.template_hash),
         });
     }
     Ok(())
@@ -884,8 +842,7 @@ fn is_supported_runtime_state_type(abi: &SilAbiArtifact, ty: &TypeArtifact) -> b
                 }
                 let supported = abi
                     .structs
-                    .iter()
-                    .find(|structure| structure.name == *name)
+                    .get(name)
                     .is_some_and(|structure| structure.fields.iter().all(|field| is_supported(abi, &field.ty, visiting)));
                 visiting.remove(name);
                 supported
@@ -903,16 +860,15 @@ fn entry_params(entry: &SilEntryArtifact) -> Vec<(&str, &TypeArtifact)> {
 }
 
 struct TypeContext<'a> {
-    structs: BTreeMap<&'a str, &'a StructArtifact>,
+    structs: &'a BTreeMap<String, StructArtifact>,
     runtime_state: StructArtifact,
 }
 
 impl<'a> TypeContext<'a> {
     fn new(abi: &'a SilAbiArtifact, contract: &'a SilContractArtifact) -> Self {
         Self {
-            structs: abi.structs.iter().map(|structure| (structure.name.as_str(), structure)).collect(),
+            structs: &abi.structs,
             runtime_state: StructArtifact {
-                name: "State".to_string(),
                 fields: contract
                     .runtime_state
                     .fields
@@ -927,7 +883,7 @@ impl<'a> TypeContext<'a> {
         if name == "State" {
             return Ok(&self.runtime_state);
         }
-        self.structs.get(name).copied().ok_or_else(|| CodecError::UnknownStruct(name.to_string()))
+        self.structs.get(name).ok_or_else(|| CodecError::UnknownStruct(name.to_string()))
     }
 }
 
@@ -1384,37 +1340,30 @@ mod tests {
     fn verifies_compiled_contract_against_its_script() {
         let mut abi = tiny_sil_abi();
         let prefix = [0xaa];
-        abi.contracts[0].runtime_state.fields = vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
+        abi.contracts.get_mut("Foo").unwrap().runtime_state.fields =
+            vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
         let state = encode_runtime_state_script(
             &abi,
-            &abi.contracts[0].runtime_state,
+            &abi.contracts["Foo"].runtime_state,
             &BTreeMap::from([("value".to_string(), ArtifactValue::Byte(2))]),
         )
         .expect("state encodes");
         let suffix = [0xbb, 0xcc];
-        let contract = &mut abi.contracts[0];
-        contract.compiled.set_bytecode([prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
-        contract.compiled.set_template_hash(template_hash(&prefix, &suffix));
+        let contract = abi.contracts.get_mut("Foo").unwrap();
+        contract.compiled.bytecode = [prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat();
+        contract.compiled.template_hash = template_hash(&prefix, &suffix);
         contract.compiled.state_span = StateSpanArtifact { offset: prefix.len(), len: state.len() };
 
         abi.verify().expect("compiled template matches its contract script");
 
-        abi.contracts[0].compiled.bytecode.push(0xff);
-        assert_eq!(abi.verify(), Err(SilAbiVerificationError::BytecodeMismatch { contract: "Foo".to_string() }));
-        abi.contracts[0].compiled.bytecode.pop();
-
-        abi.contracts[0].compiled.template_hash[0] ^= 0xff;
-        assert_eq!(abi.verify(), Err(SilAbiVerificationError::TemplateHashEncodingMismatch { contract: "Foo".to_string() }));
-        abi.contracts[0].compiled.template_hash[0] ^= 0xff;
-
-        abi.contracts[0].compiled.set_template_hash([0; 32]);
+        abi.contracts.get_mut("Foo").unwrap().compiled.template_hash = [0; 32];
         assert!(matches!(
             abi.verify(),
             Err(SilAbiVerificationError::TemplateHashMismatch { ref contract, .. }) if contract == "Foo"
         ));
 
-        abi.contracts[0].compiled.set_template_hash(template_hash(&prefix, &suffix));
-        abi.contracts[0].compiled.set_bytecode([&[0xff], state.as_slice(), suffix.as_slice()].concat());
+        abi.contracts.get_mut("Foo").unwrap().compiled.template_hash = template_hash(&prefix, &suffix);
+        abi.contracts.get_mut("Foo").unwrap().compiled.bytecode = [&[0xff], state.as_slice(), suffix.as_slice()].concat();
         assert!(matches!(
             abi.verify(),
             Err(SilAbiVerificationError::TemplateHashMismatch { ref contract, .. }) if contract == "Foo"
@@ -1433,39 +1382,52 @@ mod tests {
     #[test]
     fn rejects_colliding_dispatch_tags() {
         let mut abi = tiny_sil_abi();
-        abi.contracts[0].entries[1].dispatch_tag = abi.contracts[0].entries[0].dispatch_tag;
+        let step_tag = abi.contracts["Foo"].entries["step"].dispatch_tag;
+        abi.contracts.get_mut("Foo").unwrap().entries.get_mut("other").unwrap().dispatch_tag = step_tag;
         assert!(matches!(
             abi.verify(),
             Err(SilAbiVerificationError::DispatchTagCollision { ref contract, ref first, ref second, .. })
-                if contract == "Foo" && first == "step" && second == "other"
+                if contract == "Foo" && first == "other" && second == "step"
         ));
+    }
+
+    #[test]
+    fn rejects_unknown_entry_metadata_references() {
+        let mut abi = tiny_sil_abi();
+        abi.contracts.get_mut("Foo").unwrap().cov_decl_to_abi.insert("spend".to_string(), "missing".to_string());
+
+        assert_eq!(
+            abi.verify(),
+            Err(SilAbiVerificationError::UnknownEntryReference { contract: "Foo".to_string(), entry: "missing".to_string() })
+        );
     }
 
     #[test]
     fn rejects_state_spans_that_do_not_match_the_runtime_state() {
         let mut abi = tiny_sil_abi();
-        abi.contracts[0].runtime_state.fields = vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
+        abi.contracts.get_mut("Foo").unwrap().runtime_state.fields =
+            vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
         let prefix = [0xaa];
         let state = encode_runtime_state_script(
             &abi,
-            &abi.contracts[0].runtime_state,
+            &abi.contracts["Foo"].runtime_state,
             &BTreeMap::from([("value".to_string(), ArtifactValue::Byte(2))]),
         )
         .expect("state encodes");
         let suffix = [0xbb];
-        let contract = &mut abi.contracts[0];
-        contract.compiled.set_bytecode([prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
+        let contract = abi.contracts.get_mut("Foo").unwrap();
+        contract.compiled.bytecode = [prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat();
 
         contract.compiled.state_span = StateSpanArtifact { offset: 0, len: prefix.len() + state.len() };
-        contract.compiled.set_template_hash(template_hash(&[], &suffix));
+        contract.compiled.template_hash = template_hash(&[], &suffix);
         assert!(matches!(
             abi.verify(),
             Err(SilAbiVerificationError::InvalidRuntimeStateEncoding { ref contract, .. }) if contract == "Foo"
         ));
 
-        let contract = &mut abi.contracts[0];
+        let contract = abi.contracts.get_mut("Foo").unwrap();
         contract.compiled.state_span = StateSpanArtifact { offset: prefix.len(), len: state.len() - 1 };
-        contract.compiled.set_template_hash(template_hash(&prefix, &[state[state.len() - 1], suffix[0]]));
+        contract.compiled.template_hash = template_hash(&prefix, &[state[state.len() - 1], suffix[0]]);
         assert!(matches!(
             abi.verify(),
             Err(SilAbiVerificationError::InvalidRuntimeStateEncoding { ref contract, .. }) if contract == "Foo"
@@ -1475,17 +1437,17 @@ mod tests {
     #[test]
     fn rejects_noncanonical_and_variable_runtime_state_encodings() {
         let mut abi = tiny_sil_abi();
-        let contract = &mut abi.contracts[0];
+        let contract = abi.contracts.get_mut("Foo").unwrap();
         contract.runtime_state.fields = vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
         let prefix = [0xaa];
         let state = [OP_PUSH_DATA_1, 1, 2];
         let suffix = [0xbb];
-        contract.compiled.set_bytecode([prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
-        contract.compiled.set_template_hash(template_hash(&prefix, &suffix));
+        contract.compiled.bytecode = [prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat();
+        contract.compiled.template_hash = template_hash(&prefix, &suffix);
         contract.compiled.state_span = StateSpanArtifact { offset: prefix.len(), len: state.len() };
         assert_eq!(abi.verify(), Err(SilAbiVerificationError::NonCanonicalRuntimeStateEncoding { contract: "Foo".to_string() }));
 
-        abi.contracts[0].runtime_state.fields[0].ty = TypeArtifact::Bytes;
+        abi.contracts.get_mut("Foo").unwrap().runtime_state.fields[0].ty = TypeArtifact::Bytes;
         assert_eq!(
             abi.verify(),
             Err(SilAbiVerificationError::UnsupportedRuntimeStateType {
@@ -1499,29 +1461,31 @@ mod tests {
     #[test]
     fn validates_struct_runtime_state_types_recursively() {
         let mut abi = tiny_sil_abi();
-        abi.structs = vec![
-            StructArtifact {
-                name: "Inner".to_string(),
-                fields: vec![FieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }],
-            },
-            StructArtifact {
-                name: "Outer".to_string(),
-                fields: vec![
-                    FieldArtifact { name: "inner".to_string(), ty: TypeArtifact::Struct { name: "Inner".to_string() } },
-                    FieldArtifact {
-                        name: "values".to_string(),
-                        ty: TypeArtifact::FixedArray { item: Box::new(TypeArtifact::Int), len: 2 },
-                    },
-                ],
-            },
-        ];
+        abi.structs = BTreeMap::from([
+            (
+                "Inner".to_string(),
+                StructArtifact { fields: vec![FieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }] },
+            ),
+            (
+                "Outer".to_string(),
+                StructArtifact {
+                    fields: vec![
+                        FieldArtifact { name: "inner".to_string(), ty: TypeArtifact::Struct { name: "Inner".to_string() } },
+                        FieldArtifact {
+                            name: "values".to_string(),
+                            ty: TypeArtifact::FixedArray { item: Box::new(TypeArtifact::Int), len: 2 },
+                        },
+                    ],
+                },
+            ),
+        ]);
 
         assert!(is_supported_runtime_state_type(&abi, &TypeArtifact::Struct { name: "Outer".to_string() }));
 
-        abi.structs[0].fields[0].ty = TypeArtifact::Bytes;
+        abi.structs.get_mut("Inner").unwrap().fields[0].ty = TypeArtifact::Bytes;
         assert!(!is_supported_runtime_state_type(&abi, &TypeArtifact::Struct { name: "Outer".to_string() }));
 
-        abi.structs[0].fields[0].ty = TypeArtifact::Struct { name: "Outer".to_string() };
+        abi.structs.get_mut("Inner").unwrap().fields[0].ty = TypeArtifact::Struct { name: "Outer".to_string() };
         assert!(!is_supported_runtime_state_type(&abi, &TypeArtifact::Struct { name: "Outer".to_string() }));
     }
 
@@ -1545,7 +1509,7 @@ mod tests {
         assert_eq!(serde_json::to_value(TypeArtifact::Temporal).unwrap(), serde_json::json!({ "kind": "temporal" }));
 
         let mut artifact = tiny_sil_abi();
-        artifact.contracts[0].entries[1].params =
+        artifact.contracts.get_mut("Foo").unwrap().entries.get_mut("other").unwrap().params =
             vec![param("at", TypeArtifact::Temporal), param("history", TypeArtifact::dynamic_array(TypeArtifact::Temporal))];
         let history = ArtifactValue::Array(vec![ArtifactValue::Int(1), ArtifactValue::Int(-2)]);
         let sigscript = encode_contract_entry_sig_script(&artifact, "Foo", "other", &[ArtifactValue::Int(-5), history.clone()])
@@ -1585,13 +1549,15 @@ mod tests {
     #[test]
     fn encodes_struct_payload_without_push_framing() {
         let mut abi = tiny_sil_abi();
-        abi.structs.push(StructArtifact {
-            name: "Memory".to_string(),
-            fields: vec![
-                FieldArtifact { name: "hunger".to_string(), ty: TypeArtifact::Int },
-                FieldArtifact { name: "tag".to_string(), ty: TypeArtifact::FixedBytes { len: 2 } },
-            ],
-        });
+        abi.structs.insert(
+            "Memory".to_string(),
+            StructArtifact {
+                fields: vec![
+                    FieldArtifact { name: "hunger".to_string(), ty: TypeArtifact::Int },
+                    FieldArtifact { name: "tag".to_string(), ty: TypeArtifact::FixedBytes { len: 2 } },
+                ],
+            },
+        );
         let values = BTreeMap::from([
             ("hunger".to_string(), ArtifactValue::Int(17)),
             ("tag".to_string(), ArtifactValue::Bytes(vec![0xaa, 0xbb])),
@@ -1609,36 +1575,31 @@ mod tests {
         {
           "schema_version": 1,
           "compiler_version": "0.1.0",
-          "structs": [
-            {
-              "name": "FooState",
+          "structs": {
+            "FooState": {
               "fields": [{ "name": "count", "type": { "kind": "int" } }]
             }
-          ],
-          "contracts": [
-            {
-              "name": "Foo",
+          },
+          "contracts": {
+            "Foo": {
               "source_path": "sil/Foo.sil",
               "runtime_state": {
                 "source": "FooState",
                 "fields": [{ "name": "count", "type": { "kind": "int" } }]
               },
-              "entries": [
-                {
-                  "name": "step",
+              "entries": {
+                "step": {
                   "dispatch_tag": "2c49ed65",
                   "params": [{ "name": "amount", "type": { "kind": "int" } }]
                 }
-              ],
+              },
               "compiled": {
                 "bytecode": [0],
-                "script_hex": "00",
                 "template_hash": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                "template_hash_hex": "0000000000000000000000000000000000000000000000000000000000000000",
                 "state_span": { "offset": 0, "len": 1 }
               }
             }
-          ]
+          }
         }
         "#;
 
@@ -1654,10 +1615,10 @@ mod tests {
             Some("amount")
         );
         let serialized = serde_json::to_value(&abi).expect("Sil ABI artifact serializes");
-        assert_eq!(serialized["contracts"][0]["entries"][0]["dispatch_tag"], "2c49ed65");
-        assert_eq!(serialized["contracts"][0]["compiled"]["bytecode"], serde_json::json!([0]));
+        assert_eq!(serialized["contracts"]["Foo"]["entries"]["step"]["dispatch_tag"], "2c49ed65");
+        assert_eq!(serialized["contracts"]["Foo"]["compiled"]["bytecode"], serde_json::json!([0]));
         assert_eq!(
-            serialized["contracts"][0]["compiled"]["template_hash"],
+            serialized["contracts"]["Foo"]["compiled"]["template_hash"],
             serde_json::to_value([0u8; 32]).expect("template hash serializes")
         );
     }
@@ -1711,26 +1672,30 @@ mod tests {
     #[test]
     fn round_trips_nested_struct_and_struct_array_runtime_state() {
         let mut abi = tiny_sil_abi();
-        abi.structs = vec![
-            StructArtifact {
-                name: "Inner".to_string(),
-                fields: vec![FieldArtifact { name: "marker".to_string(), ty: TypeArtifact::Byte }],
-            },
-            StructArtifact {
-                name: "Outer".to_string(),
-                fields: vec![
-                    FieldArtifact { name: "inner".to_string(), ty: TypeArtifact::Struct { name: "Inner".to_string() } },
-                    FieldArtifact { name: "active".to_string(), ty: TypeArtifact::Bool },
-                ],
-            },
-            StructArtifact {
-                name: "Pair".to_string(),
-                fields: vec![
-                    FieldArtifact { name: "amount".to_string(), ty: TypeArtifact::Int },
-                    FieldArtifact { name: "code".to_string(), ty: TypeArtifact::FixedBytes { len: 2 } },
-                ],
-            },
-        ];
+        abi.structs = BTreeMap::from([
+            (
+                "Inner".to_string(),
+                StructArtifact { fields: vec![FieldArtifact { name: "marker".to_string(), ty: TypeArtifact::Byte }] },
+            ),
+            (
+                "Outer".to_string(),
+                StructArtifact {
+                    fields: vec![
+                        FieldArtifact { name: "inner".to_string(), ty: TypeArtifact::Struct { name: "Inner".to_string() } },
+                        FieldArtifact { name: "active".to_string(), ty: TypeArtifact::Bool },
+                    ],
+                },
+            ),
+            (
+                "Pair".to_string(),
+                StructArtifact {
+                    fields: vec![
+                        FieldArtifact { name: "amount".to_string(), ty: TypeArtifact::Int },
+                        FieldArtifact { name: "code".to_string(), ty: TypeArtifact::FixedBytes { len: 2 } },
+                    ],
+                },
+            ),
+        ]);
         let runtime_state = RuntimeStateArtifact {
             source: "FooState".to_string(),
             fields: vec![
@@ -1775,40 +1740,41 @@ mod tests {
 
     fn tiny_sil_abi() -> SilAbiArtifact {
         SilAbiArtifact {
-            schema_version: 1,
+            schema_version: SIL_ABI_SCHEMA_VERSION,
             compiler_version: "0.1.0".to_string(),
-            structs: Vec::new(),
-            contracts: vec![SilContractArtifact {
-                name: "Foo".to_string(),
-                source_path: "sil/Foo.sil".to_string(),
-                runtime_state: RuntimeStateArtifact { source: "FooState".to_string(), fields: Vec::new() },
-                entries: vec![
-                    SilEntryArtifact {
-                        name: "step".to_string(),
-                        dispatch_tag: DispatchTag::from([0x2c, 0x49, 0xed, 0x65]),
-                        params: vec![
-                            param("n", TypeArtifact::Int),
-                            param("hash", TypeArtifact::FixedBytes { len: 4 }),
-                            param("flag", TypeArtifact::Bool),
-                            param("b", TypeArtifact::Byte),
-                        ],
+            structs: BTreeMap::new(),
+            contracts: BTreeMap::from([(
+                "Foo".to_string(),
+                SilContractArtifact {
+                    source_path: "sil/Foo.sil".to_string(),
+                    runtime_state: RuntimeStateArtifact { source: "FooState".to_string(), fields: Vec::new() },
+                    entries: BTreeMap::from([
+                        (
+                            "step".to_string(),
+                            SilEntryArtifact {
+                                dispatch_tag: DispatchTag::from([0x2c, 0x49, 0xed, 0x65]),
+                                params: vec![
+                                    param("n", TypeArtifact::Int),
+                                    param("hash", TypeArtifact::FixedBytes { len: 4 }),
+                                    param("flag", TypeArtifact::Bool),
+                                    param("b", TypeArtifact::Byte),
+                                ],
+                            },
+                        ),
+                        (
+                            "other".to_string(),
+                            SilEntryArtifact { dispatch_tag: DispatchTag::from([0xde, 0xad, 0xbe, 0xef]), params: Vec::new() },
+                        ),
+                    ]),
+                    cov_decl_to_abi: BTreeMap::new(),
+                    delegate_entry_abi: None,
+                    compiled: CompiledContractArtifact {
+                        bytecode: Vec::new(),
+                        template_hash: [0; 32],
+                        state_span: StateSpanArtifact { offset: 0, len: 0 },
                     },
-                    SilEntryArtifact {
-                        name: "other".to_string(),
-                        dispatch_tag: DispatchTag::from([0xde, 0xad, 0xbe, 0xef]),
-                        params: Vec::new(),
-                    },
-                ],
-                cov_decl_to_abi: BTreeMap::new(),
-                delegate_entry_abi: None,
-                compiled: CompiledContractArtifact {
-                    bytecode: Vec::new(),
-                    script_hex: String::new(),
-                    template_hash: [0; 32],
-                    template_hash_hex: String::new(),
-                    state_span: StateSpanArtifact { offset: 0, len: 0 },
                 },
-            }],
+            )]),
         }
     }
 

--- a/silverscript-abi/src/lib.rs
+++ b/silverscript-abi/src/lib.rs
@@ -25,6 +25,10 @@ use kaspa_txscript::{
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
 
+mod json;
+
+pub use json::to_pretty_json;
+
 pub const SIL_ABI_SCHEMA_VERSION: u32 = 1;
 const TEMPLATE_PART_LENGTH_BYTES: usize = 8;
 
@@ -272,7 +276,10 @@ pub struct SilEntryArtifact {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CompiledContractArtifact {
+    /// Compiled contract bytes.
+    #[serde(with = "serde_bytes")]
     pub bytecode: Vec<u8>,
+    #[serde(with = "serde_bytes")]
     pub template_hash: [u8; 32],
     pub state_span: StateSpanArtifact,
 }
@@ -1636,6 +1643,23 @@ mod tests {
             serialized["contracts"]["Foo"]["compiled"]["template_hash"],
             serde_json::to_value([0u8; 32]).expect("template hash serializes")
         );
+    }
+
+    #[test]
+    fn pretty_json_wraps_byte_arrays_at_fixed_boundaries() {
+        let mut abi = tiny_sil_abi();
+        abi.contracts[0].compiled.bytecode = (0..=64).collect();
+
+        let json = to_pretty_json(&abi).expect("Sil ABI artifact serializes");
+        let lines = json.lines().collect::<Vec<_>>();
+        let bytecode_line = lines.iter().position(|line| line.trim() == r#""bytecode": ["#).expect("bytecode field exists");
+        assert_eq!(lines[bytecode_line + 1].split(", ").count(), 64);
+        assert_eq!(lines[bytecode_line + 2].trim(), "64");
+        assert_eq!(lines[bytecode_line + 3].trim(), "],");
+        assert!(lines.iter().any(|line| line.trim_start().starts_with(r#""template_hash": [0, 0, 0"#)));
+
+        let decoded: SilAbiArtifact = serde_json::from_str(&json).expect("Sil ABI artifact deserializes");
+        assert_eq!(decoded.contracts[0].compiled.bytecode, (0..=64).collect::<Vec<_>>());
     }
 
     #[test]

--- a/silverscript-abi/src/lib.rs
+++ b/silverscript-abi/src/lib.rs
@@ -502,7 +502,7 @@ pub fn encode_runtime_state_script(
     let mut builder = script_builder();
     for field in &runtime_state.fields {
         let value = values.get(&field.name).ok_or_else(|| CodecError::MissingField(field.name.clone()))?;
-        for (leaf_ty, leaf_value) in flatten_state_value(abi, &field.name, &field.ty, value)? {
+        for (leaf_ty, leaf_value) in flatten_sruct_value(abi, &field.name, &field.ty, value)? {
             let payload = encode_state_payload(&field.name, &leaf_ty, &leaf_value)?;
             builder.add_data_with_push_opcode(&payload)?;
         }
@@ -517,7 +517,7 @@ pub fn decode_runtime_state_script(
 ) -> CodecResult<BTreeMap<String, ArtifactValue>> {
     let pushes = parse_pushes(state_script)?;
     let field_leaf_types =
-        runtime_state.fields.iter().map(|field| flatten_state_types(abi, &field.ty)).collect::<CodecResult<Vec<_>>>()?;
+        runtime_state.fields.iter().map(|field| flatten_struct_types(abi, &field.ty)).collect::<CodecResult<Vec<_>>>()?;
     let expected_pushes = field_leaf_types.iter().map(Vec::len).sum::<usize>();
     if pushes.len() < expected_pushes {
         return Err(CodecError::InvalidPush(format!("expected {expected_pushes} state pushes, got {}", pushes.len())));
@@ -537,7 +537,7 @@ pub fn decode_runtime_state_script(
                 decode_state_payload(&field.name, leaf_ty, &payload)
             })
             .collect::<CodecResult<Vec<_>>>()?;
-        let (value, consumed) = reconstruct_state_value(abi, &field.name, &field.ty, &leaf_values)?;
+        let (value, consumed) = reconstruct_struct_value(abi, &field.name, &field.ty, &leaf_values)?;
         if consumed != leaf_values.len() {
             return Err(CodecError::UnsupportedType(format!("invalid flattened state layout for {}", field.name)));
         }
@@ -546,7 +546,7 @@ pub fn decode_runtime_state_script(
     Ok(values)
 }
 
-fn flatten_state_types(abi: &SilAbiArtifact, ty: &TypeArtifact) -> CodecResult<Vec<TypeArtifact>> {
+fn flatten_struct_types(abi: &SilAbiArtifact, ty: &TypeArtifact) -> CodecResult<Vec<TypeArtifact>> {
     fn flatten(abi: &SilAbiArtifact, ty: &TypeArtifact, visiting: &mut BTreeSet<String>) -> CodecResult<Vec<TypeArtifact>> {
         match ty {
             TypeArtifact::Struct { name } => {
@@ -563,18 +563,18 @@ fn flatten_state_types(abi: &SilAbiArtifact, ty: &TypeArtifact) -> CodecResult<V
             }
             TypeArtifact::FixedArray { item, len } => {
                 let item_leaves = flatten(abi, item, visiting)?;
-                if item_leaves.as_slice() == std::slice::from_ref(item.as_ref()) {
+                if is_single_state_leaf(item, &item_leaves) {
                     Ok(vec![ty.clone()])
                 } else {
-                    Ok(item_leaves.into_iter().map(|item| TypeArtifact::FixedArray { item: Box::new(item), len: *len }).collect())
+                    Ok(item_leaves.into_iter().map(|item| array_type(item, Some(*len))).collect())
                 }
             }
             TypeArtifact::DynamicArray { item } => {
                 let item_leaves = flatten(abi, item, visiting)?;
-                if item_leaves.as_slice() == std::slice::from_ref(item.as_ref()) {
+                if is_single_state_leaf(item, &item_leaves) {
                     Ok(vec![ty.clone()])
                 } else {
-                    Ok(item_leaves.into_iter().map(|item| TypeArtifact::DynamicArray { item: Box::new(item) }).collect())
+                    Ok(item_leaves.into_iter().map(|item| array_type(item, None)).collect())
                 }
             }
             _ => Ok(vec![ty.clone()]),
@@ -584,7 +584,7 @@ fn flatten_state_types(abi: &SilAbiArtifact, ty: &TypeArtifact) -> CodecResult<V
     flatten(abi, ty, &mut BTreeSet::new())
 }
 
-fn flatten_state_value(
+fn flatten_sruct_value(
     abi: &SilAbiArtifact,
     name: &str,
     ty: &TypeArtifact,
@@ -613,66 +613,81 @@ fn flatten_state_value(
                 visiting.remove(struct_name);
                 Ok(leaves)
             }
-            TypeArtifact::FixedArray { item, len } => flatten_state_array(abi, name, item, Some(*len), value, visiting),
-            TypeArtifact::DynamicArray { item } => flatten_state_array(abi, name, item, None, value, visiting),
+            TypeArtifact::FixedArray { item, len } => flatten_struct_array(abi, name, item, Some(*len), value, visiting),
+            TypeArtifact::DynamicArray { item } => flatten_struct_array(abi, name, item, None, value, visiting),
             _ => Ok(vec![(ty.clone(), value.clone())]),
         }
     }
 
-    fn flatten_state_array(
+    fn flatten_struct_array(
         abi: &SilAbiArtifact,
         name: &str,
         item: &TypeArtifact,
-        expected_len: Option<usize>,
+        fixed_len: Option<usize>,
         value: &ArtifactValue,
         visiting: &mut BTreeSet<String>,
     ) -> CodecResult<Vec<(TypeArtifact, ArtifactValue)>> {
-        let item_leaf_types = flatten_state_types(abi, item)?;
-
-        // A single unchanged leaf means the item type does not contain a struct.
-        if item_leaf_types.as_slice() == std::slice::from_ref(item) {
-            let ty = match expected_len {
-                Some(len) => TypeArtifact::FixedArray { item: Box::new(item.clone()), len },
-                None => TypeArtifact::DynamicArray { item: Box::new(item.clone()) },
-            };
-            return Ok(vec![(ty, value.clone())]);
+        let item_leaf_types = flatten_struct_types(abi, item)?;
+        if is_single_state_leaf(item, &item_leaf_types) {
+            return Ok(vec![(array_type(item.clone(), fixed_len), value.clone())]);
         }
 
         let values = expect_array(value)?;
-        if let Some(expected) = expected_len {
+        if let Some(expected) = fixed_len {
             require_len(name, expected, values.len())?;
         }
-        let mut grouped_values = vec![Vec::with_capacity(values.len()); item_leaf_types.len()];
-        for value in values {
-            let item_leaves = flatten(abi, name, item, value, visiting)?;
-            if item_leaves.len() != item_leaf_types.len() {
-                return Err(CodecError::UnsupportedType(format!("invalid flattened state layout for {name}")));
-            }
-            for ((expected_ty, values), (actual_ty, value)) in item_leaf_types.iter().zip(&mut grouped_values).zip(item_leaves) {
-                if expected_ty != &actual_ty {
-                    return Err(CodecError::UnsupportedType(format!("invalid flattened state layout for {name}")));
-                }
-                values.push(value);
-            }
-        }
+        let grouped_values = group_flattened_array_items(abi, name, item, values, &item_leaf_types, visiting)?;
 
         Ok(item_leaf_types
             .into_iter()
             .zip(grouped_values)
-            .map(|(item, values)| {
-                let ty = match expected_len {
-                    Some(len) => TypeArtifact::FixedArray { item: Box::new(item), len },
-                    None => TypeArtifact::DynamicArray { item: Box::new(item) },
-                };
-                (ty, ArtifactValue::Array(values))
-            })
+            .map(|(item, values)| (array_type(item, fixed_len), ArtifactValue::Array(values)))
             .collect())
+    }
+
+    fn group_flattened_array_items(
+        abi: &SilAbiArtifact,
+        name: &str,
+        item: &TypeArtifact,
+        values: &[ArtifactValue],
+        item_leaf_types: &[TypeArtifact],
+        visiting: &mut BTreeSet<String>,
+    ) -> CodecResult<Vec<Vec<ArtifactValue>>> {
+        let mut grouped_values = vec![Vec::with_capacity(values.len()); item_leaf_types.len()];
+        for value in values {
+            let item_leaves = flatten(abi, name, item, value, visiting)?;
+            if item_leaves.len() != item_leaf_types.len() {
+                return Err(invalid_flattened_state_layout(name));
+            }
+            for ((expected_ty, group), (actual_ty, value)) in item_leaf_types.iter().zip(&mut grouped_values).zip(item_leaves) {
+                if expected_ty != &actual_ty {
+                    return Err(invalid_flattened_state_layout(name));
+                }
+                group.push(value);
+            }
+        }
+        Ok(grouped_values)
     }
 
     flatten(abi, name, ty, value, &mut BTreeSet::new())
 }
 
-fn reconstruct_state_value(
+fn is_single_state_leaf(item: &TypeArtifact, item_leaf_types: &[TypeArtifact]) -> bool {
+    item_leaf_types == std::slice::from_ref(item)
+}
+
+fn array_type(item: TypeArtifact, fixed_len: Option<usize>) -> TypeArtifact {
+    match fixed_len {
+        Some(len) => TypeArtifact::FixedArray { item: Box::new(item), len },
+        None => TypeArtifact::DynamicArray { item: Box::new(item) },
+    }
+}
+
+fn invalid_flattened_state_layout(name: &str) -> CodecError {
+    CodecError::UnsupportedType(format!("invalid flattened state layout for {name}"))
+}
+
+fn reconstruct_struct_value(
     abi: &SilAbiArtifact,
     name: &str,
     ty: &TypeArtifact,
@@ -684,14 +699,14 @@ fn reconstruct_state_value(
             let mut fields = BTreeMap::new();
             let mut consumed = 0;
             for field in &structure.fields {
-                let (value, field_consumed) = reconstruct_state_value(abi, &field.name, &field.ty, &leaves[consumed..])?;
+                let (value, field_consumed) = reconstruct_struct_value(abi, &field.name, &field.ty, &leaves[consumed..])?;
                 consumed += field_consumed;
                 fields.insert(field.name.clone(), value);
             }
             Ok((ArtifactValue::Object(fields), consumed))
         }
-        TypeArtifact::FixedArray { item, len } => reconstruct_state_array(abi, name, item, Some(*len), leaves),
-        TypeArtifact::DynamicArray { item } => reconstruct_state_array(abi, name, item, None, leaves),
+        TypeArtifact::FixedArray { item, len } => reconstruct_struct_array(abi, name, item, Some(*len), leaves),
+        TypeArtifact::DynamicArray { item } => reconstruct_struct_array(abi, name, item, None, leaves),
         _ => leaves
             .first()
             .cloned()
@@ -700,14 +715,14 @@ fn reconstruct_state_value(
     }
 }
 
-fn reconstruct_state_array(
+fn reconstruct_struct_array(
     abi: &SilAbiArtifact,
     name: &str,
     item: &TypeArtifact,
     expected_len: Option<usize>,
     leaves: &[ArtifactValue],
 ) -> CodecResult<(ArtifactValue, usize)> {
-    let item_leaf_types = flatten_state_types(abi, item)?;
+    let item_leaf_types = flatten_struct_types(abi, item)?;
     if item_leaf_types.as_slice() == std::slice::from_ref(item) {
         return leaves
             .first()
@@ -734,7 +749,7 @@ fn reconstruct_state_array(
     let mut values = Vec::with_capacity(actual_len);
     for index in 0..actual_len {
         let item_leaves = arrays.iter().map(|array| array[index].clone()).collect::<Vec<_>>();
-        let (value, consumed) = reconstruct_state_value(abi, name, item, &item_leaves)?;
+        let (value, consumed) = reconstruct_struct_value(abi, name, item, &item_leaves)?;
         if consumed != item_leaves.len() {
             return Err(CodecError::UnsupportedType(format!("invalid flattened state layout for {name}")));
         }

--- a/silverscript-abi/src/lib.rs
+++ b/silverscript-abi/src/lib.rs
@@ -10,7 +10,7 @@
 //! outer `argent-artifact` crate. Keep that boundary sharp so this ABI can be
 //! replaced by a native Silverscript portable artifact later.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use blake3::Hasher as Blake3Hasher;
 use kaspa_txscript::{
@@ -210,7 +210,7 @@ impl SilAbiArtifact {
     pub fn verify(&self) -> std::result::Result<(), SilAbiVerificationError> {
         self.check_schema_version()?;
         for contract in &self.contracts {
-            verify_compiled_contract(contract)?;
+            verify_compiled_contract(self, contract)?;
         }
         Ok(())
     }
@@ -574,7 +574,7 @@ pub fn encode_hex(bytes: &[u8]) -> String {
     String::from_utf8(out).expect("hex is always valid ascii")
 }
 
-fn verify_compiled_contract(contract: &SilContractArtifact) -> std::result::Result<(), SilAbiVerificationError> {
+fn verify_compiled_contract(abi: &SilAbiArtifact, contract: &SilContractArtifact) -> std::result::Result<(), SilAbiVerificationError> {
     let decode = |field, value| {
         decode_hex(value).map_err(|err| SilAbiVerificationError::InvalidCompiledHex {
             contract: contract.name.clone(),
@@ -611,7 +611,7 @@ fn verify_compiled_contract(contract: &SilContractArtifact) -> std::result::Resu
         });
     };
     for field in &contract.runtime_state.fields {
-        if fixed_payload_len(&field.ty).is_none() {
+        if !is_supported_runtime_state_type(abi, &field.ty) {
             return Err(SilAbiVerificationError::UnsupportedRuntimeStateType {
                 contract: contract.name.clone(),
                 field: field.name.clone(),
@@ -644,6 +644,30 @@ fn verify_compiled_contract(contract: &SilContractArtifact) -> std::result::Resu
         });
     }
     Ok(())
+}
+
+fn is_supported_runtime_state_type(abi: &SilAbiArtifact, ty: &TypeArtifact) -> bool {
+    fn is_supported(abi: &SilAbiArtifact, ty: &TypeArtifact, visiting: &mut BTreeSet<String>) -> bool {
+        match ty {
+            TypeArtifact::Struct { name } => {
+                if !visiting.insert(name.clone()) {
+                    // We don't support cyclic structs.
+                    return false;
+                }
+                let supported = abi
+                    .structs
+                    .iter()
+                    .find(|structure| structure.name == *name)
+                    .is_some_and(|structure| structure.fields.iter().all(|field| is_supported(abi, &field.ty, visiting)));
+                visiting.remove(name);
+                supported
+            }
+            TypeArtifact::FixedArray { item, .. } => is_supported(abi, item, visiting),
+            _ => fixed_payload_len(ty).is_some(),
+        }
+    }
+
+    is_supported(abi, ty, &mut BTreeSet::new())
 }
 
 fn entry_params(entry: &SilEntryArtifact) -> Vec<(&str, &TypeArtifact)> {
@@ -1236,6 +1260,35 @@ mod tests {
                 ty: "bytes".to_string(),
             })
         );
+    }
+
+    #[test]
+    fn validates_struct_runtime_state_types_recursively() {
+        let mut abi = tiny_sil_abi();
+        abi.structs = vec![
+            StructArtifact {
+                name: "Inner".to_string(),
+                fields: vec![FieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }],
+            },
+            StructArtifact {
+                name: "Outer".to_string(),
+                fields: vec![
+                    FieldArtifact { name: "inner".to_string(), ty: TypeArtifact::Struct { name: "Inner".to_string() } },
+                    FieldArtifact {
+                        name: "values".to_string(),
+                        ty: TypeArtifact::FixedArray { item: Box::new(TypeArtifact::Int), len: 2 },
+                    },
+                ],
+            },
+        ];
+
+        assert!(is_supported_runtime_state_type(&abi, &TypeArtifact::Struct { name: "Outer".to_string() }));
+
+        abi.structs[0].fields[0].ty = TypeArtifact::Bytes;
+        assert!(!is_supported_runtime_state_type(&abi, &TypeArtifact::Struct { name: "Outer".to_string() }));
+
+        abi.structs[0].fields[0].ty = TypeArtifact::Struct { name: "Outer".to_string() };
+        assert!(!is_supported_runtime_state_type(&abi, &TypeArtifact::Struct { name: "Outer".to_string() }));
     }
 
     #[test]

--- a/silverscript-abi/src/lib.rs
+++ b/silverscript-abi/src/lib.rs
@@ -514,6 +514,7 @@ pub fn encode_entry_sig_script(
 }
 
 pub fn encode_runtime_state_script(
+    abi: &SilAbiArtifact,
     runtime_state: &RuntimeStateArtifact,
     values: &BTreeMap<String, ArtifactValue>,
 ) -> CodecResult<Vec<u8>> {
@@ -526,30 +527,257 @@ pub fn encode_runtime_state_script(
     let mut builder = script_builder();
     for field in &runtime_state.fields {
         let value = values.get(&field.name).ok_or_else(|| CodecError::MissingField(field.name.clone()))?;
-        let payload = encode_state_payload(&field.name, &field.ty, value)?;
-        builder.add_data_with_push_opcode(&payload)?;
+        for (leaf_ty, leaf_value) in flatten_state_value(abi, &field.name, &field.ty, value)? {
+            let payload = encode_state_payload(&field.name, &leaf_ty, &leaf_value)?;
+            builder.add_data_with_push_opcode(&payload)?;
+        }
     }
     Ok(builder.drain())
 }
 
 pub fn decode_runtime_state_script(
+    abi: &SilAbiArtifact,
     runtime_state: &RuntimeStateArtifact,
     state_script: &[u8],
 ) -> CodecResult<BTreeMap<String, ArtifactValue>> {
     let pushes = parse_pushes(state_script)?;
-    if pushes.len() < runtime_state.fields.len() {
-        return Err(CodecError::InvalidPush(format!("expected {} state pushes, got {}", runtime_state.fields.len(), pushes.len())));
+    let field_leaf_types =
+        runtime_state.fields.iter().map(|field| flatten_state_types(abi, &field.ty)).collect::<CodecResult<Vec<_>>>()?;
+    let expected_pushes = field_leaf_types.iter().map(Vec::len).sum::<usize>();
+    if pushes.len() < expected_pushes {
+        return Err(CodecError::InvalidPush(format!("expected {expected_pushes} state pushes, got {}", pushes.len())));
     }
-    if pushes.len() > runtime_state.fields.len() {
-        let offset = pushes[runtime_state.fields.len()].0;
+    if pushes.len() > expected_pushes {
+        let offset = pushes[expected_pushes].0;
         return Err(CodecError::TrailingStateBytes { offset, len: state_script.len() - offset });
     }
 
     let mut values = BTreeMap::new();
-    for (field, (_, payload)) in runtime_state.fields.iter().zip(pushes) {
-        values.insert(field.name.clone(), decode_state_payload(&field.name, &field.ty, &payload)?);
+    let mut pushes = pushes.into_iter();
+    for (field, leaf_types) in runtime_state.fields.iter().zip(field_leaf_types) {
+        let leaf_values = leaf_types
+            .iter()
+            .map(|leaf_ty| {
+                let (_, payload) = pushes.next().expect("state push count was checked");
+                decode_state_payload(&field.name, leaf_ty, &payload)
+            })
+            .collect::<CodecResult<Vec<_>>>()?;
+        let (value, consumed) = reconstruct_state_value(abi, &field.name, &field.ty, &leaf_values)?;
+        if consumed != leaf_values.len() {
+            return Err(CodecError::UnsupportedType(format!("invalid flattened state layout for {}", field.name)));
+        }
+        values.insert(field.name.clone(), value);
     }
     Ok(values)
+}
+
+fn flatten_state_types(abi: &SilAbiArtifact, ty: &TypeArtifact) -> CodecResult<Vec<TypeArtifact>> {
+    fn flatten(abi: &SilAbiArtifact, ty: &TypeArtifact, visiting: &mut BTreeSet<String>) -> CodecResult<Vec<TypeArtifact>> {
+        match ty {
+            TypeArtifact::Struct { name } => {
+                if !visiting.insert(name.clone()) {
+                    return Err(CodecError::UnsupportedType(format!("cyclic struct {name}")));
+                }
+                let structure = abi
+                    .structs
+                    .iter()
+                    .find(|structure| structure.name == *name)
+                    .ok_or_else(|| CodecError::UnknownStruct(name.clone()))?;
+                let mut leaves = Vec::new();
+                for field in &structure.fields {
+                    leaves.extend(flatten(abi, &field.ty, visiting)?);
+                }
+                visiting.remove(name);
+                Ok(leaves)
+            }
+            TypeArtifact::FixedArray { item, len } => {
+                let item_leaves = flatten(abi, item, visiting)?;
+                if item_leaves.as_slice() == std::slice::from_ref(item.as_ref()) {
+                    Ok(vec![ty.clone()])
+                } else {
+                    Ok(item_leaves.into_iter().map(|item| TypeArtifact::FixedArray { item: Box::new(item), len: *len }).collect())
+                }
+            }
+            TypeArtifact::DynamicArray { item } => {
+                let item_leaves = flatten(abi, item, visiting)?;
+                if item_leaves.as_slice() == std::slice::from_ref(item.as_ref()) {
+                    Ok(vec![ty.clone()])
+                } else {
+                    Ok(item_leaves.into_iter().map(|item| TypeArtifact::DynamicArray { item: Box::new(item) }).collect())
+                }
+            }
+            _ => Ok(vec![ty.clone()]),
+        }
+    }
+
+    flatten(abi, ty, &mut BTreeSet::new())
+}
+
+fn flatten_state_value(
+    abi: &SilAbiArtifact,
+    name: &str,
+    ty: &TypeArtifact,
+    value: &ArtifactValue,
+) -> CodecResult<Vec<(TypeArtifact, ArtifactValue)>> {
+    fn flatten(
+        abi: &SilAbiArtifact,
+        name: &str,
+        ty: &TypeArtifact,
+        value: &ArtifactValue,
+        visiting: &mut BTreeSet<String>,
+    ) -> CodecResult<Vec<(TypeArtifact, ArtifactValue)>> {
+        match ty {
+            TypeArtifact::Struct { name: struct_name } => {
+                if !visiting.insert(struct_name.clone()) {
+                    return Err(CodecError::UnsupportedType(format!("cyclic struct {struct_name}")));
+                }
+                let structure = abi
+                    .structs
+                    .iter()
+                    .find(|structure| structure.name == *struct_name)
+                    .ok_or_else(|| CodecError::UnknownStruct(struct_name.clone()))?;
+                let fields = object_fields(value)?;
+                assert_no_extra_fields(fields, &structure.fields)?;
+                let mut leaves = Vec::new();
+                for field in &structure.fields {
+                    let field_value = fields.get(&field.name).ok_or_else(|| CodecError::MissingField(field.name.clone()))?;
+                    leaves.extend(flatten(abi, &field.name, &field.ty, field_value, visiting)?);
+                }
+                visiting.remove(struct_name);
+                Ok(leaves)
+            }
+            TypeArtifact::FixedArray { item, len } => flatten_state_array(abi, name, item, Some(*len), value, visiting),
+            TypeArtifact::DynamicArray { item } => flatten_state_array(abi, name, item, None, value, visiting),
+            _ => Ok(vec![(ty.clone(), value.clone())]),
+        }
+    }
+
+    fn flatten_state_array(
+        abi: &SilAbiArtifact,
+        name: &str,
+        item: &TypeArtifact,
+        expected_len: Option<usize>,
+        value: &ArtifactValue,
+        visiting: &mut BTreeSet<String>,
+    ) -> CodecResult<Vec<(TypeArtifact, ArtifactValue)>> {
+        let item_leaf_types = flatten_state_types(abi, item)?;
+
+        // A single unchanged leaf means the item type does not contain a struct.
+        if item_leaf_types.as_slice() == std::slice::from_ref(item) {
+            let ty = match expected_len {
+                Some(len) => TypeArtifact::FixedArray { item: Box::new(item.clone()), len },
+                None => TypeArtifact::DynamicArray { item: Box::new(item.clone()) },
+            };
+            return Ok(vec![(ty, value.clone())]);
+        }
+
+        let values = expect_array(value)?;
+        if let Some(expected) = expected_len {
+            require_len(name, expected, values.len())?;
+        }
+        let mut grouped_values = vec![Vec::with_capacity(values.len()); item_leaf_types.len()];
+        for value in values {
+            let item_leaves = flatten(abi, name, item, value, visiting)?;
+            if item_leaves.len() != item_leaf_types.len() {
+                return Err(CodecError::UnsupportedType(format!("invalid flattened state layout for {name}")));
+            }
+            for ((expected_ty, values), (actual_ty, value)) in item_leaf_types.iter().zip(&mut grouped_values).zip(item_leaves) {
+                if expected_ty != &actual_ty {
+                    return Err(CodecError::UnsupportedType(format!("invalid flattened state layout for {name}")));
+                }
+                values.push(value);
+            }
+        }
+
+        Ok(item_leaf_types
+            .into_iter()
+            .zip(grouped_values)
+            .map(|(item, values)| {
+                let ty = match expected_len {
+                    Some(len) => TypeArtifact::FixedArray { item: Box::new(item), len },
+                    None => TypeArtifact::DynamicArray { item: Box::new(item) },
+                };
+                (ty, ArtifactValue::Array(values))
+            })
+            .collect())
+    }
+
+    flatten(abi, name, ty, value, &mut BTreeSet::new())
+}
+
+fn reconstruct_state_value(
+    abi: &SilAbiArtifact,
+    name: &str,
+    ty: &TypeArtifact,
+    leaves: &[ArtifactValue],
+) -> CodecResult<(ArtifactValue, usize)> {
+    match ty {
+        TypeArtifact::Struct { name: struct_name } => {
+            let structure = abi
+                .structs
+                .iter()
+                .find(|structure| structure.name == *struct_name)
+                .ok_or_else(|| CodecError::UnknownStruct(struct_name.clone()))?;
+            let mut fields = BTreeMap::new();
+            let mut consumed = 0;
+            for field in &structure.fields {
+                let (value, field_consumed) = reconstruct_state_value(abi, &field.name, &field.ty, &leaves[consumed..])?;
+                consumed += field_consumed;
+                fields.insert(field.name.clone(), value);
+            }
+            Ok((ArtifactValue::Object(fields), consumed))
+        }
+        TypeArtifact::FixedArray { item, len } => reconstruct_state_array(abi, name, item, Some(*len), leaves),
+        TypeArtifact::DynamicArray { item } => reconstruct_state_array(abi, name, item, None, leaves),
+        _ => leaves
+            .first()
+            .cloned()
+            .map(|value| (value, 1))
+            .ok_or_else(|| CodecError::InvalidPush(format!("missing flattened state value for {name}"))),
+    }
+}
+
+fn reconstruct_state_array(
+    abi: &SilAbiArtifact,
+    name: &str,
+    item: &TypeArtifact,
+    expected_len: Option<usize>,
+    leaves: &[ArtifactValue],
+) -> CodecResult<(ArtifactValue, usize)> {
+    let item_leaf_types = flatten_state_types(abi, item)?;
+    if item_leaf_types.as_slice() == std::slice::from_ref(item) {
+        return leaves
+            .first()
+            .cloned()
+            .map(|value| (value, 1))
+            .ok_or_else(|| CodecError::InvalidPush(format!("missing flattened state value for {name}")));
+    }
+    if item_leaf_types.is_empty() {
+        return Err(CodecError::UnsupportedType(format!("zero-field struct array {name}")));
+    }
+
+    let leaf_values = leaves
+        .get(..item_leaf_types.len())
+        .ok_or_else(|| CodecError::InvalidPush(format!("missing flattened state values for {name}")))?;
+    let arrays = leaf_values.iter().map(expect_array).collect::<CodecResult<Vec<_>>>()?;
+    let actual_len = arrays[0].len();
+    if let Some(expected) = expected_len {
+        require_len(name, expected, actual_len)?;
+    }
+    for array in &arrays[1..] {
+        require_len(name, actual_len, array.len())?;
+    }
+
+    let mut values = Vec::with_capacity(actual_len);
+    for index in 0..actual_len {
+        let item_leaves = arrays.iter().map(|array| array[index].clone()).collect::<Vec<_>>();
+        let (value, consumed) = reconstruct_state_value(abi, name, item, &item_leaves)?;
+        if consumed != item_leaves.len() {
+            return Err(CodecError::UnsupportedType(format!("invalid flattened state layout for {name}")));
+        }
+        values.push(value);
+    }
+    Ok((ArtifactValue::Array(values), item_leaf_types.len()))
 }
 
 pub fn encode_struct_payload(
@@ -619,10 +847,10 @@ fn verify_compiled_contract(abi: &SilAbiArtifact, contract: &SilContractArtifact
             });
         }
     }
-    let state_values = decode_runtime_state_script(&contract.runtime_state, state_script).map_err(|err| {
+    let state_values = decode_runtime_state_script(abi, &contract.runtime_state, state_script).map_err(|err| {
         SilAbiVerificationError::InvalidRuntimeStateEncoding { contract: contract.name.clone(), message: err.to_string() }
     })?;
-    let canonical_state = encode_runtime_state_script(&contract.runtime_state, &state_values).map_err(|err| {
+    let canonical_state = encode_runtime_state_script(abi, &contract.runtime_state, &state_values).map_err(|err| {
         SilAbiVerificationError::InvalidRuntimeStateEncoding { contract: contract.name.clone(), message: err.to_string() }
     })?;
     if canonical_state != state_script {
@@ -1155,13 +1383,16 @@ mod tests {
     #[test]
     fn verifies_compiled_contract_against_its_script() {
         let mut abi = tiny_sil_abi();
-        let contract = &mut abi.contracts[0];
         let prefix = [0xaa];
-        contract.runtime_state.fields = vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
-        let state =
-            encode_runtime_state_script(&contract.runtime_state, &BTreeMap::from([("value".to_string(), ArtifactValue::Byte(2))]))
-                .expect("state encodes");
+        abi.contracts[0].runtime_state.fields = vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
+        let state = encode_runtime_state_script(
+            &abi,
+            &abi.contracts[0].runtime_state,
+            &BTreeMap::from([("value".to_string(), ArtifactValue::Byte(2))]),
+        )
+        .expect("state encodes");
         let suffix = [0xbb, 0xcc];
+        let contract = &mut abi.contracts[0];
         contract.compiled.set_bytecode([prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
         contract.compiled.set_template_hash(template_hash(&prefix, &suffix));
         contract.compiled.state_span = StateSpanArtifact { offset: prefix.len(), len: state.len() };
@@ -1213,13 +1444,16 @@ mod tests {
     #[test]
     fn rejects_state_spans_that_do_not_match_the_runtime_state() {
         let mut abi = tiny_sil_abi();
-        let contract = &mut abi.contracts[0];
-        contract.runtime_state.fields = vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
+        abi.contracts[0].runtime_state.fields = vec![RuntimeFieldArtifact { name: "value".to_string(), ty: TypeArtifact::Byte }];
         let prefix = [0xaa];
-        let state =
-            encode_runtime_state_script(&contract.runtime_state, &BTreeMap::from([("value".to_string(), ArtifactValue::Byte(2))]))
-                .expect("state encodes");
+        let state = encode_runtime_state_script(
+            &abi,
+            &abi.contracts[0].runtime_state,
+            &BTreeMap::from([("value".to_string(), ArtifactValue::Byte(2))]),
+        )
+        .expect("state encodes");
         let suffix = [0xbb];
+        let contract = &mut abi.contracts[0];
         contract.compiled.set_bytecode([prefix.as_slice(), state.as_slice(), suffix.as_slice()].concat());
 
         contract.compiled.state_span = StateSpanArtifact { offset: 0, len: prefix.len() + state.len() };
@@ -1337,8 +1571,8 @@ mod tests {
             ],
         };
         let values = BTreeMap::from([("at".to_string(), ArtifactValue::Int(-5)), ("history".to_string(), history)]);
-        let encoded = encode_runtime_state_script(&runtime_state, &values).expect("temporal state encodes");
-        assert_eq!(decode_runtime_state_script(&runtime_state, &encoded).expect("temporal state decodes"), values);
+        let encoded = encode_runtime_state_script(&artifact, &runtime_state, &values).expect("temporal state encodes");
+        assert_eq!(decode_runtime_state_script(&artifact, &runtime_state, &encoded).expect("temporal state decodes"), values);
     }
 
     #[test]
@@ -1444,6 +1678,7 @@ mod tests {
 
     #[test]
     fn round_trips_runtime_state_script() {
+        let abi = tiny_sil_abi();
         let runtime_state = RuntimeStateArtifact {
             source: "FooState".to_string(),
             fields: vec![
@@ -1458,19 +1693,84 @@ mod tests {
             ("flag".to_string(), ArtifactValue::Bool(true)),
         ]);
 
-        let encoded = encode_runtime_state_script(&runtime_state, &values).expect("state encodes");
-        let decoded = decode_runtime_state_script(&runtime_state, &encoded).expect("state decodes");
+        let encoded = encode_runtime_state_script(&abi, &runtime_state, &values).expect("state encodes");
+        let decoded = decode_runtime_state_script(&abi, &runtime_state, &encoded).expect("state decodes");
 
         assert_eq!(encode_hex(&encoded), format!("20{}0805000000000000800101", "07".repeat(32)));
         assert_eq!(decoded, values);
-        assert_eq!(encode_runtime_state_script(&runtime_state, &decoded).expect("state re-encodes"), encoded);
+        assert_eq!(encode_runtime_state_script(&abi, &runtime_state, &decoded).expect("state re-encodes"), encoded);
 
         let mut extra = values;
         extra.insert("extra".to_string(), ArtifactValue::Int(1));
         assert_eq!(
-            encode_runtime_state_script(&runtime_state, &extra).expect_err("extra fields should be rejected"),
+            encode_runtime_state_script(&abi, &runtime_state, &extra).expect_err("extra fields should be rejected"),
             CodecError::UnknownField("extra".to_string())
         );
+    }
+
+    #[test]
+    fn round_trips_nested_struct_and_struct_array_runtime_state() {
+        let mut abi = tiny_sil_abi();
+        abi.structs = vec![
+            StructArtifact {
+                name: "Inner".to_string(),
+                fields: vec![FieldArtifact { name: "marker".to_string(), ty: TypeArtifact::Byte }],
+            },
+            StructArtifact {
+                name: "Outer".to_string(),
+                fields: vec![
+                    FieldArtifact { name: "inner".to_string(), ty: TypeArtifact::Struct { name: "Inner".to_string() } },
+                    FieldArtifact { name: "active".to_string(), ty: TypeArtifact::Bool },
+                ],
+            },
+            StructArtifact {
+                name: "Pair".to_string(),
+                fields: vec![
+                    FieldArtifact { name: "amount".to_string(), ty: TypeArtifact::Int },
+                    FieldArtifact { name: "code".to_string(), ty: TypeArtifact::FixedBytes { len: 2 } },
+                ],
+            },
+        ];
+        let runtime_state = RuntimeStateArtifact {
+            source: "FooState".to_string(),
+            fields: vec![
+                RuntimeFieldArtifact { name: "current".to_string(), ty: TypeArtifact::Struct { name: "Outer".to_string() } },
+                RuntimeFieldArtifact {
+                    name: "pairs".to_string(),
+                    ty: TypeArtifact::FixedArray { item: Box::new(TypeArtifact::Struct { name: "Pair".to_string() }), len: 2 },
+                },
+            ],
+        };
+        let pair = |amount, code| {
+            ArtifactValue::Object(BTreeMap::from([
+                ("amount".to_string(), ArtifactValue::Int(amount)),
+                ("code".to_string(), ArtifactValue::Bytes(code)),
+            ]))
+        };
+        let values = BTreeMap::from([
+            (
+                "current".to_string(),
+                ArtifactValue::Object(BTreeMap::from([
+                    ("inner".to_string(), ArtifactValue::Object(BTreeMap::from([("marker".to_string(), ArtifactValue::Byte(7))]))),
+                    ("active".to_string(), ArtifactValue::Bool(true)),
+                ])),
+            ),
+            ("pairs".to_string(), ArtifactValue::Array(vec![pair(11, vec![0xaa, 0xbb]), pair(12, vec![0xcc, 0xdd])])),
+        ]);
+
+        let encoded = encode_runtime_state_script(&abi, &runtime_state, &values).expect("structured state encodes");
+        let pushes = parse_pushes(&encoded).expect("structured state uses push-only encoding");
+
+        assert_eq!(
+            pushes.into_iter().map(|(_, payload)| payload).collect::<Vec<_>>(),
+            vec![
+                vec![7],
+                vec![1],
+                [serialize_fixed_i64(11, 8).unwrap(), serialize_fixed_i64(12, 8).unwrap()].concat(),
+                vec![0xaa, 0xbb, 0xcc, 0xdd],
+            ]
+        );
+        assert_eq!(decode_runtime_state_script(&abi, &runtime_state, &encoded).expect("structured state decodes"), values);
     }
 
     fn tiny_sil_abi() -> SilAbiArtifact {

--- a/silverscript-debug-artifact/Cargo.toml
+++ b/silverscript-debug-artifact/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "silverscript-debug-artifact"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lib]
+name = "silverscript_debug_artifact"
+path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+silverscript-abi.workspace = true
+silverscript-lang.workspace = true
+

--- a/silverscript-debug-artifact/src/lib.rs
+++ b/silverscript-debug-artifact/src/lib.rs
@@ -1,0 +1,78 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use silverscript_abi::{ArtifactValue, SilAbiArtifact, SilContractArtifact};
+use silverscript_lang::ast::parse_contract_ast;
+use silverscript_lang::compiler::{
+    CompileOptions, CompilerError, artifact_value_to_expr, compile_contract as compile_internal_contract,
+    sil_abi_artifact_from_compiled,
+};
+use silverscript_lang::debug_info::DebugInfo;
+
+/// A portable SilverScript ABI artifact accompanied by compiler debug metadata
+/// for each contract it contains.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SilDebugArtifact<'i> {
+    pub abi: SilAbiArtifact,
+    pub contract_debug_info: BTreeMap<String, DebugInfo<'i>>,
+}
+
+impl<'i> SilDebugArtifact<'i> {
+    pub fn contract(&self, name: &str) -> Option<&SilContractArtifact> {
+        self.abi.contract(name)
+    }
+
+    pub fn debug_info(&self, contract_name: &str) -> Option<&DebugInfo<'i>> {
+        self.contract_debug_info.get(contract_name)
+    }
+}
+
+/// Compiles one contract into its portable ABI and associated debug metadata.
+pub fn compile_contract<'i>(
+    source: &'i str,
+    constructor_args: &[ArtifactValue],
+    mut options: CompileOptions,
+) -> Result<SilDebugArtifact<'i>, CompilerError> {
+    let contract = parse_contract_ast(source)?;
+    if constructor_args.len() != contract.params.len() {
+        return Err(CompilerError::Unsupported(format!(
+            "constructor argument count mismatch: expected {}, got {}",
+            contract.params.len(),
+            constructor_args.len()
+        )));
+    }
+    let constructor_args = constructor_args
+        .iter()
+        .zip(&contract.params)
+        .map(|(value, param)| artifact_value_to_expr(value, &param.type_ref, &contract))
+        .collect::<Result<Vec<_>, CompilerError>>()?;
+
+    // A debug artifact always records debug information regardless of the
+    // caller's normal compilation preference.
+    options.record_debug_infos = true;
+    let compiled = compile_internal_contract(source, &constructor_args, options)?;
+    let abi = sil_abi_artifact_from_compiled(&compiled, &constructor_args)?;
+    let contract_name = compiled.contract_name.clone();
+    let debug_info = compiled
+        .debug_info
+        .ok_or_else(|| CompilerError::Unsupported(format!("compiled contract '{contract_name}' has no debug information")))?;
+
+    Ok(SilDebugArtifact { abi, contract_debug_info: BTreeMap::from([(contract_name, debug_info)]) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compiles_portable_artifact_with_per_contract_debug_info() {
+        let source = "contract C(int initial) { int value = initial; entry main() { require(value > 0); } }";
+        let artifact = compile_contract(source, &[1.into()], CompileOptions::default()).expect("debug artifact compiles");
+
+        let contract = artifact.contract("C").expect("portable contract exists");
+        assert!(!contract.compiled.bytecode.is_empty());
+        let debug_info = artifact.debug_info("C").expect("contract debug information exists");
+        assert_eq!(debug_info.source, source);
+        assert!(!debug_info.steps.is_empty());
+    }
+}

--- a/silverscript-lang/Cargo.toml
+++ b/silverscript-lang/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0"
 clap = { version = "4.5.60", features = ["derive"] }
 faster-hex = "0.10"
 semver = "1.0"
+silverscript-abi = { path = "../silverscript-abi" }
 
 [dev-dependencies]
 kaspa-addresses.workspace = true

--- a/silverscript-lang/src/ast/mod.rs
+++ b/silverscript-lang/src/ast/mod.rs
@@ -1604,14 +1604,14 @@ fn parse_function_definition<'i>(pair: Pair<'i, Rule>) -> Result<FunctionAst<'i>
     let mut return_types = Vec::new();
     let mut returns_tuple = false;
     let mut return_type_spans = Vec::new();
-    if let Some(next) = inner.peek() {
-        if next.as_rule() == Rule::return_type_list {
-            let return_pair = inner.next().expect("checked");
-            returns_tuple = return_pair.as_str().trim_start_matches(':').trim_start().starts_with('(');
-            let (types, spans) = parse_return_type_list(return_pair)?;
-            return_types = types;
-            return_type_spans = spans;
-        }
+    if let Some(next) = inner.peek()
+        && next.as_rule() == Rule::return_type_list
+    {
+        let return_pair = inner.next().expect("checked");
+        returns_tuple = return_pair.as_str().trim_start_matches(':').trim_start().starts_with('(');
+        let (types, spans) = parse_return_type_list(return_pair)?;
+        return_types = types;
+        return_type_spans = spans;
     }
 
     let Identifier { name, span: name_span } = parse_identifier(name_pair)?;
@@ -2581,7 +2581,7 @@ fn parse_hex_literal<'i>(pair: Pair<'i, Rule>) -> Result<Expr<'i>, CompilerError
 fn parse_hex_bytes(pair: &Pair<'_, Rule>) -> Result<Vec<u8>, CompilerError> {
     let raw = pair.as_str();
     let trimmed = raw.trim_start_matches("0x").trim_start_matches("0X");
-    let normalized = if trimmed.len() % 2 != 0 { format!("0{trimmed}") } else { trimmed.to_string() };
+    let normalized = if !trimmed.len().is_multiple_of(2) { format!("0{trimmed}") } else { trimmed.to_string() };
     (0..normalized.len())
         .step_by(2)
         .map(|i| u8::from_str_radix(&normalized[i..i + 2], 16))

--- a/silverscript-lang/src/bin/silverc.rs
+++ b/silverscript-lang/src/bin/silverc.rs
@@ -3,8 +3,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
-use silverscript_lang::ast::{Expr, parse_contract_ast};
-use silverscript_lang::compiler::{CompileOptions, compile_contract};
+use silverscript_abi::ArtifactValue;
+use silverscript_lang::ast::parse_contract_ast;
+use silverscript_lang::compiler::sil_abi_artifact;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -71,16 +72,15 @@ fn run() -> Result<(), String> {
 
     let constructor_args = if let Some(path) = &cli.constructor_args {
         let json = fs::read_to_string(path).map_err(|err| format!("failed to read {}: {err}", path.display()))?;
-        serde_json::from_str::<Vec<Expr>>(&json)
+        serde_json::from_str::<Vec<ArtifactValue>>(&json)
             .map_err(|err| format!("failed to parse constructor args {}: {err}", path.display()))?
     } else {
         Vec::new()
     };
 
-    let compiled =
-        compile_contract(&source, &constructor_args, CompileOptions::default()).map_err(|err| format!("compile error: {err}"))?;
+    let artifact = sil_abi_artifact(&source, &constructor_args).map_err(|err| format!("compile error: {err}"))?;
 
-    let json = serde_json::to_string_pretty(&compiled).map_err(|err| format!("failed to serialize output: {err}"))?;
+    let json = serde_json::to_string_pretty(&artifact).map_err(|err| format!("failed to serialize output: {err}"))?;
     let target = resolve_output_target(&cli, &cli.src, false);
     emit_output(&json, target)?;
 

--- a/silverscript-lang/src/bin/silverc.rs
+++ b/silverscript-lang/src/bin/silverc.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use clap::Parser;
 use silverscript_abi::ArtifactValue;
 use silverscript_lang::ast::parse_contract_ast;
-use silverscript_lang::compiler::sil_abi_artifact;
+use silverscript_lang::compiler::compile_to_sil_abi_artifact;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -78,7 +78,7 @@ fn run() -> Result<(), String> {
         Vec::new()
     };
 
-    let artifact = sil_abi_artifact(&source, &constructor_args).map_err(|err| format!("compile error: {err}"))?;
+    let artifact = compile_to_sil_abi_artifact(&source, &constructor_args).map_err(|err| format!("compile error: {err}"))?;
 
     let json = serde_json::to_string_pretty(&artifact).map_err(|err| format!("failed to serialize output: {err}"))?;
     let target = resolve_output_target(&cli, &cli.src, false);

--- a/silverscript-lang/src/bin/silverc.rs
+++ b/silverscript-lang/src/bin/silverc.rs
@@ -80,7 +80,7 @@ fn run() -> Result<(), String> {
 
     let artifact = compile_to_sil_abi_artifact(&source, &constructor_args).map_err(|err| format!("compile error: {err}"))?;
 
-    let json = serde_json::to_string_pretty(&artifact).map_err(|err| format!("failed to serialize output: {err}"))?;
+    let json = silverscript_abi::to_pretty_json(&artifact).map_err(|err| format!("failed to serialize output: {err}"))?;
     let target = resolve_output_target(&cli, &cli.src, false);
     emit_output(&json, target)?;
 

--- a/silverscript-lang/src/compiler/abi.rs
+++ b/silverscript-lang/src/compiler/abi.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use silverscript_abi::{
     ArtifactValue, CompiledContractArtifact, FieldArtifact, ParamArtifact, RuntimeFieldArtifact, RuntimeStateArtifact,
-    SIL_ABI_SCHEMA_VERSION, SilAbiArtifact, SilContractArtifact, SilEntryArtifact, StateArtifact, StateSpanArtifact, TypeArtifact,
+    SIL_ABI_SCHEMA_VERSION, SilAbiArtifact, SilContractArtifact, SilEntryArtifact, StateSpanArtifact, StructArtifact, TypeArtifact,
     encode_hex,
 };
 
@@ -105,13 +105,13 @@ fn artifact_value_type_mismatch(value: &ArtifactValue, expected_type: &TypeRef) 
 }
 
 /// Compiles one SilverScript contract into a complete portable ABI artifact.
-pub fn sil_abi_artifact(source: &str, constructor_args: &[ArtifactValue]) -> Result<SilAbiArtifact, CompilerError> {
-    sil_abi_artifact_with_options(source, constructor_args, CompileOptions::default())
+pub fn compile_to_sil_abi_artifact(source: &str, constructor_args: &[ArtifactValue]) -> Result<SilAbiArtifact, CompilerError> {
+    compile_to_sil_abi_artifact_with_options(source, constructor_args, CompileOptions::default())
 }
 
 /// Compiles one SilverScript contract into a complete portable ABI artifact
 /// using the requested compiler options.
-pub fn sil_abi_artifact_with_options(
+pub fn compile_to_sil_abi_artifact_with_options(
     source: &str,
     constructor_args: &[ArtifactValue],
     options: CompileOptions,
@@ -138,7 +138,7 @@ pub fn sil_abi_artifact_from_compiled<'i>(
                 .iter()
                 .map(|field| Ok(FieldArtifact { name: field.name.clone(), ty: type_artifact(&field.type_ref, &constants)? }))
                 .collect::<Result<Vec<_>, CompilerError>>()?;
-            Ok(StateArtifact { name: struct_.name.clone(), fields })
+            Ok(StructArtifact { name: struct_.name.clone(), fields })
         })
         .collect::<Result<Vec<_>, CompilerError>>()?;
     let contract = contract_artifact_from_compiled(compiled, constructor_args)?;
@@ -146,7 +146,7 @@ pub fn sil_abi_artifact_from_compiled<'i>(
     Ok(SilAbiArtifact {
         schema_version: SIL_ABI_SCHEMA_VERSION,
         compiler_version: compiled.compiler_version.clone(),
-        states,
+        structs: states,
         contracts: vec![contract],
     })
 }

--- a/silverscript-lang/src/compiler/abi.rs
+++ b/silverscript-lang/src/compiler/abi.rs
@@ -1,9 +1,8 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use silverscript_abi::{
     ArtifactValue, CompiledContractArtifact, FieldArtifact, ParamArtifact, RuntimeFieldArtifact, RuntimeStateArtifact,
     SIL_ABI_SCHEMA_VERSION, SilAbiArtifact, SilContractArtifact, SilEntryArtifact, StateSpanArtifact, StructArtifact, TypeArtifact,
-    encode_hex,
 };
 
 use super::*;
@@ -128,7 +127,7 @@ pub fn sil_abi_artifact_from_compiled<'i>(
     constructor_args: &[Expr<'i>],
 ) -> Result<SilAbiArtifact, CompilerError> {
     let constants = artifact_constants(compiled, constructor_args);
-    let states = compiled
+    let structs = compiled
         .ast
         .structs
         .iter()
@@ -138,16 +137,16 @@ pub fn sil_abi_artifact_from_compiled<'i>(
                 .iter()
                 .map(|field| Ok(FieldArtifact { name: field.name.clone(), ty: type_artifact(&field.type_ref, &constants)? }))
                 .collect::<Result<Vec<_>, CompilerError>>()?;
-            Ok(StructArtifact { name: struct_.name.clone(), fields })
+            Ok((struct_.name.clone(), StructArtifact { fields }))
         })
-        .collect::<Result<Vec<_>, CompilerError>>()?;
+        .collect::<Result<BTreeMap<_, _>, CompilerError>>()?;
     let contract = contract_artifact_from_compiled(compiled, constructor_args)?;
 
     Ok(SilAbiArtifact {
         schema_version: SIL_ABI_SCHEMA_VERSION,
         compiler_version: compiled.compiler_version.clone(),
-        structs: states,
-        contracts: vec![contract],
+        structs,
+        contracts: BTreeMap::from([(compiled.contract_name.clone(), contract)]),
     })
 }
 
@@ -180,11 +179,11 @@ fn contract_artifact_from_compiled<'i>(
                 .iter()
                 .map(|param| Ok(ParamArtifact { name: param.name.clone(), ty: type_artifact(&param.type_ref, &constants)? }))
                 .collect::<Result<Vec<_>, CompilerError>>()?;
-            Ok(SilEntryArtifact { name: function.name.clone(), dispatch_tag: dispatch_tag.into(), params })
+            Ok((function.name.clone(), SilEntryArtifact { dispatch_tag: dispatch_tag.into(), params }))
         })
-        .collect::<Result<Vec<_>, CompilerError>>()?;
+        .collect::<Result<BTreeMap<_, _>, CompilerError>>()?;
     let artifact_entry = |entry_name: &str| {
-        entries.iter().find(|artifact| artifact.name == entry_name).cloned().ok_or_else(|| {
+        entries.contains_key(entry_name).then(|| entry_name.to_string()).ok_or_else(|| {
             CompilerError::Unsupported(format!(
                 "compiled contract '{}' has no portable ABI entry for generated function '{}'",
                 compiled.contract_name, entry_name
@@ -212,7 +211,6 @@ fn contract_artifact_from_compiled<'i>(
 
     let template_hash = compiled.template_hash();
     Ok(SilContractArtifact {
-        name: compiled.contract_name.clone(),
         source_path: format!("sil/{}.sil", compiled.contract_name),
         runtime_state: RuntimeStateArtifact { source: STATE_TYPE_NAME.to_string(), fields: runtime_fields },
         entries,
@@ -220,9 +218,7 @@ fn contract_artifact_from_compiled<'i>(
         delegate_entry_abi,
         compiled: CompiledContractArtifact {
             bytecode: compiled.bytecode.clone(),
-            script_hex: encode_hex(&compiled.bytecode),
             template_hash,
-            template_hash_hex: encode_hex(&template_hash),
             state_span: StateSpanArtifact { offset: layout.start, len: layout.len },
         },
     })

--- a/silverscript-lang/src/compiler/abi.rs
+++ b/silverscript-lang/src/compiler/abi.rs
@@ -1,0 +1,142 @@
+use std::collections::HashMap;
+
+use silverscript_abi::{
+    CompiledContractArtifact, FieldArtifact, ParamArtifact, RuntimeFieldArtifact, RuntimeStateArtifact, SIL_ABI_SCHEMA_VERSION,
+    SilAbiArtifact, SilContractArtifact, SilEntryArtifact, StateArtifact, StateSpanArtifact, TypeArtifact, encode_hex,
+};
+
+use super::*;
+
+/// Compiles one SilverScript contract into a complete portable ABI artifact.
+pub fn sil_abi_artifact<'i>(source: &'i str, constructor_args: &[Expr<'i>]) -> Result<SilAbiArtifact, CompilerError> {
+    let compiled = compile_contract(source, constructor_args, CompileOptions::default())?;
+    let constants = artifact_constants(&compiled, constructor_args);
+    let states = compiled
+        .ast
+        .structs
+        .iter()
+        .map(|struct_| {
+            let fields = struct_
+                .fields
+                .iter()
+                .map(|field| Ok(FieldArtifact { name: field.name.clone(), ty: type_artifact(&field.type_ref, &constants)? }))
+                .collect::<Result<Vec<_>, CompilerError>>()?;
+            Ok(StateArtifact { name: struct_.name.clone(), fields })
+        })
+        .collect::<Result<Vec<_>, CompilerError>>()?;
+    let contract = contract_artifact_from_compiled(&compiled, constructor_args)?;
+
+    Ok(SilAbiArtifact { schema_version: SIL_ABI_SCHEMA_VERSION, states, contracts: vec![contract] })
+}
+
+fn contract_artifact_from_compiled<'i>(
+    compiled: &CompiledContract<'i>,
+    constructor_args: &[Expr<'i>],
+) -> Result<SilContractArtifact, CompilerError> {
+    let constants = artifact_constants(compiled, constructor_args);
+
+    let runtime_fields = compiled
+        .ast
+        .fields
+        .iter()
+        .map(|field| Ok(RuntimeFieldArtifact { name: field.name.clone(), ty: type_artifact(&field.type_ref, &constants)? }))
+        .collect::<Result<Vec<_>, CompilerError>>()?;
+    let entries = compiled
+        .ast
+        .functions
+        .iter()
+        .filter(|function| function.entrypoint)
+        .map(|function| {
+            let compiled_entry = compiled.entry_by_name(&function.name).ok_or_else(|| {
+                CompilerError::Unsupported(format!(
+                    "compiled contract '{}' has no ABI entry for function '{}'",
+                    compiled.contract_name, function.name
+                ))
+            })?;
+            let params = function
+                .params
+                .iter()
+                .map(|param| Ok(ParamArtifact { name: param.name.clone(), ty: type_artifact(&param.type_ref, &constants)? }))
+                .collect::<Result<Vec<_>, CompilerError>>()?;
+            Ok(SilEntryArtifact { name: function.name.clone(), dispatch_tag: compiled_entry.dispatch_tag.into(), params })
+        })
+        .collect::<Result<Vec<_>, CompilerError>>()?;
+
+    let layout = compiled.state_layout;
+    let state_end = checked_add(layout.start, layout.len)?;
+    if layout.start > compiled.bytecode.len() || state_end > compiled.bytecode.len() {
+        return Err(CompilerError::Unsupported(format!(
+            "compiled contract '{}' reported invalid state span start={} len={} for script len={}",
+            compiled.contract_name,
+            layout.start,
+            layout.len,
+            compiled.bytecode.len()
+        )));
+    }
+
+    Ok(SilContractArtifact {
+        name: compiled.contract_name.clone(),
+        source_path: format!("sil/{}.sil", compiled.contract_name),
+        runtime_state: RuntimeStateArtifact { source: STATE_TYPE_NAME.to_string(), fields: runtime_fields },
+        entries,
+        compiled: CompiledContractArtifact {
+            script_hex: encode_hex(&compiled.bytecode),
+            template_hash_hex: encode_hex(&compiled.template_hash()),
+            state_span: StateSpanArtifact { offset: layout.start, len: layout.len },
+        },
+    })
+}
+
+fn artifact_constants<'i>(compiled: &CompiledContract<'i>, constructor_args: &[Expr<'i>]) -> HashMap<String, Expr<'i>> {
+    let mut constants: HashMap<String, Expr<'i>> =
+        compiled.ast.constants.iter().map(|constant| (constant.name.clone(), constant.expr.clone())).collect();
+    constants.extend(compiled.ast.params.iter().zip(constructor_args).map(|(param, value)| (param.name.clone(), value.clone())));
+    constants
+}
+
+fn type_artifact<'i>(type_ref: &TypeRef, constants: &HashMap<String, Expr<'i>>) -> Result<TypeArtifact, CompilerError> {
+    let mut artifact = match &type_ref.base {
+        TypeBase::Int => TypeArtifact::Int,
+        TypeBase::Temporal => TypeArtifact::Temporal,
+        TypeBase::Bool => TypeArtifact::Bool,
+        TypeBase::Byte => TypeArtifact::Byte,
+        TypeBase::String => TypeArtifact::Text,
+        TypeBase::Pubkey => TypeArtifact::Pubkey,
+        TypeBase::Sig => TypeArtifact::Sig,
+        TypeBase::Datasig => TypeArtifact::Datasig,
+        TypeBase::Custom(name) => TypeArtifact::Struct { name: name.clone() },
+        TypeBase::Tuple(_) => {
+            return Err(CompilerError::Unsupported(format!("portable ABI does not support tuple type '{}'", type_ref.type_name())));
+        }
+    };
+
+    for dimension in &type_ref.array_dims {
+        let len =
+            match dimension {
+                ArrayDim::Dynamic => None,
+                ArrayDim::Fixed(len) => Some(*len),
+                ArrayDim::Constant(name) => {
+                    let value = constants
+                        .get(name)
+                        .ok_or_else(|| CompilerError::UndefinedIdentifier(name.clone()))
+                        .and_then(|expr| eval_const_int(expr, constants))?;
+                    Some(usize::try_from(value).map_err(|_| {
+                        CompilerError::Unsupported(format!("array size constant '{name}' must be a non-negative integer"))
+                    })?)
+                }
+                ArrayDim::Inferred => {
+                    return Err(CompilerError::Unsupported(
+                        "portable ABI array dimension was not inferred during compilation".to_string(),
+                    ));
+                }
+            };
+        artifact = match (artifact, len) {
+            (TypeArtifact::Byte, Some(len)) => TypeArtifact::FixedBytes { len },
+            (TypeArtifact::Byte, None) => TypeArtifact::Bytes,
+            (item, Some(len)) => TypeArtifact::FixedArray { item: Box::new(item), len },
+            (item, None) => TypeArtifact::DynamicArray { item: Box::new(item) },
+        };
+    }
+
+    Ok(artifact)
+}

--- a/silverscript-lang/src/compiler/abi.rs
+++ b/silverscript-lang/src/compiler/abi.rs
@@ -169,9 +169,9 @@ fn contract_artifact_from_compiled<'i>(
         .iter()
         .filter(|function| function.entrypoint)
         .map(|function| {
-            let compiled_entry = compiled.entry_by_name(&function.name).ok_or_else(|| {
+            let dispatch_tag = compiled.dispatch_tags.get(&function.name).copied().ok_or_else(|| {
                 CompilerError::Unsupported(format!(
-                    "compiled contract '{}' has no ABI entry for function '{}'",
+                    "compiled contract '{}' has no dispatch tag for function '{}'",
                     compiled.contract_name, function.name
                 ))
             })?;
@@ -180,23 +180,23 @@ fn contract_artifact_from_compiled<'i>(
                 .iter()
                 .map(|param| Ok(ParamArtifact { name: param.name.clone(), ty: type_artifact(&param.type_ref, &constants)? }))
                 .collect::<Result<Vec<_>, CompilerError>>()?;
-            Ok(SilEntryArtifact { name: function.name.clone(), dispatch_tag: compiled_entry.dispatch_tag.into(), params })
+            Ok(SilEntryArtifact { name: function.name.clone(), dispatch_tag: dispatch_tag.into(), params })
         })
         .collect::<Result<Vec<_>, CompilerError>>()?;
-    let artifact_entry = |entry: &FunctionAbiEntry| {
-        entries.iter().find(|artifact| artifact.name == entry.name).cloned().ok_or_else(|| {
+    let artifact_entry = |entry_name: &str| {
+        entries.iter().find(|artifact| artifact.name == entry_name).cloned().ok_or_else(|| {
             CompilerError::Unsupported(format!(
                 "compiled contract '{}' has no portable ABI entry for generated function '{}'",
-                compiled.contract_name, entry.name
+                compiled.contract_name, entry_name
             ))
         })
     };
     let cov_decl_to_abi = compiled
-        .cov_decl_to_abi
+        .covenant_entrypoints
         .iter()
-        .map(|(name, entry)| Ok((name.clone(), artifact_entry(entry)?)))
+        .map(|(name, entrypoint)| Ok((name.clone(), artifact_entry(entrypoint)?)))
         .collect::<Result<_, CompilerError>>()?;
-    let delegate_entry_abi = compiled.delegate_entry_abi.as_ref().map(artifact_entry).transpose()?;
+    let delegate_entry_abi = compiled.delegate_entrypoint.as_deref().map(artifact_entry).transpose()?;
 
     let layout = compiled.state_layout;
     let state_end = checked_add(layout.start, layout.len)?;

--- a/silverscript-lang/src/compiler/abi.rs
+++ b/silverscript-lang/src/compiler/abi.rs
@@ -160,6 +160,20 @@ fn contract_artifact_from_compiled<'i>(
             Ok(SilEntryArtifact { name: function.name.clone(), dispatch_tag: compiled_entry.dispatch_tag.into(), params })
         })
         .collect::<Result<Vec<_>, CompilerError>>()?;
+    let artifact_entry = |entry: &FunctionAbiEntry| {
+        entries.iter().find(|artifact| artifact.name == entry.name).cloned().ok_or_else(|| {
+            CompilerError::Unsupported(format!(
+                "compiled contract '{}' has no portable ABI entry for generated function '{}'",
+                compiled.contract_name, entry.name
+            ))
+        })
+    };
+    let cov_decl_to_abi = compiled
+        .cov_decl_to_abi
+        .iter()
+        .map(|(name, entry)| Ok((name.clone(), artifact_entry(entry)?)))
+        .collect::<Result<_, CompilerError>>()?;
+    let delegate_entry_abi = compiled.delegate_entry_abi.as_ref().map(artifact_entry).transpose()?;
 
     let layout = compiled.state_layout;
     let state_end = checked_add(layout.start, layout.len)?;
@@ -178,6 +192,8 @@ fn contract_artifact_from_compiled<'i>(
         source_path: format!("sil/{}.sil", compiled.contract_name),
         runtime_state: RuntimeStateArtifact { source: STATE_TYPE_NAME.to_string(), fields: runtime_fields },
         entries,
+        cov_decl_to_abi,
+        delegate_entry_abi,
         compiled: CompiledContractArtifact {
             script_hex: encode_hex(&compiled.bytecode),
             template_hash_hex: encode_hex(&compiled.template_hash()),

--- a/silverscript-lang/src/compiler/abi.rs
+++ b/silverscript-lang/src/compiler/abi.rs
@@ -119,7 +119,15 @@ pub fn sil_abi_artifact_with_options(
     let contract = parse_contract_ast(source)?;
     let constructor_args = artifact_values_to_constructor_args(constructor_args, &contract)?;
     let compiled = compile_contract(source, &constructor_args, options)?;
-    let constants = artifact_constants(&compiled, &constructor_args);
+    sil_abi_artifact_from_compiled(&compiled, &constructor_args)
+}
+
+/// Builds a portable ABI artifact from an already compiled contract.
+pub fn sil_abi_artifact_from_compiled<'i>(
+    compiled: &CompiledContract<'i>,
+    constructor_args: &[Expr<'i>],
+) -> Result<SilAbiArtifact, CompilerError> {
+    let constants = artifact_constants(compiled, constructor_args);
     let states = compiled
         .ast
         .structs
@@ -133,11 +141,11 @@ pub fn sil_abi_artifact_with_options(
             Ok(StateArtifact { name: struct_.name.clone(), fields })
         })
         .collect::<Result<Vec<_>, CompilerError>>()?;
-    let contract = contract_artifact_from_compiled(&compiled, &constructor_args)?;
+    let contract = contract_artifact_from_compiled(compiled, constructor_args)?;
 
     Ok(SilAbiArtifact {
         schema_version: SIL_ABI_SCHEMA_VERSION,
-        compiler_version: compiled.compiler_version,
+        compiler_version: compiled.compiler_version.clone(),
         states,
         contracts: vec![contract],
     })

--- a/silverscript-lang/src/compiler/abi.rs
+++ b/silverscript-lang/src/compiler/abi.rs
@@ -1,16 +1,115 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use silverscript_abi::{
-    CompiledContractArtifact, FieldArtifact, ParamArtifact, RuntimeFieldArtifact, RuntimeStateArtifact, SIL_ABI_SCHEMA_VERSION,
-    SilAbiArtifact, SilContractArtifact, SilEntryArtifact, StateArtifact, StateSpanArtifact, TypeArtifact, encode_hex,
+    ArtifactValue, CompiledContractArtifact, FieldArtifact, ParamArtifact, RuntimeFieldArtifact, RuntimeStateArtifact,
+    SIL_ABI_SCHEMA_VERSION, SilAbiArtifact, SilContractArtifact, SilEntryArtifact, StateArtifact, StateSpanArtifact, TypeArtifact,
+    encode_hex,
 };
 
 use super::*;
 
+fn artifact_values_to_constructor_args<'i>(
+    values: &[ArtifactValue],
+    contract: &ContractAst<'i>,
+) -> Result<Vec<Expr<'i>>, CompilerError> {
+    if values.len() != contract.params.len() {
+        return Err(CompilerError::Unsupported(format!(
+            "constructor argument count mismatch: expected {}, got {}",
+            contract.params.len(),
+            values.len()
+        )));
+    }
+
+    values.iter().zip(&contract.params).map(|(value, param)| artifact_value_to_expr(value, &param.type_ref, contract)).collect()
+}
+
+/// Converts a portable ABI value to a concrete expression of the declared SilverScript type.
+pub fn artifact_value_to_expr<'i>(
+    value: &ArtifactValue,
+    expected_type: &TypeRef,
+    contract: &ContractAst<'i>,
+) -> Result<Expr<'i>, CompilerError> {
+    if expected_type.is_array() {
+        if matches!(expected_type.base, TypeBase::Byte) && expected_type.array_dims.len() == 1 {
+            let ArtifactValue::Bytes(bytes) = value else {
+                return Err(artifact_value_type_mismatch(value, expected_type));
+            };
+            return Ok(Expr::array(expected_type.clone(), bytes.iter().copied().map(Expr::byte).collect()));
+        }
+
+        let ArtifactValue::Array(values) = value else {
+            return Err(artifact_value_type_mismatch(value, expected_type));
+        };
+        let element_type = expected_type
+            .array_element_type()
+            .ok_or_else(|| CompilerError::Unsupported(format!("invalid array type '{}'", expected_type.type_name())))?;
+        let values = values
+            .iter()
+            .map(|value| artifact_value_to_expr(value, &element_type, contract))
+            .collect::<Result<Vec<_>, CompilerError>>()?;
+        return Ok(Expr::array(expected_type.clone(), values));
+    }
+
+    match (&expected_type.base, value) {
+        (TypeBase::Int, ArtifactValue::Int(value)) => Ok(Expr::int(*value)),
+        (TypeBase::Temporal, ArtifactValue::Int(value)) => Ok(Expr::temporal(*value)),
+        (TypeBase::Bool, ArtifactValue::Bool(value)) => Ok(Expr::bool(*value)),
+        (TypeBase::Byte, ArtifactValue::Byte(value)) => Ok(Expr::byte(*value)),
+        (TypeBase::String, ArtifactValue::Text(value)) => Ok(Expr::string(value)),
+        (TypeBase::Pubkey | TypeBase::Sig | TypeBase::Datasig, ArtifactValue::Bytes(value)) => Ok(Expr::bytes(value.clone())),
+        (TypeBase::Custom(name), ArtifactValue::Object(values)) => {
+            let struct_ = contract
+                .structs
+                .iter()
+                .find(|struct_| struct_.name == *name)
+                .ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{name}'")))?;
+            let expected_fields = struct_.fields.iter().map(|field| field.name.as_str()).collect::<HashSet<_>>();
+            if let Some(field) = values.keys().find(|field| !expected_fields.contains(field.as_str())) {
+                return Err(CompilerError::Unsupported(format!("unknown field '{name}.{field}'")));
+            }
+            let fields = struct_
+                .fields
+                .iter()
+                .map(|field| {
+                    let value = values
+                        .get(&field.name)
+                        .ok_or_else(|| CompilerError::Unsupported(format!("missing field '{name}.{}'", field.name)))?;
+                    Ok(StateFieldExpr {
+                        name: field.name.clone(),
+                        expr: artifact_value_to_expr(value, &field.type_ref, contract)?,
+                        span: Default::default(),
+                        name_span: Default::default(),
+                    })
+                })
+                .collect::<Result<Vec<_>, CompilerError>>()?;
+            Ok(Expr::new(ExprKind::StructLiteral { name: name.clone(), fields, name_span: Default::default() }, Default::default()))
+        }
+        (TypeBase::Tuple(_), _) => {
+            Err(CompilerError::Unsupported(format!("portable ABI values do not support tuple type '{}'", expected_type.type_name())))
+        }
+        _ => Err(artifact_value_type_mismatch(value, expected_type)),
+    }
+}
+
+fn artifact_value_type_mismatch(value: &ArtifactValue, expected_type: &TypeRef) -> CompilerError {
+    let actual = match value {
+        ArtifactValue::Int(_) => "int",
+        ArtifactValue::Bool(_) => "bool",
+        ArtifactValue::Byte(_) => "byte",
+        ArtifactValue::Bytes(_) => "bytes",
+        ArtifactValue::Text(_) => "string",
+        ArtifactValue::Array(_) => "array",
+        ArtifactValue::Object(_) => "object",
+    };
+    CompilerError::Unsupported(format!("cannot convert artifact {actual} to {}", expected_type.type_name()))
+}
+
 /// Compiles one SilverScript contract into a complete portable ABI artifact.
-pub fn sil_abi_artifact<'i>(source: &'i str, constructor_args: &[Expr<'i>]) -> Result<SilAbiArtifact, CompilerError> {
-    let compiled = compile_contract(source, constructor_args, CompileOptions::default())?;
-    let constants = artifact_constants(&compiled, constructor_args);
+pub fn sil_abi_artifact(source: &str, constructor_args: &[ArtifactValue]) -> Result<SilAbiArtifact, CompilerError> {
+    let contract = parse_contract_ast(source)?;
+    let constructor_args = artifact_values_to_constructor_args(constructor_args, &contract)?;
+    let compiled = compile_contract(source, &constructor_args, CompileOptions::default())?;
+    let constants = artifact_constants(&compiled, &constructor_args);
     let states = compiled
         .ast
         .structs
@@ -24,7 +123,7 @@ pub fn sil_abi_artifact<'i>(source: &'i str, constructor_args: &[Expr<'i>]) -> R
             Ok(StateArtifact { name: struct_.name.clone(), fields })
         })
         .collect::<Result<Vec<_>, CompilerError>>()?;
-    let contract = contract_artifact_from_compiled(&compiled, constructor_args)?;
+    let contract = contract_artifact_from_compiled(&compiled, &constructor_args)?;
 
     Ok(SilAbiArtifact { schema_version: SIL_ABI_SCHEMA_VERSION, states, contracts: vec![contract] })
 }

--- a/silverscript-lang/src/compiler/abi.rs
+++ b/silverscript-lang/src/compiler/abi.rs
@@ -106,9 +106,19 @@ fn artifact_value_type_mismatch(value: &ArtifactValue, expected_type: &TypeRef) 
 
 /// Compiles one SilverScript contract into a complete portable ABI artifact.
 pub fn sil_abi_artifact(source: &str, constructor_args: &[ArtifactValue]) -> Result<SilAbiArtifact, CompilerError> {
+    sil_abi_artifact_with_options(source, constructor_args, CompileOptions::default())
+}
+
+/// Compiles one SilverScript contract into a complete portable ABI artifact
+/// using the requested compiler options.
+pub fn sil_abi_artifact_with_options(
+    source: &str,
+    constructor_args: &[ArtifactValue],
+    options: CompileOptions,
+) -> Result<SilAbiArtifact, CompilerError> {
     let contract = parse_contract_ast(source)?;
     let constructor_args = artifact_values_to_constructor_args(constructor_args, &contract)?;
-    let compiled = compile_contract(source, &constructor_args, CompileOptions::default())?;
+    let compiled = compile_contract(source, &constructor_args, options)?;
     let constants = artifact_constants(&compiled, &constructor_args);
     let states = compiled
         .ast
@@ -125,7 +135,12 @@ pub fn sil_abi_artifact(source: &str, constructor_args: &[ArtifactValue]) -> Res
         .collect::<Result<Vec<_>, CompilerError>>()?;
     let contract = contract_artifact_from_compiled(&compiled, &constructor_args)?;
 
-    Ok(SilAbiArtifact { schema_version: SIL_ABI_SCHEMA_VERSION, states, contracts: vec![contract] })
+    Ok(SilAbiArtifact {
+        schema_version: SIL_ABI_SCHEMA_VERSION,
+        compiler_version: compiled.compiler_version,
+        states,
+        contracts: vec![contract],
+    })
 }
 
 fn contract_artifact_from_compiled<'i>(
@@ -187,6 +202,7 @@ fn contract_artifact_from_compiled<'i>(
         )));
     }
 
+    let template_hash = compiled.template_hash();
     Ok(SilContractArtifact {
         name: compiled.contract_name.clone(),
         source_path: format!("sil/{}.sil", compiled.contract_name),
@@ -195,8 +211,10 @@ fn contract_artifact_from_compiled<'i>(
         cov_decl_to_abi,
         delegate_entry_abi,
         compiled: CompiledContractArtifact {
+            bytecode: compiled.bytecode.clone(),
             script_hex: encode_hex(&compiled.bytecode),
-            template_hash_hex: encode_hex(&compiled.template_hash()),
+            template_hash,
+            template_hash_hex: encode_hex(&template_hash),
             state_span: StateSpanArtifact { offset: layout.start, len: layout.len },
         },
     })

--- a/silverscript-lang/src/compiler/compile.rs
+++ b/silverscript-lang/src/compiler/compile.rs
@@ -78,9 +78,9 @@ pub(super) fn compile_contract_impl<'i>(
     let mut lowered_constants = flatten_constructor_args_env(&covenant_lowered_contract.params, constructor_args, &structs)?;
     lowered_constants.extend(lowered_contract.constants.iter().map(|constant| (constant.name.clone(), constant.expr.clone())));
 
-    let BuiltAbi { function_abi_entries, cov_decl_to_abi, delegate_entry_abi } =
-        build_abi(&covenant_lowered_contract, &constants, &structs, &covenant_abi_names)?;
-    if function_abi_entries.is_empty() {
+    let EntrypointMetadata { dispatches, covenant_entrypoints, delegate_entrypoint } =
+        build_entrypoint_metadata(&covenant_lowered_contract, &constants, &structs, &covenant_abi_names)?;
+    if dispatches.is_empty() {
         return Err(CompilerError::Unsupported("contract has no entries".to_string()));
     }
     let entrypoint_functions: Vec<&FunctionAst<'i>> = lowered_contract.functions.iter().filter(|func| func.entrypoint).collect();
@@ -89,7 +89,7 @@ pub(super) fn compile_contract_impl<'i>(
 
     // dispatch tag: verify no collisions and insert tags to global state
     let mut entrypoints_by_tag = HashMap::<DispatchTag, &str>::new();
-    for entrypoint in &function_abi_entries {
+    for entrypoint in &dispatches {
         let tag = entrypoint.dispatch_tag;
         if let Some(existing) = entrypoints_by_tag.insert(tag, entrypoint.name.as_str()) {
             return Err(CompilerError::EntrypointDispatchTagCollision { f1: existing.to_string(), f2: entrypoint.name.clone() });
@@ -107,7 +107,7 @@ pub(super) fn compile_contract_impl<'i>(
             &lowered_contract,
             &lowered_constants,
             bytecode_size,
-            &function_abi_entries,
+            &dispatches,
             &structs,
             &struct_array_param_groups,
             &mut debug_recorder,
@@ -118,9 +118,9 @@ pub(super) fn compile_contract_impl<'i>(
             return Ok(build_compiled_contract(
                 &lowered_contract,
                 &artifact_contract,
-                function_abi_entries.clone(),
-                &cov_decl_to_abi,
-                delegate_entry_abi.as_ref(),
+                &dispatches,
+                &covenant_entrypoints,
+                delegate_entrypoint.as_deref(),
                 bytecode,
                 state_layout,
                 debug_info,
@@ -132,9 +132,9 @@ pub(super) fn compile_contract_impl<'i>(
             return Ok(build_compiled_contract(
                 &lowered_contract,
                 &artifact_contract,
-                function_abi_entries.clone(),
-                &cov_decl_to_abi,
-                delegate_entry_abi.as_ref(),
+                &dispatches,
+                &covenant_entrypoints,
+                delegate_entrypoint.as_deref(),
                 bytecode,
                 state_layout,
                 debug_info,
@@ -250,7 +250,7 @@ fn compile_contract_bytecode_iteration<'i>(
     lowered_contract: &ContractAst<'i>,
     lowered_constants: &HashMap<String, Expr<'i>>,
     bytecode_size: Option<i64>,
-    function_abi_entries: &[FunctionAbiEntry],
+    dispatches: &[EntrypointDispatch],
     structs: &StructRegistry,
     struct_array_param_groups: &StructArrayParamGroups,
     debug_recorder: &mut DebugRecorder<'i>,
@@ -273,7 +273,7 @@ fn compile_contract_bytecode_iteration<'i>(
         bytecode_size,
         debug_recorder,
     )?;
-    let bytecode = build_contract_bytecode(debug_recorder, &state_push_bytecode, &compiled_entrypoints, function_abi_entries)?;
+    let bytecode = build_contract_bytecode(debug_recorder, &state_push_bytecode, &compiled_entrypoints, dispatches)?;
     let entrypoints = lowered_contract.functions.iter().filter(|function| function.entrypoint).collect::<Vec<_>>();
     validate_signature_script_limits(&bytecode, &entrypoints, lowered_constants)?;
     Ok((bytecode, state_layout))
@@ -313,7 +313,7 @@ fn build_contract_bytecode(
     debug_recorder: &mut DebugRecorder<'_>,
     state_push_bytecode: &[u8],
     compiled_entrypoints: &[(String, Vec<u8>)],
-    function_abi_entries: &[FunctionAbiEntry],
+    dispatches: &[EntrypointDispatch],
 ) -> Result<Vec<u8>, CompilerError> {
     let mut builder = script_builder();
     if !state_push_bytecode.is_empty() {
@@ -326,7 +326,7 @@ fn build_contract_bytecode(
     let total = compiled_entrypoints.len();
 
     let dispatch_tag_by_entry_name =
-        function_abi_entries.iter().map(|entry| (entry.name.as_str(), entry.dispatch_tag)).collect::<HashMap<_, _>>();
+        dispatches.iter().map(|entry| (entry.name.as_str(), entry.dispatch_tag)).collect::<HashMap<_, _>>();
 
     for (entrypoint_index, (name, bytecode)) in compiled_entrypoints.iter().enumerate() {
         let dispatch_tag = dispatch_tag_by_entry_name.get(name.as_str()).expect("compiled entrypoint must have an ABI entry");
@@ -353,9 +353,9 @@ fn build_contract_bytecode(
 fn build_compiled_contract<'i>(
     lowered_contract: &ContractAst<'i>,
     covenant_lowered_contract: &ContractAst<'i>,
-    function_abi_entries: Vec<FunctionAbiEntry>,
-    cov_decl_to_abi: &BTreeMap<String, FunctionAbiEntry>,
-    delegate_entry_abi: Option<&FunctionAbiEntry>,
+    dispatches: &[EntrypointDispatch],
+    covenant_entrypoints: &BTreeMap<String, String>,
+    delegate_entrypoint: Option<&str>,
     bytecode: Vec<u8>,
     state_layout: CompiledStateLayout,
     debug_info: Option<DebugInfo<'i>>,
@@ -365,9 +365,9 @@ fn build_compiled_contract<'i>(
         compiler_version: COMPILER_VERSION.to_string(),
         bytecode,
         ast: covenant_lowered_contract.clone(),
-        abi: function_abi_entries,
-        cov_decl_to_abi: cov_decl_to_abi.clone(),
-        delegate_entry_abi: delegate_entry_abi.cloned(),
+        dispatch_tags: dispatches.iter().map(|entry| (entry.name.clone(), entry.dispatch_tag)).collect(),
+        covenant_entrypoints: covenant_entrypoints.clone(),
+        delegate_entrypoint: delegate_entrypoint.map(str::to_string),
         state_layout,
         debug_info,
     }

--- a/silverscript-lang/src/compiler/compile/helpers.rs
+++ b/silverscript-lang/src/compiler/compile/helpers.rs
@@ -270,20 +270,20 @@ pub(super) fn encode_value_with_constant_size<'i>(
         }
         _ => {
             // Handle fixed-size byte arrays like byte[N]
-            if let (Some(inner_type), Some(size)) = (type_ref.array_element_type(), array_type_size(type_ref, constants)?) {
-                if inner_type.is_byte() {
-                    let ExprKind::Array { values, .. } = &value.kind else {
-                        return Err(array_literal_encoding_error(value));
-                    };
-                    if values.len() != size {
-                        return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
-                    }
-                    return values
-                        .iter()
-                        .map(|value| encode_value_with_constant_size(value, &inner_type, constants))
-                        .collect::<Result<Vec<_>, _>>()
-                        .map(|chunks| chunks.concat());
+            if let (Some(inner_type), Some(size)) = (type_ref.array_element_type(), array_type_size(type_ref, constants)?)
+                && inner_type.is_byte()
+            {
+                let ExprKind::Array { values, .. } = &value.kind else {
+                    return Err(array_literal_encoding_error(value));
+                };
+                if values.len() != size {
+                    return Err(CompilerError::Unsupported("array literal element type mismatch".to_string()));
                 }
+                return values
+                    .iter()
+                    .map(|value| encode_value_with_constant_size(value, &inner_type, constants))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(|chunks| chunks.concat());
             }
 
             // Handle nested fixed-size arrays with known element sizes.

--- a/silverscript-lang/src/compiler/compile/helpers.rs
+++ b/silverscript-lang/src/compiler/compile/helpers.rs
@@ -1,10 +1,10 @@
 use super::*;
 use crate::compiler::covenant_declarations::CovenantDeclarationAbiNames;
 
-pub(super) struct BuiltAbi {
-    pub(super) function_abi_entries: Vec<FunctionAbiEntry>,
-    pub(super) cov_decl_to_abi: BTreeMap<String, FunctionAbiEntry>,
-    pub(super) delegate_entry_abi: Option<FunctionAbiEntry>,
+pub(super) struct EntrypointMetadata {
+    pub(super) dispatches: Vec<EntrypointDispatch>,
+    pub(super) covenant_entrypoints: BTreeMap<String, String>,
+    pub(super) delegate_entrypoint: Option<String>,
 }
 
 pub(super) fn compile_contract_fields<'i>(
@@ -98,67 +98,62 @@ fn write_dispatch_type_name<'i>(
     Ok(())
 }
 
-pub(super) fn build_abi<'i>(
+pub(super) fn build_entrypoint_metadata<'i>(
     contract: &ContractAst<'i>,
     constants: &HashMap<String, Expr<'i>>,
     structs: &StructRegistry,
     covenant_abi_names: &CovenantDeclarationAbiNames,
-) -> Result<BuiltAbi, CompilerError> {
+) -> Result<EntrypointMetadata, CompilerError> {
     let source_name_by_entrypoint = covenant_abi_names
         .entrypoints
         .iter()
         .map(|(source_name, entrypoint_name)| (entrypoint_name.as_str(), source_name.as_str()))
         .collect::<HashMap<_, _>>();
     let delegate_entrypoint = covenant_abi_names.delegate_entrypoint.as_deref();
-    let mut function_abi_entries = Vec::new();
-    let mut cov_decl_to_abi = BTreeMap::new();
-    let mut delegate_entry_abi = None;
+    let mut dispatches = Vec::new();
+    let mut covenant_entrypoints = BTreeMap::new();
+    let mut built_delegate_entrypoint = None;
 
     for func in contract.functions.iter().filter(|func| func.entrypoint) {
-        let input_specs = func
+        let signature_types = func
             .params
             .iter()
             .map(|param| {
                 let type_ref = resolve_abi_type_ref(&param.type_ref, constants, &func.name, &param.name)?;
-                let type_name = type_ref.type_name();
                 let mut signature_type = String::new();
                 write_dispatch_type_name(&type_ref, structs, constants, &mut signature_type)?;
-                Ok((FunctionInputAbi { name: param.name.clone(), type_name }, signature_type))
+                Ok(signature_type)
             })
             .collect::<Result<Vec<_>, CompilerError>>()?;
-        let (inputs, signature_types): (Vec<_>, Vec<_>) = input_specs.into_iter().unzip();
-
-        // dispatch tag creation
         let signature = format!("{}({})", func.name, signature_types.join(","));
         let hash = blake3::hash(signature.as_bytes());
-        let mut dispatch_tag = [0u8; 4];
+        let mut dispatch_tag = [0; 4];
         dispatch_tag.copy_from_slice(&hash.as_bytes()[..4]);
-
-        let entry = FunctionAbiEntry { name: func.name.clone(), inputs, dispatch_tag };
+        let entry = EntrypointDispatch { name: func.name.clone(), dispatch_tag };
 
         if let Some(source_name) = source_name_by_entrypoint.get(func.name.as_str()) {
-            cov_decl_to_abi.insert((*source_name).to_string(), entry.clone());
+            covenant_entrypoints.insert((*source_name).to_string(), func.name.clone());
         }
         if delegate_entrypoint == Some(func.name.as_str()) {
-            delegate_entry_abi = Some(entry.clone());
+            built_delegate_entrypoint = Some(func.name.clone());
         }
-        function_abi_entries.push(entry);
+        dispatches.push(entry);
     }
 
     if let Some((source_name, entrypoint_name)) =
-        covenant_abi_names.entrypoints.iter().find(|(source_name, _)| !cov_decl_to_abi.contains_key(*source_name))
+        covenant_abi_names.entrypoints.iter().find(|(source_name, _)| !covenant_entrypoints.contains_key(*source_name))
     {
         return Err(CompilerError::Unsupported(format!(
-            "generated covenant entrypoint '{entrypoint_name}' for declaration '{source_name}' is missing from the ABI"
+            "generated covenant entrypoint '{entrypoint_name}' for declaration '{source_name}' is missing from dispatch metadata"
         )));
     }
-    if let Some(entrypoint_name) = delegate_entrypoint.filter(|_| delegate_entry_abi.is_none()) {
+    if let Some(entrypoint_name) = delegate_entrypoint.filter(|_| built_delegate_entrypoint.is_none()) {
         return Err(CompilerError::Unsupported(format!(
-            "generated covenant delegate entrypoint '{entrypoint_name}' is missing from the ABI"
+            "generated covenant delegate entrypoint '{entrypoint_name}' is missing from dispatch metadata"
         )));
     }
 
-    Ok(BuiltAbi { function_abi_entries, cov_decl_to_abi, delegate_entry_abi })
+    Ok(EntrypointMetadata { dispatches, covenant_entrypoints, delegate_entrypoint: built_delegate_entrypoint })
 }
 
 pub(super) fn resolve_artifact_struct_type_refs<'i>(

--- a/silverscript-lang/src/compiler/debug_recording.rs
+++ b/silverscript-lang/src/compiler/debug_recording.rs
@@ -351,11 +351,9 @@ impl<'i> DebugRecorder<'i> {
             (active.start_statement_slot(stmt, bytecode_start), true)
         };
 
-        if is_new_slot {
-            if let Some(entrypoint) = active.active_entrypoint_mut() {
-                entrypoint.emit_inline_call_resumes(slot.statement_index, bytecode_start);
-                entrypoint.emit_inline_call_enters(slot.statement_index, bytecode_start);
-            }
+        if is_new_slot && let Some(entrypoint) = active.active_entrypoint_mut() {
+            entrypoint.emit_inline_call_resumes(slot.statement_index, bytecode_start);
+            entrypoint.emit_inline_call_enters(slot.statement_index, bytecode_start);
         }
         active.statement_debug_state_stack.push(slot);
     }

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use crate::checked_arithmetic::{checked_add, checked_div, checked_mul
 use crate::debug_info::{DebugInfo, DebugNamedValue};
 pub use crate::errors::{CompilerError, ErrorSpan};
 use crate::span;
+mod abi;
 mod array_append;
 mod builtin_types;
 mod compile;
@@ -31,6 +32,7 @@ mod type_check;
 mod type_system;
 mod validate_output_state;
 
+pub use abi::sil_abi_artifact;
 use compile::compile_contract_impl;
 pub use compile::compile_debug_expr;
 pub(crate) use compile::resolve_constant_references;

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -1,7 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
 
-use kaspa_txscript::EngineFlags;
-use kaspa_txscript::script_builder::ScriptBuilder;
 use serde::{Deserialize, Serialize};
 
 use crate::ast::{
@@ -89,16 +87,9 @@ pub struct CompileOptions {
     pub record_debug_infos: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct FunctionInputAbi {
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EntrypointDispatch {
     pub name: String,
-    pub type_name: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct FunctionAbiEntry {
-    pub name: String,
-    pub inputs: Vec<FunctionInputAbi>,
     pub dispatch_tag: DispatchTag,
 }
 
@@ -116,13 +107,13 @@ pub struct CompiledContract<'i> {
     pub compiler_version: String,
     pub bytecode: Vec<u8>,
     pub ast: ContractAst<'i>,
-    pub abi: Vec<FunctionAbiEntry>,
-    /// Public leader/auth ABI entries keyed by their pre-lowering covenant declaration names.
+    pub dispatch_tags: BTreeMap<String, DispatchTag>,
+    /// Generated leader/auth entrypoint names keyed by their pre-lowering covenant declaration names.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub cov_decl_to_abi: BTreeMap<String, FunctionAbiEntry>,
-    /// The shared delegate ABI entry generated for a cov-bound contract.
+    covenant_entrypoints: BTreeMap<String, String>,
+    /// The shared delegate entrypoint generated for a cov-bound contract.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub delegate_entry_abi: Option<FunctionAbiEntry>,
+    delegate_entrypoint: Option<String>,
     pub state_layout: CompiledStateLayout,
     pub debug_info: Option<DebugInfo<'i>>,
 }
@@ -212,261 +203,11 @@ pub fn struct_object<'i>(name: &str, fields: Vec<(&str, Expr<'i>)>) -> Expr<'i> 
 }
 
 impl<'i> CompiledContract<'i> {
-    pub fn entry_by_name(&self, name: &str) -> Option<&FunctionAbiEntry> {
-        self.abi.iter().find(|entry| entry.name == name)
-    }
-
     /// Calculate the canonical hash of this contract's state template.
     pub fn template_hash(&self) -> [u8; 32] {
         let state_end = self.state_layout.start + self.state_layout.len;
         crate::template::template_hash(&self.bytecode[..self.state_layout.start], &self.bytecode[state_end..])
     }
-
-    pub fn build_sig_script(&self, function_name: &str, args: Vec<Expr<'i>>) -> Result<Vec<u8>, CompilerError> {
-        let structs = build_struct_registry(&self.ast)?;
-        // ABI parameter types and artifact struct fields have already had
-        // constant array dimensions resolved to fixed dimensions during
-        // compilation, so argument validation does not need a constants map.
-        let constants = HashMap::new();
-        let function = self
-            .entry_by_name(function_name)
-            .ok_or_else(|| CompilerError::Unsupported(format!("function '{}' not found", function_name)))?;
-
-        if function.inputs.len() != args.len() {
-            return Err(CompilerError::Unsupported(format!(
-                "function '{}' expects {} arguments",
-                function_name,
-                function.inputs.len()
-            )));
-        }
-
-        let mut builder = ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() });
-        for (input, arg) in function.inputs.iter().zip(args) {
-            let type_ref = parse_type_ref(&input.type_name)?;
-            push_typed_sigscript_arg(&mut builder, arg, &type_ref, &structs, &constants).map_err(|err| {
-                CompilerError::Unsupported(format!("function argument '{}' expects {} ({err})", input.name, input.type_name))
-            })?;
-        }
-
-        builder.add_data(&function.dispatch_tag)?;
-
-        Ok(builder.drain())
-    }
-
-    pub fn build_sig_script_for_covenant_decl(
-        &self,
-        function_name: &str,
-        args: Vec<Expr<'i>>,
-        options: CovenantDeclCallOptions,
-    ) -> Result<Vec<u8>, CompilerError> {
-        let entrypoint = self.covenant_decl_entrypoint_name(function_name, options.is_leader).ok_or_else(|| {
-            let metadata_hint = if self.cov_decl_to_abi.is_empty() {
-                "; the compiled artifact may use an outdated schema without covenant declaration ABI metadata"
-            } else {
-                ""
-            };
-            CompilerError::Unsupported(format!("covenant declaration '{function_name}' not found{metadata_hint}"))
-        })?;
-        self.build_sig_script(entrypoint, args)
-    }
-
-    /// Resolves a source covenant declaration to its final public ABI entrypoint.
-    /// For cov-bound declarations, `is_leader` selects the leader or shared
-    /// delegate wrapper. Auth-bound declarations resolve to the same wrapper in
-    /// either case.
-    pub fn covenant_decl_entrypoint_name(&self, function_name: &str, is_leader: bool) -> Option<&str> {
-        let entry = self.cov_decl_to_abi.get(function_name)?;
-        if is_leader || self.delegate_entry_abi.is_none() {
-            return Some(entry.name.as_str());
-        }
-
-        self.delegate_entry_abi.as_ref().map(|entry| entry.name.as_str())
-    }
-}
-
-fn push_typed_sigscript_arg<'i>(
-    builder: &mut ScriptBuilder,
-    arg: Expr<'i>,
-    type_ref: &TypeRef,
-    structs: &StructRegistry,
-    constants: &HashMap<String, Expr<'i>>,
-) -> Result<(), CompilerError> {
-    validate_sigscript_arg(&arg, type_ref, structs, constants)?;
-
-    if is_struct_array(type_ref, structs) {
-        return push_struct_array_sigscript_arg(builder, arg, type_ref, structs, constants);
-    }
-
-    if is_struct(type_ref, structs) {
-        return push_struct_sigscript_arg(builder, arg, structs, constants);
-    }
-
-    if type_ref.is_array() {
-        return push_array_sigscript_arg(builder, arg, type_ref, constants);
-    }
-
-    push_sigscript_non_array_arg(builder, arg)
-}
-
-fn validate_sigscript_arg<'i>(
-    arg: &Expr<'i>,
-    type_ref: &TypeRef,
-    structs: &StructRegistry,
-    constants: &HashMap<String, Expr<'i>>,
-) -> Result<(), CompilerError> {
-    // Signature-script construction receives already classified AST values.
-    // Unlike source-language checking, do not reinterpret an integer literal
-    // as a byte: callers must use Expr::byte so encoding retains byte semantics.
-    validate_explicit_sigscript_bytes(arg, type_ref)?;
-
-    let types = HashMap::new();
-    let functions = HashMap::new();
-    let type_context = type_check::TypeCheckContext { types: &types, structs, constants, functions: &functions, contract_fields: &[] };
-    type_check::check_expr(arg, Some(type_ref), &type_context)?;
-    Ok(())
-}
-
-fn validate_explicit_sigscript_bytes(arg: &Expr<'_>, type_ref: &TypeRef) -> Result<(), CompilerError> {
-    if !matches!(type_ref.base, TypeBase::Byte) {
-        return Ok(());
-    }
-
-    if type_ref.is_byte() {
-        return if matches!(arg.kind, ExprKind::Byte(_)) { Ok(()) } else { Err(CompilerError::TypeMismatch) };
-    }
-
-    if let (Some(element_type), ExprKind::Array { values, .. }) = (type_ref.array_element_type(), &arg.kind) {
-        for value in values {
-            validate_explicit_sigscript_bytes(value, &element_type)?;
-        }
-    }
-    Ok(())
-}
-
-fn push_struct_sigscript_arg<'i>(
-    builder: &mut ScriptBuilder,
-    arg: Expr<'i>,
-    structs: &StructRegistry,
-    constants: &HashMap<String, Expr<'i>>,
-) -> Result<(), CompilerError> {
-    let ExprKind::StructLiteral { name, fields, .. } = arg.kind else {
-        return Err(CompilerError::Unsupported("signature script struct arguments must be object literals".to_string()));
-    };
-    let item = structs.get(&name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{name}'")))?;
-    let mut provided = fields.into_iter().map(|field| (field.name, field.expr)).collect::<HashMap<_, _>>();
-
-    for field in &item.fields {
-        let value = provided
-            .remove(&field.name)
-            .ok_or_else(|| CompilerError::Unsupported(format!("struct field '{}' must be initialized", field.name)))?;
-        push_typed_sigscript_arg(builder, value, &field.type_ref, structs, constants)?;
-    }
-
-    if let Some(extra) = provided.keys().next() {
-        return Err(CompilerError::Unsupported(format!("unknown struct field '{}'", extra)));
-    }
-    Ok(())
-}
-
-fn push_struct_array_sigscript_arg<'i>(
-    builder: &mut ScriptBuilder,
-    arg: Expr<'i>,
-    type_ref: &TypeRef,
-    structs: &StructRegistry,
-    constants: &HashMap<String, Expr<'i>>,
-) -> Result<(), CompilerError> {
-    let element_type = type_ref
-        .array_element_type()
-        .ok_or_else(|| CompilerError::Unsupported("signature script struct array argument requires an array type".to_string()))?;
-    let struct_name = struct_name(&element_type, structs).ok_or_else(|| {
-        CompilerError::Unsupported("signature script struct array argument requires a struct element type".to_string())
-    })?;
-    let item = structs.get(struct_name).ok_or_else(|| CompilerError::Unsupported(format!("unknown struct '{struct_name}'")))?;
-    let dimension = type_ref
-        .array_size()
-        .cloned()
-        .ok_or_else(|| CompilerError::Unsupported("signature script struct array argument requires an array type".to_string()))?;
-    let ExprKind::Array { values, .. } = arg.kind else {
-        return Err(CompilerError::Unsupported("signature script struct array arguments must be array literals".to_string()));
-    };
-
-    let mut objects = Vec::with_capacity(values.len());
-    for value in values {
-        let ExprKind::StructLiteral { name, fields: entries, .. } = value.kind else {
-            return Err(CompilerError::Unsupported(
-                "signature script struct array arguments must contain object literals".to_string(),
-            ));
-        };
-        if name != struct_name {
-            return Err(CompilerError::Unsupported(format!("expected struct '{struct_name}', got '{name}'")));
-        }
-        objects.push(entries.into_iter().map(|entry| (entry.name, entry.expr)).collect::<HashMap<_, _>>());
-    }
-
-    for field in &item.fields {
-        let field_values = objects
-            .iter_mut()
-            .map(|fields| {
-                fields
-                    .remove(&field.name)
-                    .ok_or_else(|| CompilerError::Unsupported(format!("struct field '{}' must be initialized", field.name)))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-        let mut field_type = field.type_ref.clone();
-        field_type.array_dims.push(dimension.clone());
-        push_typed_sigscript_arg(builder, Expr::array(field_type.clone(), field_values), &field_type, structs, constants)?;
-    }
-
-    if let Some(extra) = objects.iter().find_map(|fields| fields.keys().next()) {
-        return Err(CompilerError::Unsupported(format!("unknown struct field '{}'", extra)));
-    }
-    Ok(())
-}
-
-fn push_array_sigscript_arg<'i>(
-    builder: &mut ScriptBuilder,
-    arg: Expr<'i>,
-    type_ref: &TypeRef,
-    constants: &HashMap<String, Expr<'i>>,
-) -> Result<(), CompilerError> {
-    match &arg.kind {
-        ExprKind::Array { values, .. } => {
-            let bytes = compile::encode_array_literal(values, type_ref, constants)?;
-            builder.add_data(&bytes)?;
-            Ok(())
-        }
-        _ => Err(CompilerError::Unsupported("signature script arguments must be literals".to_string())),
-    }
-}
-
-fn push_sigscript_non_array_arg<'i>(builder: &mut ScriptBuilder, arg: Expr<'i>) -> Result<(), CompilerError> {
-    match arg.kind {
-        ExprKind::Int(value) | ExprKind::Temporal(value) => {
-            builder.add_i64(value)?;
-        }
-        ExprKind::Bool(value) => {
-            builder.add_i64(if value { 1 } else { 0 })?;
-        }
-        ExprKind::String(value) => {
-            builder.add_data(value.as_bytes())?;
-        }
-        ExprKind::Byte(value) => {
-            builder.add_data(&[value])?;
-        }
-        // This is not intended for byte-arrays, but for pubkey, datasig, etc.
-        ExprKind::Array { values, .. } if values.iter().all(|value| matches!(&value.kind, ExprKind::Byte(_))) => {
-            let bytes: Vec<u8> =
-                values.iter().filter_map(|value| if let ExprKind::Byte(byte) = &value.kind { Some(*byte) } else { None }).collect();
-            builder.add_data(&bytes)?;
-        }
-        ExprKind::DateLiteral(value) => {
-            builder.add_i64(value)?;
-        }
-        _ => {
-            return Err(CompilerError::Unsupported("signature script arguments must be literals".to_string()));
-        }
-    }
-    Ok(())
 }
 
 fn binary_expr<'i>(op: BinaryOp, left: Expr<'i>, right: Expr<'i>) -> Expr<'i> {

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -30,7 +30,9 @@ mod type_check;
 mod type_system;
 mod validate_output_state;
 
-pub use abi::{artifact_value_to_expr, sil_abi_artifact, sil_abi_artifact_from_compiled, sil_abi_artifact_with_options};
+pub use abi::{
+    artifact_value_to_expr, compile_to_sil_abi_artifact, compile_to_sil_abi_artifact_with_options, sil_abi_artifact_from_compiled,
+};
 use compile::compile_contract_impl;
 pub use compile::compile_debug_expr;
 pub(crate) use compile::resolve_constant_references;

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -32,7 +32,7 @@ mod type_check;
 mod type_system;
 mod validate_output_state;
 
-pub use abi::{artifact_value_to_expr, sil_abi_artifact, sil_abi_artifact_with_options};
+pub use abi::{artifact_value_to_expr, sil_abi_artifact, sil_abi_artifact_from_compiled, sil_abi_artifact_with_options};
 use compile::compile_contract_impl;
 pub use compile::compile_debug_expr;
 pub(crate) use compile::resolve_constant_references;

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -32,7 +32,7 @@ mod type_check;
 mod type_system;
 mod validate_output_state;
 
-pub use abi::sil_abi_artifact;
+pub use abi::{artifact_value_to_expr, sil_abi_artifact};
 use compile::compile_contract_impl;
 pub use compile::compile_debug_expr;
 pub(crate) use compile::resolve_constant_references;

--- a/silverscript-lang/src/compiler/mod.rs
+++ b/silverscript-lang/src/compiler/mod.rs
@@ -32,7 +32,7 @@ mod type_check;
 mod type_system;
 mod validate_output_state;
 
-pub use abi::{artifact_value_to_expr, sil_abi_artifact};
+pub use abi::{artifact_value_to_expr, sil_abi_artifact, sil_abi_artifact_with_options};
 use compile::compile_contract_impl;
 pub use compile::compile_debug_expr;
 pub(crate) use compile::resolve_constant_references;

--- a/silverscript-lang/src/compiler/static_check.rs
+++ b/silverscript-lang/src/compiler/static_check.rs
@@ -796,10 +796,10 @@ fn validate_require_age_daa_statement_shape<'i>(
     expr: &Expr<'i>,
 ) -> Result<(), CompilerError> {
     ctx.check_expr(expr, Some(&TypeRef { base: TypeBase::Int, array_dims: Vec::new() }))?;
-    if let Some(value) = eval_optional_const_int(expr, ctx.constants)? {
-        if !(0..(1_i64 << 32)).contains(&value) {
-            return Err(CompilerError::Unsupported(format!("this.ageDaa value must satisfy 0 <= value < 2^32, got {value}")));
-        }
+    if let Some(value) = eval_optional_const_int(expr, ctx.constants)?
+        && !(0..(1_i64 << 32)).contains(&value)
+    {
+        return Err(CompilerError::Unsupported(format!("this.ageDaa value must satisfy 0 <= value < 2^32, got {value}")));
     }
     Ok(())
 }

--- a/silverscript-lang/src/compiler/structs/scalar_expr.rs
+++ b/silverscript-lang/src/compiler/structs/scalar_expr.rs
@@ -80,10 +80,10 @@ pub(super) fn lower_scalar_expr<'i>(
                 let left_type = scalar_struct_expr_type(left, scope, structs);
                 let right_type = scalar_struct_expr_type(right, scope, structs);
                 if let Some(expected_type) = left_type.as_ref().or(right_type.as_ref()) {
-                    if let Some((left, right)) = left_type.as_ref().zip(right_type.as_ref()) {
-                        if !type_refs_equal(left, right, lowerer.contract_constants)? {
-                            return Err(CompilerError::Unsupported("struct comparison requires matching types".to_string()));
-                        }
+                    if let Some((left, right)) = left_type.as_ref().zip(right_type.as_ref())
+                        && !type_refs_equal(left, right, lowerer.contract_constants)?
+                    {
+                        return Err(CompilerError::Unsupported("struct comparison requires matching types".to_string()));
                     }
                     let left_leaves = lower_struct_expr(left, expected_type, scope, lowerer)?;
                     let right_leaves = lower_struct_expr(right, expected_type, scope, lowerer)?;

--- a/silverscript-lang/tests/cashc_valid_examples_tests.rs
+++ b/silverscript-lang/tests/cashc_valid_examples_tests.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use blake2b_simd::Params;
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
 use kaspa_consensus_core::hashing::sighash::calc_schnorr_signature_hash;
@@ -12,8 +14,8 @@ use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::{EngineCtx, EngineFlags, TxScriptEngine, pay_to_script_hash_script};
 use rand::{RngCore, thread_rng};
 use secp256k1::{Keypair, Message, Secp256k1, SecretKey};
-use silverscript_lang::ast::Expr;
-use silverscript_lang::compiler::{CompileOptions, CompiledContract, DispatchTag, compile_contract};
+use silverscript_abi::{ArtifactValue, SilAbiArtifact};
+use silverscript_lang::compiler::{DispatchTag, sil_abi_artifact};
 use std::fs;
 
 fn load_example_source(name: &str) -> String {
@@ -42,12 +44,12 @@ fn parse_contract_param_types(source: &str) -> Vec<String> {
     result
 }
 
-fn dummy_expr_for_type(type_name: &str) -> Expr<'static> {
+fn dummy_artifact_value_for_type(type_name: &str) -> ArtifactValue {
     if type_name == "int" {
         return 0i64.into();
     }
     if type_name == "temporal" {
-        return Expr::temporal(kaspa_txscript::LOCK_TIME_THRESHOLD as i64);
+        return (kaspa_txscript::LOCK_TIME_THRESHOLD as i64).into();
     }
     if type_name == "bool" {
         return false.into();
@@ -56,10 +58,10 @@ fn dummy_expr_for_type(type_name: &str) -> Expr<'static> {
         return String::from("aa").into();
     }
     if type_name == "byte[]" {
-        return Expr::dynamic_bytes(Vec::new());
+        return Vec::<u8>::new().into();
     }
     if type_name == "pubkey" {
-        return vec![0u8; 32].into(); // Converts to Expr::Array of Expr::Byte
+        return vec![0u8; 32].into();
     }
     if type_name == "sig" {
         return vec![0u8; 65].into();
@@ -127,8 +129,18 @@ fn build_sigscript(args: &[ArgValue], dispatch_tag: DispatchTag) -> Vec<u8> {
     builder.drain()
 }
 
-fn dispatch_tag_for_compiled(compiled: &CompiledContract<'_>, function_name: &str) -> DispatchTag {
-    compiled.entry_by_name(function_name).expect("entrypoint resolved").dispatch_tag
+fn dispatch_tag(artifact: &SilAbiArtifact, function_name: &str) -> DispatchTag {
+    let [contract] = artifact.contracts.as_slice() else {
+        panic!("expected one contract, found {}", artifact.contracts.len());
+    };
+    contract.entry(function_name).expect("entrypoint resolved").dispatch_tag.into_bytes()
+}
+
+fn bytecode(artifact: &SilAbiArtifact) -> &Vec<u8> {
+    let [contract] = artifact.contracts.as_slice() else {
+        panic!("expected one contract, found {}", artifact.contracts.len());
+    };
+    &contract.compiled.bytecode
 }
 
 fn build_p2pk_script(pubkey: &[u8]) -> Vec<u8> {
@@ -263,12 +275,12 @@ fn runs_cashc_valid_examples() {
         match example {
             "bitwise.sil" => {
                 let constructor_args = vec![vec![0u8; 8].into(), vec![0u8; 8].into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -279,12 +291,12 @@ fn runs_cashc_valid_examples() {
             }
             "bytes1_equals_byte.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Byte(1)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -295,10 +307,10 @@ fn runs_cashc_valid_examples() {
             }
             "cast_hash_checksig.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -306,8 +318,8 @@ fn runs_cashc_valid_examples() {
                 let keypair = random_keypair();
                 let pubkey_bytes = keypair.x_only_public_key().0.serialize().to_vec();
                 let signature = sign_tx(&tx, &reused, &keypair);
-                let sigscript =
-                    compiled.build_sig_script("hello", vec![pubkey_bytes.into(), signature.clone().into()]).expect("sigscript builds");
+                let sigscript = common::encode_entry_sig_script(&compiled, "hello", &[pubkey_bytes.into(), signature.clone().into()])
+                    .expect("sigscript builds");
                 tx.tx.inputs[0].signature_script = sigscript;
                 let result = execute_tx(tx, utxo, reused);
                 assert!(result.is_ok(), "{example} failed: {}", result.unwrap_err());
@@ -315,11 +327,11 @@ fn runs_cashc_valid_examples() {
             "comments.sil" => {
                 // Unsatisfiable: `myOtherVariable` equals `i`, but the contract requires `myOtherVariable > i`.
                 let constructor_args = vec![0i64.into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -334,11 +346,11 @@ fn runs_cashc_valid_examples() {
             }
             "correct_pragma.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -354,12 +366,12 @@ fn runs_cashc_valid_examples() {
             "covenant.sil" => {
                 // Unsatisfiable: requires `this.activeScriptPubKey == 0x00`.
                 let constructor_args = vec![1i64.into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "spend");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -371,12 +383,12 @@ fn runs_cashc_valid_examples() {
             "date_literal.sil" => {
                 // Unsatisfiable: `date("2021-02-17T01:30:00")` is non-zero but the contract requires `d == 0`.
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "test");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "test");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -387,12 +399,12 @@ fn runs_cashc_valid_examples() {
             }
             "debug_messages.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "spend");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[ArgValue::Int(1)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -404,12 +416,12 @@ fn runs_cashc_valid_examples() {
             "deep_replace.sil" => {
                 // Unsatisfiable: `a` becomes 3, so `a > b + c + d + e + f` is false.
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -423,11 +435,11 @@ fn runs_cashc_valid_examples() {
                 let recipient_pk = recipient.x_only_public_key().0.serialize().to_vec();
                 let sender_pk = vec![0u8; 32];
                 let constructor_args = vec![sender_pk.into(), recipient_pk.clone().into(), 0i64.into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "transfer");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "transfer");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -440,13 +452,13 @@ fn runs_cashc_valid_examples() {
             }
             "double_split.sil" => {
                 let expected_pkh = vec![0u8; 20];
-                let compiled =
-                    compile_contract(&source, &[expected_pkh.clone().into()], CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "spend");
+                let constructor_args = vec![expected_pkh.clone().into()];
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -459,12 +471,12 @@ fn runs_cashc_valid_examples() {
             "force_cast_smaller_bytes.sil" => {
                 // Unsatisfiable: byte[](0x1234) is 2 bytes, so the forced cast has length 2.
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -475,12 +487,12 @@ fn runs_cashc_valid_examples() {
             }
             "if_statement.sil" => {
                 let constructor_args = vec![0i64.into(), 2i64.into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Int(1)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -491,12 +503,12 @@ fn runs_cashc_valid_examples() {
             }
             "if_statement_number_units-logs.sil" | "if_statement_number_units.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(20_000), ArgValue::Int(1_209_600_000)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -507,12 +519,12 @@ fn runs_cashc_valid_examples() {
             }
             "int_to_byte.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Byte(1)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -529,12 +541,12 @@ fn runs_cashc_valid_examples() {
                 } else {
                     (vec![], "hello")
                 };
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, function_name);
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, function_name);
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -550,12 +562,12 @@ fn runs_cashc_valid_examples() {
                 let recipient_pk = recipient.x_only_public_key().0.serialize().to_vec();
                 let sender_pk = vec![0u8; 32];
                 let constructor_args =
-                    vec![sender_pk.into(), recipient_pk.clone().into(), Expr::temporal(kaspa_txscript::LOCK_TIME_THRESHOLD as i64)];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "transfer");
+                    vec![sender_pk.into(), recipient_pk.clone().into(), (kaspa_txscript::LOCK_TIME_THRESHOLD as i64).into()];
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "transfer");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -568,12 +580,12 @@ fn runs_cashc_valid_examples() {
             }
             "multifunction_if_statements.sil" => {
                 let constructor_args = vec![0i64.into(), 2i64.into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "transfer");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "transfer");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Int(2)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -584,12 +596,12 @@ fn runs_cashc_valid_examples() {
             }
             "multiline_statements.sil" => {
                 let constructor_args = vec![0i64.into(), String::from("World").into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "spend");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[ArgValue::Int(0), ArgValue::String("Nope".to_string())], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -600,12 +612,12 @@ fn runs_cashc_valid_examples() {
             }
             "multiplication.sil" => {
                 let constructor_args = vec![(-1i64).into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -616,12 +628,12 @@ fn runs_cashc_valid_examples() {
             }
             "num2bin_variable.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "spend");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -635,17 +647,17 @@ fn runs_cashc_valid_examples() {
                 let pubkey_bytes = keypair.x_only_public_key().0.serialize().to_vec();
                 let pkh = Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
                 let constructor_args = vec![pkh.into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
                 );
                 let signature = sign_tx(&tx, &reused, &keypair);
-                let sigscript =
-                    compiled.build_sig_script("spend", vec![pubkey_bytes.into(), signature.clone().into()]).expect("sigscript builds");
+                let sigscript = common::encode_entry_sig_script(&compiled, "spend", &[pubkey_bytes.into(), signature.clone().into()])
+                    .expect("sigscript builds");
                 tx.tx.inputs[0].signature_script = sigscript;
                 let result = execute_tx(tx, utxo, reused);
                 assert!(result.is_ok(), "{example} failed: {}", result.unwrap_err());
@@ -655,17 +667,17 @@ fn runs_cashc_valid_examples() {
                 let pubkey_bytes = keypair.x_only_public_key().0.serialize().to_vec();
                 let pkh = Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
                 let constructor_args = vec![pkh.into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
                 );
                 let signature = sign_tx(&tx, &reused, &keypair);
-                let sigscript =
-                    compiled.build_sig_script("spend", vec![pubkey_bytes.into(), signature.clone().into()]).expect("sigscript builds");
+                let sigscript = common::encode_entry_sig_script(&compiled, "spend", &[pubkey_bytes.into(), signature.clone().into()])
+                    .expect("sigscript builds");
                 tx.tx.inputs[0].signature_script = sigscript;
                 let result = execute_tx(tx, utxo, reused);
                 assert!(result.is_ok(), "{example} failed: {}", result.unwrap_err());
@@ -673,11 +685,11 @@ fn runs_cashc_valid_examples() {
             "reassignment.sil" => {
                 // Unsatisfiable: requires sha256(pubkey) == sha256("Hello World" + y).
                 let constructor_args = vec![0i64.into(), String::from("y").into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -693,11 +705,11 @@ fn runs_cashc_valid_examples() {
             "simple_cast.sil" => {
                 // Unsatisfiable: requires sha256(pubkey) == sha256(byte[]("Hello World" + y) + byte[](pubkey)).
                 let constructor_args = vec![0i64.into(), String::from("y").into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -723,12 +735,12 @@ fn runs_cashc_valid_examples() {
 
                 let run = |signature: Vec<u8>| {
                     let constructor_args = vec![signature.into(), pubkey_bytes.clone().into()];
-                    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                    let dispatch_tag = dispatch_tag_for_compiled(&compiled, "cds");
+                    let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                    let dispatch_tag = dispatch_tag(&compiled, "cds");
                     let sigscript = build_sigscript(&[ArgValue::Bytes(message.clone())], dispatch_tag);
                     let (mut tx, utxo, reused) = build_tx_context(
-                        compiled.bytecode.clone(),
-                        vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                        bytecode(&compiled).clone(),
+                        vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                         2_000,
                         0,
                         1,
@@ -755,12 +767,12 @@ fn runs_cashc_valid_examples() {
 
                 let run = |signature: Vec<u8>| {
                     let constructor_args = vec![signature.into(), pubkey_bytes.clone().into()];
-                    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                    let dispatch_tag = dispatch_tag_for_compiled(&compiled, "cds");
+                    let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                    let dispatch_tag = dispatch_tag(&compiled, "cds");
                     let sigscript = build_sigscript(&[ArgValue::Bytes(message.clone())], dispatch_tag);
                     let (mut tx, utxo, reused) = build_tx_context(
-                        compiled.bytecode.clone(),
-                        vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                        bytecode(&compiled).clone(),
+                        vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                         2_000,
                         0,
                         1,
@@ -776,12 +788,12 @@ fn runs_cashc_valid_examples() {
             }
             "simple_constant.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -792,12 +804,12 @@ fn runs_cashc_valid_examples() {
             }
             "simple_covenant.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "covenant");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "covenant");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     2,
@@ -808,12 +820,12 @@ fn runs_cashc_valid_examples() {
             }
             "simple_functions.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "world");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "world");
                 let sigscript = build_sigscript(&[ArgValue::Int(5)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -824,12 +836,12 @@ fn runs_cashc_valid_examples() {
             }
             "simple_if_statement.sil" => {
                 let constructor_args = vec![0i64.into(), String::from("World").into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(0), ArgValue::String("Hello World".to_string())], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -839,13 +851,13 @@ fn runs_cashc_valid_examples() {
                 assert!(result.is_ok(), "{example} failed: {}", result.unwrap_err());
             }
             "simple_splice.sil" => {
-                let constructor_args = vec![Expr::dynamic_bytes(vec![0u8; 6])];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "spend");
+                let constructor_args = vec![vec![0u8; 6].into()];
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -857,11 +869,11 @@ fn runs_cashc_valid_examples() {
             "simple_variables.sil" => {
                 // Unsatisfiable: requires sha256(pubkey) == sha256("Hello World" + y).
                 let constructor_args = vec![0i64.into(), String::from("y").into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -884,8 +896,8 @@ fn runs_cashc_valid_examples() {
                 initial_block_bytes.resize(8, 0);
                 let constructor_args =
                     vec![recipient.clone().into(), funder.clone().into(), pledge_per_block.into(), initial_block_bytes.clone().into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "receive");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "receive");
 
                 let lock_time = 10u64;
                 let passed_blocks = lock_time as i64 - initial_block_value;
@@ -904,7 +916,7 @@ fn runs_cashc_valid_examples() {
                     out.extend_from_slice(&lock_bytes);
                     let mut active_bytecode = Vec::new();
                     active_bytecode.extend_from_slice(&0u16.to_be_bytes());
-                    active_bytecode.extend_from_slice(&compiled.bytecode);
+                    active_bytecode.extend_from_slice(bytecode(&compiled));
                     out.extend_from_slice(&active_bytecode[9..]);
                     out
                 };
@@ -914,7 +926,7 @@ fn runs_cashc_valid_examples() {
 
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
+                    bytecode(&compiled).clone(),
                     vec![(output0_value, output0_script), (output1_value, output1_script)],
                     input_value,
                     lock_time,
@@ -926,13 +938,13 @@ fn runs_cashc_valid_examples() {
             }
             "slice.sil" | "slice_variable_parameter.sil" => {
                 let expected_pkh = vec![0u8; 20];
-                let compiled =
-                    compile_contract(&source, &[expected_pkh.clone().into()], CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "spend");
+                let constructor_args = vec![expected_pkh.clone().into()];
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -944,12 +956,12 @@ fn runs_cashc_valid_examples() {
             }
             "slice_optimised.sil" => {
                 let constructor_args = vec![vec![0u8; 32].into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "spend");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -963,12 +975,12 @@ fn runs_cashc_valid_examples() {
                 let mut signature = vec![0u8; 64];
                 signature.push(0x01);
                 let constructor_args = vec![signature.into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "spend");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -978,13 +990,13 @@ fn runs_cashc_valid_examples() {
                 assert!(result.is_ok(), "{example} failed: {}", result.unwrap_err());
             }
             "split_size.sil" => {
-                let constructor_args = vec![Expr::dynamic_bytes(b"abcd".to_vec())];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "spend");
+                let constructor_args = vec![b"abcd".to_vec().into()];
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -994,13 +1006,13 @@ fn runs_cashc_valid_examples() {
                 assert!(result.is_ok(), "{example} failed: {}", result.unwrap_err());
             }
             "split_typed.sil" => {
-                let constructor_args = vec![Expr::dynamic_bytes(b"abcde".to_vec())];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "spend");
+                let constructor_args = vec![b"abcde".to_vec().into()];
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -1011,12 +1023,12 @@ fn runs_cashc_valid_examples() {
             }
             "string_concatenation.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::String("world".to_string())], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -1028,12 +1040,12 @@ fn runs_cashc_valid_examples() {
             "string_with_escaped_characters.sil" => {
                 // Unsatisfiable in this runtime: escaped string literals hash differently.
                 let constructor_args = vec![0i64.into()];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "hello");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -1045,12 +1057,12 @@ fn runs_cashc_valid_examples() {
             "tuple_unpacking.sil" => {
                 // Unsatisfiable: split("hello" + "there") yields "hello" and "there", which are not equal.
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "split");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "split");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -1061,12 +1073,12 @@ fn runs_cashc_valid_examples() {
             }
             "tuple_unpacking_parameter.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "split");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "split");
                 let sigscript = build_sigscript(&[ArgValue::Bytes(vec![0u8; 32])], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -1077,12 +1089,12 @@ fn runs_cashc_valid_examples() {
             }
             "tuple_unpacking_single_side_type.sil" => {
                 let constructor_args = vec![];
-                let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-                let dispatch_tag = dispatch_tag_for_compiled(&compiled, "split");
+                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let dispatch_tag = dispatch_tag(&compiled, "split");
                 let sigscript = build_sigscript(&[ArgValue::Bytes(vec![0u8; 32])], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
-                    compiled.bytecode.clone(),
-                    vec![(1_000, compiled.bytecode.clone()), (1_000, compiled.bytecode.clone())],
+                    bytecode(&compiled).clone(),
+                    vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
                     2_000,
                     0,
                     1,
@@ -1161,8 +1173,8 @@ fn compiles_cashc_valid_examples() {
     for example in examples {
         let source = load_example_source(example);
         let param_types = parse_contract_param_types(&source);
-        let constructor_args = param_types.into_iter().map(|t| dummy_expr_for_type(&t)).collect::<Vec<_>>();
-        let compiled = compile_contract(&source, &constructor_args, CompileOptions::default());
+        let constructor_args = param_types.into_iter().map(|t| dummy_artifact_value_for_type(&t)).collect::<Vec<_>>();
+        let compiled = sil_abi_artifact(&source, &constructor_args);
         assert!(compiled.is_ok(), "{example} failed to compile: {}", compiled.unwrap_err());
     }
 }

--- a/silverscript-lang/tests/cashc_valid_examples_tests.rs
+++ b/silverscript-lang/tests/cashc_valid_examples_tests.rs
@@ -130,14 +130,14 @@ fn build_sigscript(args: &[ArgValue], dispatch_tag: DispatchTag) -> Vec<u8> {
 }
 
 fn dispatch_tag(artifact: &SilAbiArtifact, function_name: &str) -> DispatchTag {
-    let [contract] = artifact.contracts.as_slice() else {
+    let Some(contract) = artifact.contracts.values().next().filter(|_| artifact.contracts.len() == 1) else {
         panic!("expected one contract, found {}", artifact.contracts.len());
     };
     contract.entry(function_name).expect("entrypoint resolved").dispatch_tag.into_bytes()
 }
 
 fn bytecode(artifact: &SilAbiArtifact) -> &Vec<u8> {
-    let [contract] = artifact.contracts.as_slice() else {
+    let Some(contract) = artifact.contracts.values().next().filter(|_| artifact.contracts.len() == 1) else {
         panic!("expected one contract, found {}", artifact.contracts.len());
     };
     &contract.compiled.bytecode

--- a/silverscript-lang/tests/cashc_valid_examples_tests.rs
+++ b/silverscript-lang/tests/cashc_valid_examples_tests.rs
@@ -15,7 +15,7 @@ use kaspa_txscript::{EngineCtx, EngineFlags, TxScriptEngine, pay_to_script_hash_
 use rand::{RngCore, thread_rng};
 use secp256k1::{Keypair, Message, Secp256k1, SecretKey};
 use silverscript_abi::{ArtifactValue, SilAbiArtifact};
-use silverscript_lang::compiler::{DispatchTag, sil_abi_artifact};
+use silverscript_lang::compiler::{DispatchTag, compile_to_sil_abi_artifact};
 use std::fs;
 
 fn load_example_source(name: &str) -> String {
@@ -275,7 +275,7 @@ fn runs_cashc_valid_examples() {
         match example {
             "bitwise.sil" => {
                 let constructor_args = vec![vec![0u8; 8].into(), vec![0u8; 8].into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -291,7 +291,7 @@ fn runs_cashc_valid_examples() {
             }
             "bytes1_equals_byte.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Byte(1)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -307,7 +307,7 @@ fn runs_cashc_valid_examples() {
             }
             "cast_hash_checksig.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let (mut tx, utxo, reused) = build_tx_context(
                     bytecode(&compiled).clone(),
                     vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
@@ -327,7 +327,7 @@ fn runs_cashc_valid_examples() {
             "comments.sil" => {
                 // Unsatisfiable: `myOtherVariable` equals `i`, but the contract requires `myOtherVariable > i`.
                 let constructor_args = vec![0i64.into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
                     bytecode(&compiled).clone(),
@@ -346,7 +346,7 @@ fn runs_cashc_valid_examples() {
             }
             "correct_pragma.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
                     bytecode(&compiled).clone(),
@@ -366,7 +366,7 @@ fn runs_cashc_valid_examples() {
             "covenant.sil" => {
                 // Unsatisfiable: requires `this.activeScriptPubKey == 0x00`.
                 let constructor_args = vec![1i64.into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -383,7 +383,7 @@ fn runs_cashc_valid_examples() {
             "date_literal.sil" => {
                 // Unsatisfiable: `date("2021-02-17T01:30:00")` is non-zero but the contract requires `d == 0`.
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "test");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -399,7 +399,7 @@ fn runs_cashc_valid_examples() {
             }
             "debug_messages.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[ArgValue::Int(1)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -416,7 +416,7 @@ fn runs_cashc_valid_examples() {
             "deep_replace.sil" => {
                 // Unsatisfiable: `a` becomes 3, so `a > b + c + d + e + f` is false.
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -435,7 +435,7 @@ fn runs_cashc_valid_examples() {
                 let recipient_pk = recipient.x_only_public_key().0.serialize().to_vec();
                 let sender_pk = vec![0u8; 32];
                 let constructor_args = vec![sender_pk.into(), recipient_pk.clone().into(), 0i64.into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "transfer");
                 let (mut tx, utxo, reused) = build_tx_context(
                     bytecode(&compiled).clone(),
@@ -453,7 +453,7 @@ fn runs_cashc_valid_examples() {
             "double_split.sil" => {
                 let expected_pkh = vec![0u8; 20];
                 let constructor_args = vec![expected_pkh.clone().into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -471,7 +471,7 @@ fn runs_cashc_valid_examples() {
             "force_cast_smaller_bytes.sil" => {
                 // Unsatisfiable: byte[](0x1234) is 2 bytes, so the forced cast has length 2.
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -487,7 +487,7 @@ fn runs_cashc_valid_examples() {
             }
             "if_statement.sil" => {
                 let constructor_args = vec![0i64.into(), 2i64.into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Int(1)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -503,7 +503,7 @@ fn runs_cashc_valid_examples() {
             }
             "if_statement_number_units-logs.sil" | "if_statement_number_units.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(20_000), ArgValue::Int(1_209_600_000)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -519,7 +519,7 @@ fn runs_cashc_valid_examples() {
             }
             "int_to_byte.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Byte(1)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -541,7 +541,7 @@ fn runs_cashc_valid_examples() {
                 } else {
                     (vec![], "hello")
                 };
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, function_name);
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -563,7 +563,7 @@ fn runs_cashc_valid_examples() {
                 let sender_pk = vec![0u8; 32];
                 let constructor_args =
                     vec![sender_pk.into(), recipient_pk.clone().into(), (kaspa_txscript::LOCK_TIME_THRESHOLD as i64).into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "transfer");
                 let (mut tx, utxo, reused) = build_tx_context(
                     bytecode(&compiled).clone(),
@@ -580,7 +580,7 @@ fn runs_cashc_valid_examples() {
             }
             "multifunction_if_statements.sil" => {
                 let constructor_args = vec![0i64.into(), 2i64.into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "transfer");
                 let sigscript = build_sigscript(&[ArgValue::Int(1), ArgValue::Int(2)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -596,7 +596,7 @@ fn runs_cashc_valid_examples() {
             }
             "multiline_statements.sil" => {
                 let constructor_args = vec![0i64.into(), String::from("World").into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[ArgValue::Int(0), ArgValue::String("Nope".to_string())], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -612,7 +612,7 @@ fn runs_cashc_valid_examples() {
             }
             "multiplication.sil" => {
                 let constructor_args = vec![(-1i64).into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -628,7 +628,7 @@ fn runs_cashc_valid_examples() {
             }
             "num2bin_variable.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -647,7 +647,7 @@ fn runs_cashc_valid_examples() {
                 let pubkey_bytes = keypair.x_only_public_key().0.serialize().to_vec();
                 let pkh = Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
                 let constructor_args = vec![pkh.into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let (mut tx, utxo, reused) = build_tx_context(
                     bytecode(&compiled).clone(),
                     vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
@@ -667,7 +667,7 @@ fn runs_cashc_valid_examples() {
                 let pubkey_bytes = keypair.x_only_public_key().0.serialize().to_vec();
                 let pkh = Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
                 let constructor_args = vec![pkh.into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let (mut tx, utxo, reused) = build_tx_context(
                     bytecode(&compiled).clone(),
                     vec![(1_000, bytecode(&compiled).clone()), (1_000, bytecode(&compiled).clone())],
@@ -685,7 +685,7 @@ fn runs_cashc_valid_examples() {
             "reassignment.sil" => {
                 // Unsatisfiable: requires sha256(pubkey) == sha256("Hello World" + y).
                 let constructor_args = vec![0i64.into(), String::from("y").into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
                     bytecode(&compiled).clone(),
@@ -705,7 +705,7 @@ fn runs_cashc_valid_examples() {
             "simple_cast.sil" => {
                 // Unsatisfiable: requires sha256(pubkey) == sha256(byte[]("Hello World" + y) + byte[](pubkey)).
                 let constructor_args = vec![0i64.into(), String::from("y").into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
                     bytecode(&compiled).clone(),
@@ -735,7 +735,7 @@ fn runs_cashc_valid_examples() {
 
                 let run = |signature: Vec<u8>| {
                     let constructor_args = vec![signature.into(), pubkey_bytes.clone().into()];
-                    let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                    let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                     let dispatch_tag = dispatch_tag(&compiled, "cds");
                     let sigscript = build_sigscript(&[ArgValue::Bytes(message.clone())], dispatch_tag);
                     let (mut tx, utxo, reused) = build_tx_context(
@@ -767,7 +767,7 @@ fn runs_cashc_valid_examples() {
 
                 let run = |signature: Vec<u8>| {
                     let constructor_args = vec![signature.into(), pubkey_bytes.clone().into()];
-                    let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                    let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                     let dispatch_tag = dispatch_tag(&compiled, "cds");
                     let sigscript = build_sigscript(&[ArgValue::Bytes(message.clone())], dispatch_tag);
                     let (mut tx, utxo, reused) = build_tx_context(
@@ -788,7 +788,7 @@ fn runs_cashc_valid_examples() {
             }
             "simple_constant.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -804,7 +804,7 @@ fn runs_cashc_valid_examples() {
             }
             "simple_covenant.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "covenant");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -820,7 +820,7 @@ fn runs_cashc_valid_examples() {
             }
             "simple_functions.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "world");
                 let sigscript = build_sigscript(&[ArgValue::Int(5)], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -836,7 +836,7 @@ fn runs_cashc_valid_examples() {
             }
             "simple_if_statement.sil" => {
                 let constructor_args = vec![0i64.into(), String::from("World").into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::Int(0), ArgValue::String("Hello World".to_string())], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -852,7 +852,7 @@ fn runs_cashc_valid_examples() {
             }
             "simple_splice.sil" => {
                 let constructor_args = vec![vec![0u8; 6].into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -869,7 +869,7 @@ fn runs_cashc_valid_examples() {
             "simple_variables.sil" => {
                 // Unsatisfiable: requires sha256(pubkey) == sha256("Hello World" + y).
                 let constructor_args = vec![0i64.into(), String::from("y").into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let (mut tx, utxo, reused) = build_tx_context(
                     bytecode(&compiled).clone(),
@@ -896,7 +896,7 @@ fn runs_cashc_valid_examples() {
                 initial_block_bytes.resize(8, 0);
                 let constructor_args =
                     vec![recipient.clone().into(), funder.clone().into(), pledge_per_block.into(), initial_block_bytes.clone().into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "receive");
 
                 let lock_time = 10u64;
@@ -939,7 +939,7 @@ fn runs_cashc_valid_examples() {
             "slice.sil" | "slice_variable_parameter.sil" => {
                 let expected_pkh = vec![0u8; 20];
                 let constructor_args = vec![expected_pkh.clone().into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -956,7 +956,7 @@ fn runs_cashc_valid_examples() {
             }
             "slice_optimised.sil" => {
                 let constructor_args = vec![vec![0u8; 32].into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -975,7 +975,7 @@ fn runs_cashc_valid_examples() {
                 let mut signature = vec![0u8; 64];
                 signature.push(0x01);
                 let constructor_args = vec![signature.into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -991,7 +991,7 @@ fn runs_cashc_valid_examples() {
             }
             "split_size.sil" => {
                 let constructor_args = vec![b"abcd".to_vec().into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -1007,7 +1007,7 @@ fn runs_cashc_valid_examples() {
             }
             "split_typed.sil" => {
                 let constructor_args = vec![b"abcde".to_vec().into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "spend");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -1023,7 +1023,7 @@ fn runs_cashc_valid_examples() {
             }
             "string_concatenation.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[ArgValue::String("world".to_string())], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -1040,7 +1040,7 @@ fn runs_cashc_valid_examples() {
             "string_with_escaped_characters.sil" => {
                 // Unsatisfiable in this runtime: escaped string literals hash differently.
                 let constructor_args = vec![0i64.into()];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "hello");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -1057,7 +1057,7 @@ fn runs_cashc_valid_examples() {
             "tuple_unpacking.sil" => {
                 // Unsatisfiable: split("hello" + "there") yields "hello" and "there", which are not equal.
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "split");
                 let sigscript = build_sigscript(&[], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -1073,7 +1073,7 @@ fn runs_cashc_valid_examples() {
             }
             "tuple_unpacking_parameter.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "split");
                 let sigscript = build_sigscript(&[ArgValue::Bytes(vec![0u8; 32])], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -1089,7 +1089,7 @@ fn runs_cashc_valid_examples() {
             }
             "tuple_unpacking_single_side_type.sil" => {
                 let constructor_args = vec![];
-                let compiled = sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
+                let compiled = compile_to_sil_abi_artifact(&source, &constructor_args).expect("compile succeeds");
                 let dispatch_tag = dispatch_tag(&compiled, "split");
                 let sigscript = build_sigscript(&[ArgValue::Bytes(vec![0u8; 32])], dispatch_tag);
                 let (mut tx, utxo, reused) = build_tx_context(
@@ -1174,7 +1174,7 @@ fn compiles_cashc_valid_examples() {
         let source = load_example_source(example);
         let param_types = parse_contract_param_types(&source);
         let constructor_args = param_types.into_iter().map(|t| dummy_artifact_value_for_type(&t)).collect::<Vec<_>>();
-        let compiled = sil_abi_artifact(&source, &constructor_args);
+        let compiled = compile_to_sil_abi_artifact(&source, &constructor_args);
         assert!(compiled.is_ok(), "{example} failed to compile: {}", compiled.unwrap_err());
     }
 }

--- a/silverscript-lang/tests/cashc_valid_examples_tests.rs
+++ b/silverscript-lang/tests/cashc_valid_examples_tests.rs
@@ -74,15 +74,15 @@ fn dummy_artifact_value_for_type(type_name: &str) -> ArtifactValue {
         return vec![0u8; size].into();
     }
     // Support byte[N] syntax
-    if let Some(bracket_pos) = type_name.find('[') {
-        if type_name.ends_with(']') {
-            let base_type = &type_name[..bracket_pos];
-            let size_str = &type_name[bracket_pos + 1..type_name.len() - 1];
-            if base_type == "byte" {
-                if let Ok(size) = size_str.parse::<usize>() {
-                    return vec![0u8; size].into();
-                }
-            }
+    if let Some(bracket_pos) = type_name.find('[')
+        && type_name.ends_with(']')
+    {
+        let base_type = &type_name[..bracket_pos];
+        let size_str = &type_name[bracket_pos + 1..type_name.len() - 1];
+        if base_type == "byte"
+            && let Ok(size) = size_str.parse::<usize>()
+        {
+            return vec![0u8; size].into();
         }
     }
     0i64.into()

--- a/silverscript-lang/tests/chess_apps_tests.rs
+++ b/silverscript-lang/tests/chess_apps_tests.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -20,14 +22,14 @@ use kaspa_txscript::{
 };
 use kaspa_txscript_errors::TxScriptError;
 use secp256k1::{Keypair, Message, Secp256k1, SecretKey};
-use silverscript_lang::ast::Expr;
-use silverscript_lang::compiler::{CompileOptions, CompiledContract, compile_contract};
+use silverscript_abi::ArtifactValue;
+use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
 
 const DEFAULT_MOVE_TIMEOUT: i64 = 600;
 
 struct SizeSnapshot {
     name: &'static str,
-    ctor: fn() -> Vec<Expr<'static>>,
+    ctor: fn() -> Vec<ArtifactValue>,
     expected_bytecode_len: usize,
     // Total complete P2SH sigscript bytes in the runtime-tested transaction.
     expected_sigscript_len: usize,
@@ -108,16 +110,16 @@ fn source_cache() -> &'static Mutex<HashMap<String, &'static str>> {
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn compiled_contract_cache() -> &'static Mutex<HashMap<String, Arc<CompiledContract<'static>>>> {
-    static CACHE: OnceLock<Mutex<HashMap<String, Arc<CompiledContract<'static>>>>> = OnceLock::new();
+fn compiled_contract_cache() -> &'static Mutex<HashMap<String, Arc<silverscript_abi::SilAbiArtifact>>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, Arc<silverscript_abi::SilAbiArtifact>>>> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-fn compile_cache_key(source: &'static str, ctor: &[Expr<'static>]) -> String {
+fn compile_cache_key(source: &'static str, ctor: &[ArtifactValue]) -> String {
     format!("{:p}:{}:{}", source.as_ptr(), source.len(), serde_json::to_string(ctor).expect("serialize chess ctor args"))
 }
 
-fn compile_cached(source: &'static str, ctor: &[Expr<'static>]) -> Arc<CompiledContract<'static>> {
+fn compile_cached(source: &'static str, ctor: &[ArtifactValue]) -> Arc<silverscript_abi::SilAbiArtifact> {
     let key = compile_cache_key(source, ctor);
     {
         let cache = compiled_contract_cache().lock().expect("compile cache mutex poisoned");
@@ -126,7 +128,8 @@ fn compile_cached(source: &'static str, ctor: &[Expr<'static>]) -> Arc<CompiledC
         }
     }
 
-    let compiled = Arc::new(compile_contract(source, ctor, CompileOptions::default()).expect("compile chess contract succeeds"));
+    let compiled =
+        Arc::new(sil_abi_artifact_with_options(source, ctor, CompileOptions::default()).expect("compile chess contract succeeds"));
     let mut cache = compiled_contract_cache().lock().expect("compile cache mutex poisoned");
     cache.insert(key, Arc::clone(&compiled));
     compiled
@@ -219,8 +222,8 @@ fn hash_pair(left: Hash, right: Hash) -> Hash {
     blake2b_bytes(&[left.as_slice(), right.as_slice()].concat())
 }
 
-fn hash_expr(value: Hash) -> Expr<'static> {
-    Expr::bytes(hash_bytes(value))
+fn hash_value(value: Hash) -> ArtifactValue {
+    ArtifactValue::Bytes(hash_bytes(value))
 }
 
 fn repeated_hash(byte: u8) -> Hash {
@@ -272,8 +275,8 @@ fn full_castle_rights() -> [u8; 4] {
     [1, 1, 1, 1]
 }
 
-fn castle_rights_expr(rights: [u8; 4]) -> Expr<'static> {
-    Expr::bytes(rights.to_vec())
+fn castle_rights_value(rights: [u8; 4]) -> ArtifactValue {
+    ArtifactValue::Bytes(rights.to_vec())
 }
 
 fn move_piece(board: &mut [u8], from_x: usize, from_y: usize, to_x: usize, to_y: usize) {
@@ -315,12 +318,12 @@ fn routes_commitment(route_templates: &[u8]) -> Hash {
     blake2b_bytes(route_templates)
 }
 
-fn template_fixture(source: &'static str, ctor: &[Expr<'static>]) -> TemplateFixture {
+fn template_fixture(source: &'static str, ctor: &[ArtifactValue]) -> TemplateFixture {
     let compiled = compile_cached(source, ctor);
-    let layout = compiled.state_layout;
-    let prefix = compiled.bytecode[..layout.start].to_vec();
-    let suffix = compiled.bytecode[layout.start + layout.len..].to_vec();
-    let hash = Hash::from_bytes(compiled.template_hash());
+    let layout = common::state_layout(&compiled);
+    let prefix = common::bytecode(&compiled)[..layout.start].to_vec();
+    let suffix = common::bytecode(&compiled)[layout.start + layout.len..].to_vec();
+    let hash = Hash::from_bytes(common::template_hash(&compiled));
     TemplateFixture { source, prefix, suffix, hash }
 }
 
@@ -329,24 +332,28 @@ fn fixture() -> &'static MuxChessFixture {
     FIXTURE.get_or_init(|| {
         let dummy_board = standard_board();
         let game_ctor = vec![
-            Expr::bytes(vec![0x11u8; 32]),
-            Expr::bytes(vec![0x33u8; 32 * 9]),
-            Expr::bytes(vec![0x21u8; 32]),
-            Expr::bytes(vec![0x22u8; 32]),
-            Expr::bytes(dummy_board),
-            Expr::int(0),
-            Expr::int(0),
-            Expr::int(DEFAULT_MOVE_TIMEOUT),
-            castle_rights_expr(full_castle_rights()),
-            Expr::int(-1),
-            Expr::int(-1),
-            Expr::int(-1),
-            Expr::int(0),
-            Expr::int(0),
-            Expr::int(3),
+            ArtifactValue::Bytes(vec![0x11u8; 32]),
+            ArtifactValue::Bytes(vec![0x33u8; 32 * 9]),
+            ArtifactValue::Bytes(vec![0x21u8; 32]),
+            ArtifactValue::Bytes(vec![0x22u8; 32]),
+            ArtifactValue::Bytes(dummy_board),
+            ArtifactValue::Int(0),
+            ArtifactValue::Int(0),
+            ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+            castle_rights_value(full_castle_rights()),
+            ArtifactValue::Int(-1),
+            ArtifactValue::Int(-1),
+            ArtifactValue::Int(-1),
+            ArtifactValue::Int(0),
+            ArtifactValue::Int(0),
+            ArtifactValue::Int(3),
         ];
-        let settle_ctor =
-            vec![Expr::bytes(vec![0x44u8; 32]), Expr::bytes(vec![0x21u8; 32]), Expr::bytes(vec![0x22u8; 32]), Expr::int(0)];
+        let settle_ctor = vec![
+            ArtifactValue::Bytes(vec![0x44u8; 32]),
+            ArtifactValue::Bytes(vec![0x21u8; 32]),
+            ArtifactValue::Bytes(vec![0x22u8; 32]),
+            ArtifactValue::Int(0),
+        ];
 
         MuxChessFixture {
             mux: template_fixture(mux_source(), &game_ctor),
@@ -369,23 +376,23 @@ fn compile_state(
     white_hash: &Hash,
     black_hash: &Hash,
     state: GameStateArgs<'_>,
-) -> Arc<CompiledContract<'static>> {
+) -> Arc<silverscript_abi::SilAbiArtifact> {
     let ctor = vec![
-        hash_expr(fix.mux.hash),
-        Expr::bytes(packed_route_templates(fix)),
-        hash_expr(*white_hash),
-        hash_expr(*black_hash),
-        Expr::bytes(state.board.to_vec()),
-        Expr::int(state.turn),
-        Expr::int(state.status),
-        Expr::int(DEFAULT_MOVE_TIMEOUT),
-        castle_rights_expr(state.castle_rights),
-        Expr::int(state.en_passant_idx),
-        Expr::int(state.pending_src_idx),
-        Expr::int(state.pending_dst_idx),
-        Expr::int(state.pending_promo),
-        Expr::int(state.recent_castle),
-        Expr::int(state.draw_state),
+        hash_value(fix.mux.hash),
+        ArtifactValue::Bytes(packed_route_templates(fix)),
+        hash_value(*white_hash),
+        hash_value(*black_hash),
+        ArtifactValue::Bytes(state.board.to_vec()),
+        ArtifactValue::Int(state.turn),
+        ArtifactValue::Int(state.status),
+        ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+        castle_rights_value(state.castle_rights),
+        ArtifactValue::Int(state.en_passant_idx),
+        ArtifactValue::Int(state.pending_src_idx),
+        ArtifactValue::Int(state.pending_dst_idx),
+        ArtifactValue::Int(state.pending_promo),
+        ArtifactValue::Int(state.recent_castle),
+        ArtifactValue::Int(state.draw_state),
     ];
     compile_cached(source, &ctor)
 }
@@ -396,25 +403,25 @@ fn compile_settle_state(
     white_hash: &Hash,
     black_hash: &Hash,
     status: i64,
-) -> Arc<CompiledContract<'static>> {
-    let ctor = vec![hash_expr(*player_template), hash_expr(*white_hash), hash_expr(*black_hash), Expr::int(status)];
+) -> Arc<silverscript_abi::SilAbiArtifact> {
+    let ctor = vec![hash_value(*player_template), hash_value(*white_hash), hash_value(*black_hash), ArtifactValue::Int(status)];
     compile_cached(source, &ctor)
 }
 
-fn compile_player_state(source: &'static str, state: PlayerStateArgs<'_>) -> Arc<CompiledContract<'static>> {
+fn compile_player_state(source: &'static str, state: PlayerStateArgs<'_>) -> Arc<silverscript_abi::SilAbiArtifact> {
     let ctor = vec![
-        hash_expr(*state.league_template),
-        hash_expr(*state.player_template),
-        hash_expr(*state.mux_template),
-        hash_expr(*state.routes_commitment),
-        hash_expr(*state.owner_hash),
-        hash_expr(*state.player_id),
-        Expr::int(state.open_games),
-        Expr::int(state.rating),
-        Expr::int(state.games),
-        Expr::int(state.wins),
-        Expr::int(state.draws),
-        Expr::int(state.losses),
+        hash_value(*state.league_template),
+        hash_value(*state.player_template),
+        hash_value(*state.mux_template),
+        hash_value(*state.routes_commitment),
+        hash_value(*state.owner_hash),
+        hash_value(*state.player_id),
+        ArtifactValue::Int(state.open_games),
+        ArtifactValue::Int(state.rating),
+        ArtifactValue::Int(state.games),
+        ArtifactValue::Int(state.wins),
+        ArtifactValue::Int(state.draws),
+        ArtifactValue::Int(state.losses),
     ];
     compile_cached(source, &ctor)
 }
@@ -437,13 +444,13 @@ fn player_template_hash(fix: &MuxChessFixture) -> Hash {
             losses: 0,
         },
     );
-    Hash::from_bytes(compiled.template_hash())
+    Hash::from_bytes(common::template_hash(&compiled))
 }
 
-fn entry_sigscript(compiled: &CompiledContract<'_>, function: &str, args: Vec<Expr<'_>>) -> Vec<u8> {
-    let sigscript = compiled.build_sig_script(function, args).expect("sigscript builds");
+fn entry_sigscript(compiled: &silverscript_abi::SilAbiArtifact, function: &str, args: Vec<ArtifactValue>) -> Vec<u8> {
+    let sigscript = common::encode_entry_sig_script(compiled, function, &args).expect("sigscript builds");
     pay_to_script_hash_signature_script_with_flags(
-        compiled.bytecode.clone(),
+        common::bytecode(compiled).clone(),
         sigscript,
         EngineFlags { covenants_enabled: true, ..Default::default() },
     )
@@ -460,27 +467,27 @@ fn tx_input(index: u32, signature_script: Vec<u8>, sig_op_count: u8) -> Transact
 }
 
 fn covenant_output_with_value(
-    compiled: &CompiledContract<'_>,
+    compiled: &silverscript_abi::SilAbiArtifact,
     authorizing_input: u16,
     covenant_id: Hash,
     value: u64,
 ) -> TransactionOutput {
     TransactionOutput {
         value,
-        script_public_key: pay_to_script_hash_script(&compiled.bytecode),
+        script_public_key: pay_to_script_hash_script(&common::bytecode(compiled)),
         covenant: Some(CovenantBinding { authorizing_input, covenant_id }),
     }
 }
 
-fn covenant_output(compiled: &CompiledContract<'_>, authorizing_input: u16, covenant_id: Hash) -> TransactionOutput {
+fn covenant_output(compiled: &silverscript_abi::SilAbiArtifact, authorizing_input: u16, covenant_id: Hash) -> TransactionOutput {
     covenant_output_with_value(compiled, authorizing_input, covenant_id, 1_000)
 }
 
-fn covenant_utxo_with_value(compiled: &CompiledContract<'_>, covenant_id: Hash, value: u64) -> UtxoEntry {
-    UtxoEntry::new(value, pay_to_script_hash_script(&compiled.bytecode), 0, false, Some(covenant_id))
+fn covenant_utxo_with_value(compiled: &silverscript_abi::SilAbiArtifact, covenant_id: Hash, value: u64) -> UtxoEntry {
+    UtxoEntry::new(value, pay_to_script_hash_script(&common::bytecode(compiled)), 0, false, Some(covenant_id))
 }
 
-fn covenant_utxo(compiled: &CompiledContract<'_>, covenant_id: Hash) -> UtxoEntry {
+fn covenant_utxo(compiled: &silverscript_abi::SilAbiArtifact, covenant_id: Hash) -> UtxoEntry {
     covenant_utxo_with_value(compiled, covenant_id, 1_000)
 }
 
@@ -515,12 +522,12 @@ fn sign_tx_input_schnorr(tx: &Transaction, entries: &[UtxoEntry], input_idx: usi
 }
 
 fn run_route(
-    active: &CompiledContract<'_>,
+    active: &silverscript_abi::SilAbiArtifact,
     selector: i64,
     mv: MoveArgs,
     player: &Player,
     target: &TemplateFixture,
-    out: &CompiledContract<'_>,
+    out: &silverscript_abi::SilAbiArtifact,
     covenant_id: Hash,
 ) {
     let placeholder_sig = vec![0u8; 65];
@@ -535,11 +542,11 @@ fn run_route(
             mv.to_y.into(),
             mv.promo_piece.into(),
             0.into(),
-            Expr::bytes(placeholder_sig),
-            Expr::bytes(player.pubkey_bytes.clone()),
-            hash_expr(player.player_id),
-            Expr::dynamic_bytes(target.prefix.clone()),
-            Expr::dynamic_bytes(target.suffix.clone()),
+            ArtifactValue::Bytes(placeholder_sig),
+            ArtifactValue::Bytes(player.pubkey_bytes.clone()),
+            hash_value(player.player_id),
+            ArtifactValue::Bytes(target.prefix.clone()),
+            ArtifactValue::Bytes(target.suffix.clone()),
         ],
     );
     let outputs = vec![covenant_output(out, 0, covenant_id)];
@@ -557,11 +564,11 @@ fn run_route(
             mv.to_y.into(),
             mv.promo_piece.into(),
             0.into(),
-            Expr::bytes(sig),
-            Expr::bytes(player.pubkey_bytes.clone()),
-            hash_expr(player.player_id),
-            Expr::dynamic_bytes(target.prefix.clone()),
-            Expr::dynamic_bytes(target.suffix.clone()),
+            ArtifactValue::Bytes(sig),
+            ArtifactValue::Bytes(player.pubkey_bytes.clone()),
+            hash_value(player.player_id),
+            ArtifactValue::Bytes(target.prefix.clone()),
+            ArtifactValue::Bytes(target.suffix.clone()),
         ],
     );
     assert_sigscript_size("chess_mux.sil", &tx);
@@ -571,13 +578,13 @@ fn run_route(
 
 fn run_worker_apply(
     label: &str,
-    active: &CompiledContract<'_>,
-    next: &CompiledContract<'_>,
+    active: &silverscript_abi::SilAbiArtifact,
+    next: &silverscript_abi::SilAbiArtifact,
     covenant_id: Hash,
     mux: &TemplateFixture,
 ) {
     let sigscript =
-        entry_sigscript(active, "apply", vec![Expr::dynamic_bytes(mux.prefix.clone()), Expr::dynamic_bytes(mux.suffix.clone())]);
+        entry_sigscript(active, "apply", vec![ArtifactValue::Bytes(mux.prefix.clone()), ArtifactValue::Bytes(mux.suffix.clone())]);
     let outputs = vec![covenant_output(next, 0, covenant_id)];
     let entries = vec![covenant_utxo(active, covenant_id)];
     let tx = Transaction::new(1, vec![tx_input(0, sigscript, 0)], outputs, 0, Default::default(), 0, vec![]);
@@ -588,13 +595,16 @@ fn run_worker_apply(
 
 fn run_prep_apply(
     label: &str,
-    active: &CompiledContract<'_>,
-    next: &CompiledContract<'_>,
+    active: &silverscript_abi::SilAbiArtifact,
+    next: &silverscript_abi::SilAbiArtifact,
     covenant_id: Hash,
     target: &TemplateFixture,
 ) {
-    let sigscript =
-        entry_sigscript(active, "apply", vec![Expr::dynamic_bytes(target.prefix.clone()), Expr::dynamic_bytes(target.suffix.clone())]);
+    let sigscript = entry_sigscript(
+        active,
+        "apply",
+        vec![ArtifactValue::Bytes(target.prefix.clone()), ArtifactValue::Bytes(target.suffix.clone())],
+    );
     let outputs = vec![covenant_output(next, 0, covenant_id)];
     let entries = vec![covenant_utxo(active, covenant_id)];
     let tx = Transaction::new(1, vec![tx_input(0, sigscript, 0)], outputs, 0, Default::default(), 0, vec![]);
@@ -770,75 +780,80 @@ fn assert_sigscript_size(name: &str, tx: &Transaction) {
     assert_size_within_noise(&format!("{name} sigscript_len"), actual, expected);
 }
 
-fn pawn_constructor_args() -> Vec<Expr<'static>> {
+fn pawn_constructor_args() -> Vec<ArtifactValue> {
     vec![
-        Expr::bytes(vec![0x11u8; 32]),
-        Expr::bytes(sample_route_templates()),
-        Expr::bytes(vec![0x21u8; 32]),
-        Expr::bytes(vec![0x22u8; 32]),
-        Expr::bytes(standard_board()),
-        Expr::int(0),
-        Expr::int(0),
-        Expr::int(DEFAULT_MOVE_TIMEOUT),
-        Expr::bytes(vec![1u8; 4]),
-        Expr::int(-1),
-        Expr::int(12),
-        Expr::int(28),
-        Expr::int(0),
-        Expr::int(0),
-        Expr::int(3),
+        ArtifactValue::Bytes(vec![0x11u8; 32]),
+        ArtifactValue::Bytes(sample_route_templates()),
+        ArtifactValue::Bytes(vec![0x21u8; 32]),
+        ArtifactValue::Bytes(vec![0x22u8; 32]),
+        ArtifactValue::Bytes(standard_board()),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+        ArtifactValue::Bytes(vec![1u8; 4]),
+        ArtifactValue::Int(-1),
+        ArtifactValue::Int(12),
+        ArtifactValue::Int(28),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(3),
     ]
 }
 
-fn mux_constructor_args() -> Vec<Expr<'static>> {
+fn mux_constructor_args() -> Vec<ArtifactValue> {
     vec![
-        Expr::bytes(vec![0x11u8; 32]),
-        Expr::bytes(sample_route_templates()),
-        Expr::bytes(vec![0x21u8; 32]),
-        Expr::bytes(vec![0x22u8; 32]),
-        Expr::bytes(vec![0u8; 64]),
-        Expr::int(0),
-        Expr::int(0),
-        Expr::int(DEFAULT_MOVE_TIMEOUT),
-        Expr::bytes(vec![1u8; 4]),
-        Expr::int(-1),
-        Expr::int(-1),
-        Expr::int(-1),
-        Expr::int(0),
-        Expr::int(0),
-        Expr::int(3),
+        ArtifactValue::Bytes(vec![0x11u8; 32]),
+        ArtifactValue::Bytes(sample_route_templates()),
+        ArtifactValue::Bytes(vec![0x21u8; 32]),
+        ArtifactValue::Bytes(vec![0x22u8; 32]),
+        ArtifactValue::Bytes(vec![0u8; 64]),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+        ArtifactValue::Bytes(vec![1u8; 4]),
+        ArtifactValue::Int(-1),
+        ArtifactValue::Int(-1),
+        ArtifactValue::Int(-1),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(3),
     ]
 }
 
-fn settle_constructor_args() -> Vec<Expr<'static>> {
-    vec![Expr::bytes(vec![0x31u8; 32]), Expr::bytes(vec![0x21u8; 32]), Expr::bytes(vec![0x22u8; 32]), Expr::int(1)]
-}
-
-fn player_constructor_args() -> Vec<Expr<'static>> {
+fn settle_constructor_args() -> Vec<ArtifactValue> {
     vec![
-        Expr::bytes(vec![0x11u8; 32]),
-        Expr::bytes(vec![0x22u8; 32]),
-        Expr::bytes(vec![0x33u8; 32]),
-        Expr::bytes(sample_routes_commitment().as_bytes().to_vec()),
-        Expr::bytes(vec![0x44u8; 32]),
-        Expr::bytes(vec![0x55u8; 32]),
-        Expr::int(0),
-        Expr::int(1200),
-        Expr::int(7),
-        Expr::int(4),
-        Expr::int(2),
-        Expr::int(1),
+        ArtifactValue::Bytes(vec![0x31u8; 32]),
+        ArtifactValue::Bytes(vec![0x21u8; 32]),
+        ArtifactValue::Bytes(vec![0x22u8; 32]),
+        ArtifactValue::Int(1),
     ]
 }
 
-fn league_constructor_args() -> Vec<Expr<'static>> {
+fn player_constructor_args() -> Vec<ArtifactValue> {
     vec![
-        Expr::bytes(vec![0x11u8; 32]),
-        Expr::bytes(vec![0x22u8; 32]),
-        Expr::bytes(vec![0x33u8; 32]),
-        Expr::bytes(sample_routes_commitment().as_bytes().to_vec()),
-        Expr::int(1200),
-        Expr::bytes(vec![0x44u8; 32]),
+        ArtifactValue::Bytes(vec![0x11u8; 32]),
+        ArtifactValue::Bytes(vec![0x22u8; 32]),
+        ArtifactValue::Bytes(vec![0x33u8; 32]),
+        ArtifactValue::Bytes(sample_routes_commitment().as_bytes().to_vec()),
+        ArtifactValue::Bytes(vec![0x44u8; 32]),
+        ArtifactValue::Bytes(vec![0x55u8; 32]),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(1200),
+        ArtifactValue::Int(7),
+        ArtifactValue::Int(4),
+        ArtifactValue::Int(2),
+        ArtifactValue::Int(1),
+    ]
+}
+
+fn league_constructor_args() -> Vec<ArtifactValue> {
+    vec![
+        ArtifactValue::Bytes(vec![0x11u8; 32]),
+        ArtifactValue::Bytes(vec![0x22u8; 32]),
+        ArtifactValue::Bytes(vec![0x33u8; 32]),
+        ArtifactValue::Bytes(sample_routes_commitment().as_bytes().to_vec()),
+        ArtifactValue::Int(1200),
+        ArtifactValue::Bytes(vec![0x44u8; 32]),
     ]
 }
 
@@ -850,9 +865,9 @@ fn chess_apps_compile_and_probe_sizes_within_noise() {
         let source = local_contract_source(snapshot.name);
         let ctor = (snapshot.ctor)();
         let compiled = compile_cached(source, &ctor);
-        let (instruction_count, charged_op_count) = bytecode_op_counts(&compiled.bytecode);
+        let (instruction_count, charged_op_count) = bytecode_op_counts(&common::bytecode(&compiled));
 
-        actual_sizes.push((snapshot.name, compiled.bytecode.len(), instruction_count, charged_op_count));
+        actual_sizes.push((snapshot.name, common::bytecode(&compiled).len(), instruction_count, charged_op_count));
     }
 
     for (name, bytecode_len, instruction_count, charged_op_count) in &actual_sizes {
@@ -884,32 +899,32 @@ fn league_register_player_runtime_matches_expected_output_state() {
     let player_id_domain = b"LeaguePlayerId".to_vec();
 
     let player_template_ctor = vec![
-        hash_expr(league_template),
-        hash_expr(repeated_hash(0x44)),
-        hash_expr(fix.mux.hash),
-        hash_expr(routes_commitment),
-        hash_expr(repeated_hash(0x55)),
-        hash_expr(repeated_hash(0x77)),
-        Expr::int(0),
-        Expr::int(900),
-        Expr::int(1),
-        Expr::int(2),
-        Expr::int(3),
-        Expr::int(4),
+        hash_value(league_template),
+        hash_value(repeated_hash(0x44)),
+        hash_value(fix.mux.hash),
+        hash_value(routes_commitment),
+        hash_value(repeated_hash(0x55)),
+        hash_value(repeated_hash(0x77)),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(900),
+        ArtifactValue::Int(1),
+        ArtifactValue::Int(2),
+        ArtifactValue::Int(3),
+        ArtifactValue::Int(4),
     ];
     let player_template_contract = compile_cached(player_source(), &player_template_ctor);
-    let layout = player_template_contract.state_layout;
-    let player_prefix = player_template_contract.bytecode[..layout.start].to_vec();
-    let player_suffix = player_template_contract.bytecode[layout.start + layout.len..].to_vec();
-    let player_template = Hash::from_bytes(player_template_contract.template_hash());
+    let layout = common::state_layout(&player_template_contract);
+    let player_prefix = common::bytecode(&player_template_contract)[..layout.start].to_vec();
+    let player_suffix = common::bytecode(&player_template_contract)[layout.start + layout.len..].to_vec();
+    let player_template = Hash::from_bytes(common::template_hash(&player_template_contract));
 
     let league_ctor = vec![
-        hash_expr(league_template),
-        hash_expr(player_template),
-        hash_expr(fix.mux.hash),
-        hash_expr(routes_commitment),
-        Expr::int(base_rating),
-        hash_expr(admin),
+        hash_value(league_template),
+        hash_value(player_template),
+        hash_value(fix.mux.hash),
+        hash_value(routes_commitment),
+        ArtifactValue::Int(base_rating),
+        hash_value(admin),
     ];
     let league = compile_cached(league_source(), &league_ctor);
 
@@ -944,10 +959,10 @@ fn league_register_player_runtime_matches_expected_output_state() {
         &league,
         "register_player",
         vec![
-            Expr::bytes(vec![0u8; 65]),
-            Expr::bytes(owner.pubkey_bytes.clone()),
-            Expr::dynamic_bytes(player_prefix.clone()),
-            Expr::dynamic_bytes(player_suffix.clone()),
+            ArtifactValue::Bytes(vec![0u8; 65]),
+            ArtifactValue::Bytes(owner.pubkey_bytes.clone()),
+            ArtifactValue::Bytes(player_prefix.clone()),
+            ArtifactValue::Bytes(player_suffix.clone()),
         ],
     );
     let outputs = vec![covenant_output(&league, 0, covenant_id), covenant_output(&registered_player, 0, covenant_id)];
@@ -960,10 +975,10 @@ fn league_register_player_runtime_matches_expected_output_state() {
         &league,
         "register_player",
         vec![
-            Expr::bytes(sig),
-            Expr::bytes(owner.pubkey_bytes),
-            Expr::dynamic_bytes(player_prefix),
-            Expr::dynamic_bytes(player_suffix),
+            ArtifactValue::Bytes(sig),
+            ArtifactValue::Bytes(owner.pubkey_bytes),
+            ArtifactValue::Bytes(player_prefix),
+            ArtifactValue::Bytes(player_suffix),
         ],
     );
 
@@ -1001,10 +1016,10 @@ fn player_start_game_runtime_matches_expected_output_states() {
             losses: 0,
         },
     );
-    let player_layout = player_contract.state_layout;
-    let player_template = Hash::from_bytes(player_contract.template_hash());
+    let player_layout = common::state_layout(&player_contract);
+    let player_template = Hash::from_bytes(common::template_hash(&player_contract));
     let player_prefix_len = player_layout.start as i64;
-    let player_suffix_len = (player_contract.bytecode.len() - (player_layout.start + player_layout.len)) as i64;
+    let player_suffix_len = (common::bytecode(&player_contract).len() - (player_layout.start + player_layout.len)) as i64;
 
     let white_player = compile_player_state(
         player_source(),
@@ -1097,26 +1112,26 @@ fn player_start_game_runtime_matches_expected_output_states() {
         &white_player,
         "start_game",
         vec![
-            Expr::bytes(vec![0u8; 65]),
-            Expr::bytes(white.pubkey_bytes.clone()),
-            Expr::int(0),
-            Expr::int(player_prefix_len),
-            Expr::int(player_suffix_len),
-            Expr::bytes(route_templates.clone()),
-            Expr::int(DEFAULT_MOVE_TIMEOUT),
-            Expr::dynamic_bytes(fix.mux.prefix.clone()),
-            Expr::dynamic_bytes(fix.mux.suffix.clone()),
+            ArtifactValue::Bytes(vec![0u8; 65]),
+            ArtifactValue::Bytes(white.pubkey_bytes.clone()),
+            ArtifactValue::Int(0),
+            ArtifactValue::Int(player_prefix_len),
+            ArtifactValue::Int(player_suffix_len),
+            ArtifactValue::Bytes(route_templates.clone()),
+            ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+            ArtifactValue::Bytes(fix.mux.prefix.clone()),
+            ArtifactValue::Bytes(fix.mux.suffix.clone()),
         ],
     );
     let black_placeholder = entry_sigscript(
         &black_player,
         "delegate_start_game",
         vec![
-            Expr::bytes(vec![0u8; 65]),
-            Expr::bytes(black.pubkey_bytes.clone()),
-            Expr::int(DEFAULT_MOVE_TIMEOUT),
-            Expr::int(player_prefix_len),
-            Expr::int(player_suffix_len),
+            ArtifactValue::Bytes(vec![0u8; 65]),
+            ArtifactValue::Bytes(black.pubkey_bytes.clone()),
+            ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+            ArtifactValue::Int(player_prefix_len),
+            ArtifactValue::Int(player_suffix_len),
         ],
     );
 
@@ -1143,26 +1158,26 @@ fn player_start_game_runtime_matches_expected_output_states() {
         &white_player,
         "start_game",
         vec![
-            Expr::bytes(white_sig),
-            Expr::bytes(white.pubkey_bytes),
-            Expr::int(0),
-            Expr::int(player_prefix_len),
-            Expr::int(player_suffix_len),
-            Expr::bytes(route_templates),
-            Expr::int(DEFAULT_MOVE_TIMEOUT),
-            Expr::dynamic_bytes(fix.mux.prefix.clone()),
-            Expr::dynamic_bytes(fix.mux.suffix.clone()),
+            ArtifactValue::Bytes(white_sig),
+            ArtifactValue::Bytes(white.pubkey_bytes),
+            ArtifactValue::Int(0),
+            ArtifactValue::Int(player_prefix_len),
+            ArtifactValue::Int(player_suffix_len),
+            ArtifactValue::Bytes(route_templates),
+            ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+            ArtifactValue::Bytes(fix.mux.prefix.clone()),
+            ArtifactValue::Bytes(fix.mux.suffix.clone()),
         ],
     );
     tx.inputs[1].signature_script = entry_sigscript(
         &black_player,
         "delegate_start_game",
         vec![
-            Expr::bytes(black_sig),
-            Expr::bytes(black.pubkey_bytes),
-            Expr::int(DEFAULT_MOVE_TIMEOUT),
-            Expr::int(player_prefix_len),
-            Expr::int(player_suffix_len),
+            ArtifactValue::Bytes(black_sig),
+            ArtifactValue::Bytes(black.pubkey_bytes),
+            ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+            ArtifactValue::Int(player_prefix_len),
+            ArtifactValue::Int(player_suffix_len),
         ],
     );
 
@@ -1217,30 +1232,38 @@ fn player_rebalance_requires_a_standalone_covenant_input() {
             losses: 0,
         },
     );
-    let player_layout = player.state_layout;
+    let player_layout = common::state_layout(&player);
     let player_prefix_len = player_layout.start as i64;
-    let player_suffix_len = (player.bytecode.len() - player_layout.start - player_layout.len) as i64;
+    let player_suffix_len = (common::bytecode(&player).len() - player_layout.start - player_layout.len) as i64;
 
-    let placeholder = entry_sigscript(&player, "rebalance", vec![Expr::bytes(vec![0u8; 65]), Expr::bytes(owner.pubkey_bytes.clone())]);
+    let placeholder = entry_sigscript(
+        &player,
+        "rebalance",
+        vec![ArtifactValue::Bytes(vec![0u8; 65]), ArtifactValue::Bytes(owner.pubkey_bytes.clone())],
+    );
     let entries = vec![covenant_utxo(&player, covenant_id)];
     let outputs = vec![covenant_output(&player, 0, covenant_id)];
     let mut standalone_tx = Transaction::new(1, vec![tx_input(0, placeholder, 1)], outputs, 0, Default::default(), 0, vec![]);
     let signature = sign_tx_input_schnorr(&standalone_tx, &entries, 0, &owner);
     standalone_tx.inputs[0].signature_script =
-        entry_sigscript(&player, "rebalance", vec![Expr::bytes(signature), Expr::bytes(owner.pubkey_bytes.clone())]);
+        entry_sigscript(&player, "rebalance", vec![ArtifactValue::Bytes(signature), ArtifactValue::Bytes(owner.pubkey_bytes.clone())]);
     let standalone_result = execute_input_with_covenants(standalone_tx, entries, 0);
     assert!(standalone_result.is_ok(), "standalone player rebalance failed: {}", standalone_result.unwrap_err());
 
-    let placeholder = entry_sigscript(&player, "rebalance", vec![Expr::bytes(vec![0u8; 65]), Expr::bytes(owner.pubkey_bytes.clone())]);
+    let placeholder = entry_sigscript(
+        &player,
+        "rebalance",
+        vec![ArtifactValue::Bytes(vec![0u8; 65]), ArtifactValue::Bytes(owner.pubkey_bytes.clone())],
+    );
     let delegate_placeholder = entry_sigscript(
         &delegate,
         "delegate_start_game",
         vec![
-            Expr::bytes(vec![0u8; 65]),
-            Expr::bytes(delegate_owner.pubkey_bytes.clone()),
-            Expr::int(DEFAULT_MOVE_TIMEOUT),
-            Expr::int(player_prefix_len),
-            Expr::int(player_suffix_len),
+            ArtifactValue::Bytes(vec![0u8; 65]),
+            ArtifactValue::Bytes(delegate_owner.pubkey_bytes.clone()),
+            ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+            ArtifactValue::Int(player_prefix_len),
+            ArtifactValue::Int(player_suffix_len),
         ],
     );
     let entries = vec![covenant_utxo(&player, covenant_id), covenant_utxo(&delegate, covenant_id)];
@@ -1257,16 +1280,16 @@ fn player_rebalance_requires_a_standalone_covenant_input() {
     let signature = sign_tx_input_schnorr(&shared_tx, &entries, 0, &owner);
     let delegate_signature = sign_tx_input_schnorr(&shared_tx, &entries, 1, &delegate_owner);
     shared_tx.inputs[0].signature_script =
-        entry_sigscript(&player, "rebalance", vec![Expr::bytes(signature), Expr::bytes(owner.pubkey_bytes)]);
+        entry_sigscript(&player, "rebalance", vec![ArtifactValue::Bytes(signature), ArtifactValue::Bytes(owner.pubkey_bytes)]);
     shared_tx.inputs[1].signature_script = entry_sigscript(
         &delegate,
         "delegate_start_game",
         vec![
-            Expr::bytes(delegate_signature),
-            Expr::bytes(delegate_owner.pubkey_bytes),
-            Expr::int(DEFAULT_MOVE_TIMEOUT),
-            Expr::int(player_prefix_len),
-            Expr::int(player_suffix_len),
+            ArtifactValue::Bytes(delegate_signature),
+            ArtifactValue::Bytes(delegate_owner.pubkey_bytes),
+            ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+            ArtifactValue::Int(player_prefix_len),
+            ArtifactValue::Int(player_suffix_len),
         ],
     );
     let delegate_result = execute_input_with_covenants(shared_tx.clone(), entries.clone(), 1);
@@ -1318,29 +1341,37 @@ fn player_retire_requires_a_standalone_covenant_input() {
             losses: 0,
         },
     );
-    let player_layout = player.state_layout;
+    let player_layout = common::state_layout(&player);
     let player_prefix_len = player_layout.start as i64;
-    let player_suffix_len = (player.bytecode.len() - player_layout.start - player_layout.len) as i64;
+    let player_suffix_len = (common::bytecode(&player).len() - player_layout.start - player_layout.len) as i64;
 
-    let placeholder = entry_sigscript(&player, "retire", vec![Expr::bytes(vec![0u8; 65]), Expr::bytes(owner.pubkey_bytes.clone())]);
+    let placeholder = entry_sigscript(
+        &player,
+        "retire",
+        vec![ArtifactValue::Bytes(vec![0u8; 65]), ArtifactValue::Bytes(owner.pubkey_bytes.clone())],
+    );
     let entries = vec![covenant_utxo(&player, covenant_id)];
     let mut standalone_tx = Transaction::new(1, vec![tx_input(0, placeholder, 1)], vec![], 0, Default::default(), 0, vec![]);
     let signature = sign_tx_input_schnorr(&standalone_tx, &entries, 0, &owner);
     standalone_tx.inputs[0].signature_script =
-        entry_sigscript(&player, "retire", vec![Expr::bytes(signature), Expr::bytes(owner.pubkey_bytes.clone())]);
+        entry_sigscript(&player, "retire", vec![ArtifactValue::Bytes(signature), ArtifactValue::Bytes(owner.pubkey_bytes.clone())]);
     let standalone_result = execute_input_with_covenants(standalone_tx, entries, 0);
     assert!(standalone_result.is_ok(), "standalone player retirement failed: {}", standalone_result.unwrap_err());
 
-    let placeholder = entry_sigscript(&player, "retire", vec![Expr::bytes(vec![0u8; 65]), Expr::bytes(owner.pubkey_bytes.clone())]);
+    let placeholder = entry_sigscript(
+        &player,
+        "retire",
+        vec![ArtifactValue::Bytes(vec![0u8; 65]), ArtifactValue::Bytes(owner.pubkey_bytes.clone())],
+    );
     let delegate_placeholder = entry_sigscript(
         &delegate,
         "delegate_start_game",
         vec![
-            Expr::bytes(vec![0u8; 65]),
-            Expr::bytes(delegate_owner.pubkey_bytes.clone()),
-            Expr::int(DEFAULT_MOVE_TIMEOUT),
-            Expr::int(player_prefix_len),
-            Expr::int(player_suffix_len),
+            ArtifactValue::Bytes(vec![0u8; 65]),
+            ArtifactValue::Bytes(delegate_owner.pubkey_bytes.clone()),
+            ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+            ArtifactValue::Int(player_prefix_len),
+            ArtifactValue::Int(player_suffix_len),
         ],
     );
     let entries = vec![covenant_utxo(&player, covenant_id), covenant_utxo(&delegate, covenant_id)];
@@ -1356,16 +1387,16 @@ fn player_retire_requires_a_standalone_covenant_input() {
     let signature = sign_tx_input_schnorr(&shared_tx, &entries, 0, &owner);
     let delegate_signature = sign_tx_input_schnorr(&shared_tx, &entries, 1, &delegate_owner);
     shared_tx.inputs[0].signature_script =
-        entry_sigscript(&player, "retire", vec![Expr::bytes(signature), Expr::bytes(owner.pubkey_bytes)]);
+        entry_sigscript(&player, "retire", vec![ArtifactValue::Bytes(signature), ArtifactValue::Bytes(owner.pubkey_bytes)]);
     shared_tx.inputs[1].signature_script = entry_sigscript(
         &delegate,
         "delegate_start_game",
         vec![
-            Expr::bytes(delegate_signature),
-            Expr::bytes(delegate_owner.pubkey_bytes),
-            Expr::int(DEFAULT_MOVE_TIMEOUT),
-            Expr::int(player_prefix_len),
-            Expr::int(player_suffix_len),
+            ArtifactValue::Bytes(delegate_signature),
+            ArtifactValue::Bytes(delegate_owner.pubkey_bytes),
+            ArtifactValue::Int(DEFAULT_MOVE_TIMEOUT),
+            ArtifactValue::Int(player_prefix_len),
+            ArtifactValue::Int(player_suffix_len),
         ],
     );
     let delegate_result = execute_input_with_covenants(shared_tx.clone(), entries.clone(), 1);
@@ -1864,8 +1895,8 @@ fn settle_runtime_matches_expected_output_states() {
             losses: 0,
         },
     );
-    let player_layout = player_contract.state_layout;
-    let player_template = Hash::from_bytes(player_contract.template_hash());
+    let player_layout = common::state_layout(&player_contract);
+    let player_template = Hash::from_bytes(common::template_hash(&player_contract));
     let white_player = compile_player_state(
         player_source(),
         PlayerStateArgs {
@@ -1944,8 +1975,8 @@ fn settle_runtime_matches_expected_output_states() {
         &routed_settle,
         "settle",
         vec![
-            Expr::int(player_layout.start as i64),
-            Expr::int((player_contract.bytecode.len() - player_layout.start - player_layout.len) as i64),
+            ArtifactValue::Int(player_layout.start as i64),
+            ArtifactValue::Int((common::bytecode(&player_contract).len() - player_layout.start - player_layout.len) as i64),
         ],
     );
     let settle_prefix_len = fix.settle.prefix.len() as i64;
@@ -1954,16 +1985,21 @@ fn settle_runtime_matches_expected_output_states() {
         &white_player,
         "delegate_settle",
         vec![
-            Expr::int(settle_prefix_len),
-            Expr::int(settle_suffix_len),
-            hash_expr(fix.settle.hash),
-            Expr::bytes(route_templates.clone()),
+            ArtifactValue::Int(settle_prefix_len),
+            ArtifactValue::Int(settle_suffix_len),
+            hash_value(fix.settle.hash),
+            ArtifactValue::Bytes(route_templates.clone()),
         ],
     );
     let black_delegate_sigscript = entry_sigscript(
         &black_player,
         "delegate_settle",
-        vec![Expr::int(settle_prefix_len), Expr::int(settle_suffix_len), hash_expr(fix.settle.hash), Expr::bytes(route_templates)],
+        vec![
+            ArtifactValue::Int(settle_prefix_len),
+            ArtifactValue::Int(settle_suffix_len),
+            hash_value(fix.settle.hash),
+            ArtifactValue::Bytes(route_templates),
+        ],
     );
 
     let outputs = vec![

--- a/silverscript-lang/tests/chess_apps_tests.rs
+++ b/silverscript-lang/tests/chess_apps_tests.rs
@@ -23,7 +23,7 @@ use kaspa_txscript::{
 use kaspa_txscript_errors::TxScriptError;
 use secp256k1::{Keypair, Message, Secp256k1, SecretKey};
 use silverscript_abi::ArtifactValue;
-use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
+use silverscript_lang::compiler::{CompileOptions, compile_to_sil_abi_artifact_with_options};
 
 const DEFAULT_MOVE_TIMEOUT: i64 = 600;
 
@@ -129,7 +129,7 @@ fn compile_cached(source: &'static str, ctor: &[ArtifactValue]) -> Arc<silverscr
     }
 
     let compiled =
-        Arc::new(sil_abi_artifact_with_options(source, ctor, CompileOptions::default()).expect("compile chess contract succeeds"));
+        Arc::new(compile_to_sil_abi_artifact_with_options(source, ctor, CompileOptions::default()).expect("compile chess contract succeeds"));
     let mut cache = compiled_contract_cache().lock().expect("compile cache mutex poisoned");
     cache.insert(key, Arc::clone(&compiled));
     compiled

--- a/silverscript-lang/tests/chess_apps_tests.rs
+++ b/silverscript-lang/tests/chess_apps_tests.rs
@@ -128,8 +128,9 @@ fn compile_cached(source: &'static str, ctor: &[ArtifactValue]) -> Arc<silverscr
         }
     }
 
-    let compiled =
-        Arc::new(compile_to_sil_abi_artifact_with_options(source, ctor, CompileOptions::default()).expect("compile chess contract succeeds"));
+    let compiled = Arc::new(
+        compile_to_sil_abi_artifact_with_options(source, ctor, CompileOptions::default()).expect("compile chess contract succeeds"),
+    );
     let mut cache = compiled_contract_cache().lock().expect("compile cache mutex poisoned");
     cache.insert(key, Arc::clone(&compiled));
     compiled

--- a/silverscript-lang/tests/common.rs
+++ b/silverscript-lang/tests/common.rs
@@ -32,7 +32,7 @@ pub fn compile_contract(
 }
 
 pub fn single_contract(artifact: &SilAbiArtifact) -> &SilContractArtifact {
-    let [contract] = artifact.contracts.as_slice() else {
+    let Some(contract) = artifact.contracts.values().next().filter(|_| artifact.contracts.len() == 1) else {
         panic!("expected exactly one contract, found {}", artifact.contracts.len());
     };
     contract
@@ -61,34 +61,36 @@ pub fn build_sig_script_for_covenant_decl(
     args: Vec<ArtifactValue>,
     options: CovenantDeclCallOptions,
 ) -> Result<Vec<u8>, CompilerError> {
-    let contract = single_contract(artifact);
-    encode_contract_covenant_decl_sig_script(artifact, &contract.name, function_name, options.is_leader, &args)
+    let Some((contract_name, _)) = artifact.contracts.first_key_value().filter(|_| artifact.contracts.len() == 1) else {
+        return Err(CompilerError::Unsupported(format!("expected exactly one contract, found {}", artifact.contracts.len())));
+    };
+    encode_contract_covenant_decl_sig_script(artifact, contract_name, function_name, options.is_leader, &args)
         .map_err(|err| CompilerError::Unsupported(err.to_string()))
 }
 
 /// Encodes an invocation for an artifact containing exactly one contract and
 /// exactly one public entrypoint.
 pub fn encode_single_entry_sig_script(artifact: &SilAbiArtifact, args: &[ArtifactValue]) -> CodecResult<Vec<u8>> {
-    let [contract] = artifact.contracts.as_slice() else {
+    let Some((contract_name, contract)) = artifact.contracts.first_key_value().filter(|_| artifact.contracts.len() == 1) else {
         return Err(CodecError::UnsupportedType(format!("expected exactly one contract, found {}", artifact.contracts.len())));
     };
-    let [entry] = contract.entries.as_slice() else {
+    let Some((entry_name, _)) = contract.entries.first_key_value().filter(|_| contract.entries.len() == 1) else {
         return Err(CodecError::UnsupportedType(format!(
             "expected exactly one entry in contract `{}`, found {}",
-            contract.name,
+            contract_name,
             contract.entries.len()
         )));
     };
-    encode_contract_entry_sig_script(artifact, &contract.name, &entry.name, args)
+    encode_contract_entry_sig_script(artifact, contract_name, entry_name, args)
 }
 
 /// Encodes a named entry invocation for an artifact containing exactly one
 /// contract.
 pub fn encode_entry_sig_script(artifact: &SilAbiArtifact, entry_name: &str, args: &[ArtifactValue]) -> CodecResult<Vec<u8>> {
-    let [contract] = artifact.contracts.as_slice() else {
+    let Some((contract_name, _)) = artifact.contracts.first_key_value().filter(|_| artifact.contracts.len() == 1) else {
         return Err(CodecError::UnsupportedType(format!("expected exactly one contract, found {}", artifact.contracts.len())));
     };
-    encode_contract_entry_sig_script(artifact, &contract.name, entry_name, args)
+    encode_contract_entry_sig_script(artifact, contract_name, entry_name, args)
 }
 
 pub fn push_redeem_script(bytecode: &[u8]) -> Vec<u8> {

--- a/silverscript-lang/tests/common.rs
+++ b/silverscript-lang/tests/common.rs
@@ -17,7 +17,7 @@ use silverscript_abi::{
     encode_contract_covenant_decl_sig_script, encode_contract_entry_sig_script,
 };
 use silverscript_lang::compiler::{
-    CompileOptions, CompiledStateLayout, CompilerError, CovenantDeclCallOptions, sil_abi_artifact_with_options,
+    CompileOptions, CompiledStateLayout, CompilerError, CovenantDeclCallOptions, compile_to_sil_abi_artifact_with_options,
 };
 
 pub const COV_A: Hash = Hash::from_bytes(*b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
@@ -28,7 +28,7 @@ pub fn compile_contract(
     constructor_args: &[ArtifactValue],
     options: CompileOptions,
 ) -> Result<SilAbiArtifact, CompilerError> {
-    sil_abi_artifact_with_options(source, constructor_args, options)
+    compile_to_sil_abi_artifact_with_options(source, constructor_args, options)
 }
 
 pub fn single_contract(artifact: &SilAbiArtifact) -> &SilContractArtifact {

--- a/silverscript-lang/tests/common.rs
+++ b/silverscript-lang/tests/common.rs
@@ -13,7 +13,8 @@ use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::{EngineCtx, EngineFlags, TxScriptEngine, pay_to_script_hash_script};
 use kaspa_txscript_errors::TxScriptError;
 use silverscript_abi::{
-    ArtifactValue, CodecError, CodecResult, SilAbiArtifact, SilContractArtifact, SilEntryArtifact, encode_contract_entry_sig_script,
+    ArtifactValue, CodecError, CodecResult, SilAbiArtifact, SilContractArtifact, SilEntryArtifact,
+    encode_contract_covenant_decl_sig_script, encode_contract_entry_sig_script,
 };
 use silverscript_lang::compiler::{
     CompileOptions, CompiledStateLayout, CompilerError, CovenantDeclCallOptions, sil_abi_artifact_with_options,
@@ -54,25 +55,15 @@ pub fn template_hash(artifact: &SilAbiArtifact) -> [u8; 32] {
     single_contract(artifact).compiled.template_hash
 }
 
-pub fn covenant_decl_entrypoint_name<'a>(artifact: &'a SilAbiArtifact, function_name: &str, is_leader: bool) -> Option<&'a str> {
-    let contract = single_contract(artifact);
-    let entry = contract.cov_decl_to_abi.get(function_name)?;
-    if is_leader || contract.delegate_entry_abi.is_none() {
-        Some(&entry.name)
-    } else {
-        contract.delegate_entry_abi.as_ref().map(|entry| entry.name.as_str())
-    }
-}
-
 pub fn build_sig_script_for_covenant_decl(
     artifact: &SilAbiArtifact,
     function_name: &str,
     args: Vec<ArtifactValue>,
     options: CovenantDeclCallOptions,
 ) -> Result<Vec<u8>, CompilerError> {
-    let entrypoint = covenant_decl_entrypoint_name(artifact, function_name, options.is_leader)
-        .ok_or_else(|| CompilerError::Unsupported(format!("covenant declaration '{function_name}' not found")))?;
-    encode_entry_sig_script(artifact, entrypoint, &args).map_err(|err| CompilerError::Unsupported(err.to_string()))
+    let contract = single_contract(artifact);
+    encode_contract_covenant_decl_sig_script(artifact, &contract.name, function_name, options.is_leader, &args)
+        .map_err(|err| CompilerError::Unsupported(err.to_string()))
 }
 
 /// Encodes an invocation for an artifact containing exactly one contract and

--- a/silverscript-lang/tests/common.rs
+++ b/silverscript-lang/tests/common.rs
@@ -12,11 +12,93 @@ use kaspa_txscript::opcodes::codes::OpTrue;
 use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::{EngineCtx, EngineFlags, TxScriptEngine, pay_to_script_hash_script};
 use kaspa_txscript_errors::TxScriptError;
-use silverscript_lang::ast::Expr;
-use silverscript_lang::compiler::{CompiledContract, CovenantDeclCallOptions};
+use silverscript_abi::{
+    ArtifactValue, CodecError, CodecResult, SilAbiArtifact, SilContractArtifact, SilEntryArtifact, encode_contract_entry_sig_script,
+};
+use silverscript_lang::compiler::{
+    CompileOptions, CompiledStateLayout, CompilerError, CovenantDeclCallOptions, sil_abi_artifact_with_options,
+};
 
 pub const COV_A: Hash = Hash::from_bytes(*b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
 pub const COV_B: Hash = Hash::from_bytes(*b"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
+
+pub fn compile_contract(
+    source: &str,
+    constructor_args: &[ArtifactValue],
+    options: CompileOptions,
+) -> Result<SilAbiArtifact, CompilerError> {
+    sil_abi_artifact_with_options(source, constructor_args, options)
+}
+
+pub fn single_contract(artifact: &SilAbiArtifact) -> &SilContractArtifact {
+    let [contract] = artifact.contracts.as_slice() else {
+        panic!("expected exactly one contract, found {}", artifact.contracts.len());
+    };
+    contract
+}
+
+pub fn bytecode(artifact: &SilAbiArtifact) -> Vec<u8> {
+    single_contract(artifact).compiled.bytecode.clone()
+}
+
+pub fn state_layout(artifact: &SilAbiArtifact) -> CompiledStateLayout {
+    let span = single_contract(artifact).compiled.state_span;
+    CompiledStateLayout { start: span.offset, len: span.len }
+}
+
+pub fn entry_by_name<'a>(artifact: &'a SilAbiArtifact, name: &str) -> Option<&'a SilEntryArtifact> {
+    single_contract(artifact).entry(name)
+}
+
+pub fn template_hash(artifact: &SilAbiArtifact) -> [u8; 32] {
+    single_contract(artifact).compiled.template_hash
+}
+
+pub fn covenant_decl_entrypoint_name<'a>(artifact: &'a SilAbiArtifact, function_name: &str, is_leader: bool) -> Option<&'a str> {
+    let contract = single_contract(artifact);
+    let entry = contract.cov_decl_to_abi.get(function_name)?;
+    if is_leader || contract.delegate_entry_abi.is_none() {
+        Some(&entry.name)
+    } else {
+        contract.delegate_entry_abi.as_ref().map(|entry| entry.name.as_str())
+    }
+}
+
+pub fn build_sig_script_for_covenant_decl(
+    artifact: &SilAbiArtifact,
+    function_name: &str,
+    args: Vec<ArtifactValue>,
+    options: CovenantDeclCallOptions,
+) -> Result<Vec<u8>, CompilerError> {
+    let entrypoint = covenant_decl_entrypoint_name(artifact, function_name, options.is_leader)
+        .ok_or_else(|| CompilerError::Unsupported(format!("covenant declaration '{function_name}' not found")))?;
+    encode_entry_sig_script(artifact, entrypoint, &args).map_err(|err| CompilerError::Unsupported(err.to_string()))
+}
+
+/// Encodes an invocation for an artifact containing exactly one contract and
+/// exactly one public entrypoint.
+pub fn encode_single_entry_sig_script(artifact: &SilAbiArtifact, args: &[ArtifactValue]) -> CodecResult<Vec<u8>> {
+    let [contract] = artifact.contracts.as_slice() else {
+        return Err(CodecError::UnsupportedType(format!("expected exactly one contract, found {}", artifact.contracts.len())));
+    };
+    let [entry] = contract.entries.as_slice() else {
+        return Err(CodecError::UnsupportedType(format!(
+            "expected exactly one entry in contract `{}`, found {}",
+            contract.name,
+            contract.entries.len()
+        )));
+    };
+    encode_contract_entry_sig_script(artifact, &contract.name, &entry.name, args)
+}
+
+/// Encodes a named entry invocation for an artifact containing exactly one
+/// contract.
+pub fn encode_entry_sig_script(artifact: &SilAbiArtifact, entry_name: &str, args: &[ArtifactValue]) -> CodecResult<Vec<u8>> {
+    let [contract] = artifact.contracts.as_slice() else {
+        return Err(CodecError::UnsupportedType(format!("expected exactly one contract, found {}", artifact.contracts.len())));
+    };
+    encode_contract_entry_sig_script(artifact, &contract.name, entry_name, args)
+}
 
 pub fn push_redeem_script(bytecode: &[u8]) -> Vec<u8> {
     ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() })
@@ -25,16 +107,15 @@ pub fn push_redeem_script(bytecode: &[u8]) -> Vec<u8> {
         .drain()
 }
 
-pub fn covenant_decl_sigscript(compiled: &CompiledContract<'_>, function_name: &str, args: Vec<Expr<'_>>, is_leader: bool) -> Vec<u8> {
-    let mut sigscript = compiled
-        .build_sig_script_for_covenant_decl(function_name, args, CovenantDeclCallOptions { is_leader })
+pub fn covenant_decl_sigscript(compiled: &SilAbiArtifact, function_name: &str, args: Vec<ArtifactValue>, is_leader: bool) -> Vec<u8> {
+    let mut sigscript = build_sig_script_for_covenant_decl(compiled, function_name, args, CovenantDeclCallOptions { is_leader })
         .expect("build covenant declaration sigscript");
-    sigscript.extend_from_slice(&push_redeem_script(&compiled.bytecode));
+    sigscript.extend_from_slice(&push_redeem_script(&bytecode(compiled)));
     sigscript
 }
 
-pub fn covenant_utxo(compiled: &CompiledContract<'_>, covenant_id: Hash) -> UtxoEntry {
-    UtxoEntry::new(1_500, pay_to_script_hash_script(&compiled.bytecode), 0, false, Some(covenant_id))
+pub fn covenant_utxo(compiled: &SilAbiArtifact, covenant_id: Hash) -> UtxoEntry {
+    UtxoEntry::new(1_500, pay_to_script_hash_script(&bytecode(compiled)), 0, false, Some(covenant_id))
 }
 
 pub fn plain_covenant_output(authorizing_input: u16, covenant_id: Hash) -> TransactionOutput {
@@ -81,18 +162,19 @@ pub fn tx_input(index: u32, signature_script: Vec<u8>) -> TransactionInput {
     )
 }
 
-pub fn covenant_output(compiled: &CompiledContract<'_>, authorizing_input: u16, covenant_id: Hash) -> TransactionOutput {
+pub fn covenant_output(compiled: &SilAbiArtifact, authorizing_input: u16, covenant_id: Hash) -> TransactionOutput {
     TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&compiled.bytecode),
+        script_public_key: pay_to_script_hash_script(&bytecode(compiled)),
         covenant: Some(CovenantBinding { authorizing_input, covenant_id }),
     }
 }
 
-pub fn compiled_template_parts_and_hash(compiled: &CompiledContract) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-    let layout = compiled.state_layout;
-    let prefix = compiled.bytecode[..layout.start].to_vec();
-    let suffix = compiled.bytecode[layout.start + layout.len..].to_vec();
-    let template_hash = compiled.template_hash().to_vec();
+pub fn compiled_template_parts_and_hash(compiled: &SilAbiArtifact) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    let layout = state_layout(compiled);
+    let bytecode = bytecode(compiled);
+    let prefix = bytecode[..layout.start].to_vec();
+    let suffix = bytecode[layout.start + layout.len..].to_vec();
+    let template_hash = template_hash(compiled).to_vec();
     (prefix, suffix, template_hash)
 }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -385,6 +385,29 @@ fn supports_struct_contract_params_fields_and_constants() {
 }
 
 #[test]
+fn portable_abi_verifies_struct_contract_field_state_layout() {
+    let source = r#"
+        contract StructState(Pair init_pair) {
+            struct Pair {
+                int amount;
+                byte[2] code;
+            }
+
+            Pair from_param = init_pair;
+
+            entry main() {
+                require(true);
+            }
+        }
+    "#;
+    let args = vec![artifact_object([("amount", 11.into()), ("code", vec![0xabu8, 0xcd].into())])];
+
+    let abi = compile_to_sil_abi_artifact(source, &args).expect("struct state contract compiles to a portable ABI");
+
+    abi.verify().expect("portable ABI runtime-state metadata matches the flattened state span");
+}
+
+#[test]
 fn constructor_arguments_are_concrete_values_not_runtime_introspection() {
     let source = r#"
         contract RuntimeConstructor(int expected_lock_time) {

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -22,9 +22,9 @@ use kaspa_txscript::{
 use silverscript_abi::{ArtifactValue, SilAbiArtifact, TypeArtifact};
 use silverscript_lang::ast::{ContractAst, Expr, ExprKind, Statement, format_contract_ast, parse_contract_ast, parse_type_ref};
 use silverscript_lang::compiler::{
-    COMPILER_VERSION, CompileOptions, CompiledContract, CompilerError, CovenantDeclCallOptions, DispatchTag, FunctionAbiEntry,
-    FunctionInputAbi, compile_contract as compile_internal_contract, compile_contract_ast, compile_debug_expr,
-    generated_covenant_auth_entrypoint_name, sil_abi_artifact, struct_object,
+    COMPILER_VERSION, CompileOptions, CompiledContract, CompilerError, CovenantDeclCallOptions, DispatchTag,
+    compile_contract as compile_internal_contract, compile_contract_ast, compile_debug_expr, generated_covenant_auth_entrypoint_name,
+    sil_abi_artifact, sil_abi_artifact_from_compiled, struct_object,
 };
 use silverscript_lang::debug_info::StepKind;
 use silverscript_lang::template::template_hash;
@@ -3012,21 +3012,10 @@ fn matrix_state_array_arg(values: Vec<(i64, Vec<u8>)>) -> ArtifactValue {
 fn replace_compiled_interface<'i>(
     compiled: &mut CompiledContract<'i>,
     source: &'i str,
-    entrypoint_name: &str,
-    inputs: &[(&str, &str)],
-    dispatch_tag: DispatchTag,
+    old_dispatch_tag: DispatchTag,
+    new_dispatch_tag: DispatchTag,
 ) {
-    let old_dispatch_tag = compiled.abi[0].dispatch_tag;
     compiled.ast = parse_contract_ast(source).expect("interface parses");
-    compiled.abi = vec![FunctionAbiEntry {
-        name: entrypoint_name.to_string(),
-        inputs: inputs
-            .iter()
-            .map(|(name, type_name)| FunctionInputAbi { name: (*name).to_string(), type_name: (*type_name).to_string() })
-            .collect(),
-        dispatch_tag,
-    }];
-    let new_dispatch_tag = compiled.abi[0].dispatch_tag;
     let tag_offset = compiled
         .bytecode
         .windows(old_dispatch_tag.len())
@@ -3786,9 +3775,11 @@ fn runtime_supports_regular_struct_array_entrypoint_arguments_with_struct_signat
     "#;
 
     let mut compiled = compile_internal_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let original_artifact = sil_abi_artifact(source, &[]).expect("original interface compiles");
+    let old_dispatch_tag = single_contract(&original_artifact).entry("main").expect("main entry exists").dispatch_tag.into_bytes();
     let interface_artifact = sil_abi_artifact(struct_signature_source, &[]).expect("struct interface compiles");
     let dispatch_tag = single_contract(&interface_artifact).entry("main").expect("main entry exists").dispatch_tag.into_bytes();
-    replace_compiled_interface(&mut compiled, struct_signature_source, "main", &[("x", "S[]")], dispatch_tag);
+    replace_compiled_interface(&mut compiled, struct_signature_source, old_dispatch_tag, dispatch_tag);
 
     let main_param_types: Vec<String> = compiled
         .ast
@@ -4233,9 +4224,11 @@ fn runtime_supports_regular_struct_array_non_entrypoint_arguments_with_struct_si
     "#;
 
     let mut compiled = compile_internal_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let original_artifact = sil_abi_artifact(source, &[]).expect("original interface compiles");
+    let old_dispatch_tag = single_contract(&original_artifact).entry("main").expect("main entry exists").dispatch_tag.into_bytes();
     let interface_artifact = sil_abi_artifact(struct_signature_source, &[]).expect("struct interface compiles");
     let dispatch_tag = single_contract(&interface_artifact).entry("main").expect("main entry exists").dispatch_tag.into_bytes();
-    replace_compiled_interface(&mut compiled, struct_signature_source, "main", &[("x", "S[]")], dispatch_tag);
+    replace_compiled_interface(&mut compiled, struct_signature_source, old_dispatch_tag, dispatch_tag);
 
     let main_param_types: Vec<String> = compiled
         .ast
@@ -7431,7 +7424,7 @@ fn dispatch_tag_hashes_exact_utf8_signature_bytes() {
 
         let compiled = compile_contract_ast(&contract, &[], CompileOptions::default()).expect("contract compiles");
         assert_eq!(&blake3::hash(utf8_signature).as_bytes()[..4], expected_tag);
-        assert_eq!(compiled.entry_by_name(name).expect("entrypoint exists").dispatch_tag, expected_tag);
+        assert_eq!(compiled.dispatch_tags.get(name).copied(), Some(expected_tag));
     }
 }
 
@@ -17172,13 +17165,15 @@ fn formatting_and_ast_round_trip_preserve_artifact() {
     let formatted = format_contract_ast(&ast);
     let reparsed = parse_contract_ast(&formatted).expect("formatted source parses");
     let from_ast = compile_contract_ast(&reparsed, &args, CompileOptions::default()).expect("public AST path compiles");
+    let from_ast_artifact = sil_abi_artifact_from_compiled(&from_ast, &args).expect("AST portable artifact builds");
     assert_eq!(bytecode(&original), from_ast.bytecode);
     let original_entries = &single_contract(&original).entries;
-    assert_eq!(original_entries.len(), from_ast.abi.len());
-    for (original_entry, ast_entry) in original_entries.iter().zip(&from_ast.abi) {
+    let ast_entries = &single_contract(&from_ast_artifact).entries;
+    assert_eq!(original_entries.len(), ast_entries.len());
+    for (original_entry, ast_entry) in original_entries.iter().zip(ast_entries) {
         assert_eq!(original_entry.name, ast_entry.name);
-        assert_eq!(original_entry.dispatch_tag.into_bytes(), ast_entry.dispatch_tag);
-        assert_eq!(original_entry.params.len(), ast_entry.inputs.len());
+        assert_eq!(original_entry.dispatch_tag, ast_entry.dispatch_tag);
+        assert_eq!(original_entry.params, ast_entry.params);
     }
     assert_eq!(state_layout(&original), from_ast.state_layout);
 }

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -1,4 +1,5 @@
 mod common;
+use std::collections::BTreeMap;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use kaspa_addresses::{Address, Prefix, Version};
@@ -18,11 +19,12 @@ use kaspa_txscript::{
     EngineCtx, EngineFlags, SeqCommitAccessor, TxScriptEngine, parse_script, pay_to_address_script, pay_to_script_hash_script,
     pay_to_script_hash_signature_script_with_flags, script_to_str, serialize_i64,
 };
+use silverscript_abi::{ArtifactValue, encode_contract_entry_sig_script};
 use silverscript_lang::ast::{ContractAst, Expr, ExprKind, Statement, format_contract_ast, parse_contract_ast, parse_type_ref};
 use silverscript_lang::compiler::{
     COMPILER_VERSION, CompileOptions, CompiledContract, CompilerError, CovenantDeclCallOptions, DispatchTag, FunctionAbiEntry,
     FunctionInputAbi, compile_contract, compile_contract_ast, compile_debug_expr, generated_covenant_auth_entrypoint_name,
-    struct_object,
+    sil_abi_artifact, struct_object,
 };
 use silverscript_lang::debug_info::StepKind;
 use silverscript_lang::template::template_hash;
@@ -7153,6 +7155,80 @@ fn nested_record_dispatch_tags_hash_structural_type_preimages() {
     for (entrypoint, preimage) in vectors {
         assert_eq!(dispatch_tag_for(&compiled, entrypoint), dispatch_tag_for_preimage(preimage), "preimage: {preimage}");
     }
+}
+
+#[test]
+fn silverscript_abi_encodes_and_runs_nested_struct_entry_arguments() {
+    let source = r#"
+        contract AbiStructs(int expectedAmount) {
+            struct Coordinates {
+                int x;
+                int y;
+            }
+
+            struct Item {
+                int amount;
+                Coordinates location;
+                byte[4] code;
+                bool active;
+            }
+
+            entry main(Item selected, Item[] items, Item[2] fixedItems) {
+                Coordinates selectedLocation = selected.location;
+                require(selected.amount == expectedAmount);
+                require(selectedLocation.x == 1);
+                require(selectedLocation.y == 2);
+                require(selected.code == byte[4](0x01020304));
+                require(selected.active);
+
+                require(items.length == 2);
+                require(items[0].amount == 10);
+                require(items[0].code == byte[4](0x11121314));
+                require(!items[0].active);
+                require(items[1].amount == 20);
+                require(items[1].code == byte[4](0x21222324));
+                require(items[1].active);
+
+                require(fixedItems[0].amount == 30);
+                require(fixedItems[0].code == byte[4](0x31323334));
+                require(fixedItems[0].active);
+                require(fixedItems[1].amount == 40);
+                require(fixedItems[1].code == byte[4](0x41424344));
+                require(!fixedItems[1].active);
+            }
+        }
+    "#;
+
+    let constructor_args = [Expr::int(7)];
+    let compiled = compile_contract(source, &constructor_args, CompileOptions::default()).expect("contract compiles");
+    let abi = sil_abi_artifact(source, &constructor_args).expect("source compiles to a complete portable ABI artifact");
+    abi.verify().expect("portable ABI matches the compiled contract");
+
+    let coordinates = |x, y| {
+        ArtifactValue::Object(BTreeMap::from([("x".to_string(), ArtifactValue::Int(x)), ("y".to_string(), ArtifactValue::Int(y))]))
+    };
+    let item = |amount, x, y, code: [u8; 4], active| {
+        ArtifactValue::Object(BTreeMap::from([
+            ("amount".to_string(), ArtifactValue::Int(amount)),
+            ("location".to_string(), coordinates(x, y)),
+            ("code".to_string(), ArtifactValue::Bytes(code.to_vec())),
+            ("active".to_string(), ArtifactValue::Bool(active)),
+        ]))
+    };
+    let args = vec![
+        item(7, 1, 2, [1, 2, 3, 4], true),
+        ArtifactValue::Array(vec![
+            item(10, 11, 12, [0x11, 0x12, 0x13, 0x14], false),
+            item(20, 21, 22, [0x21, 0x22, 0x23, 0x24], true),
+        ]),
+        ArtifactValue::Array(vec![
+            item(30, 31, 32, [0x31, 0x32, 0x33, 0x34], true),
+            item(40, 41, 42, [0x41, 0x42, 0x43, 0x44], false),
+        ]),
+    ];
+    let sigscript = encode_contract_entry_sig_script(&abi, "AbiStructs", "main", &args).expect("ABI encodes sigscript");
+
+    run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect("ABI-generated sigscript executes");
 }
 
 #[test]

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -23,8 +23,8 @@ use silverscript_abi::{ArtifactValue, SilAbiArtifact, TypeArtifact};
 use silverscript_lang::ast::{ContractAst, Expr, ExprKind, Statement, format_contract_ast, parse_contract_ast, parse_type_ref};
 use silverscript_lang::compiler::{
     COMPILER_VERSION, CompileOptions, CompiledContract, CompilerError, CovenantDeclCallOptions, DispatchTag,
-    compile_contract as compile_internal_contract, compile_contract_ast, compile_debug_expr, generated_covenant_auth_entrypoint_name,
-    sil_abi_artifact, sil_abi_artifact_from_compiled, struct_object,
+    compile_contract as compile_internal_contract, compile_contract_ast, compile_debug_expr, compile_to_sil_abi_artifact,
+    generated_covenant_auth_entrypoint_name, sil_abi_artifact_from_compiled, struct_object,
 };
 use silverscript_lang::debug_info::StepKind;
 use silverscript_lang::template::template_hash;
@@ -81,7 +81,7 @@ fn artifact_with_options_preserves_compiled_output_and_state_layout() {
         }
     "#;
 
-    let default_artifact = sil_abi_artifact(source, &[7.into()]).expect("default artifact compiles");
+    let default_artifact = compile_to_sil_abi_artifact(source, &[7.into()]).expect("default artifact compiles");
     let default_contract = single_contract(&default_artifact);
     assert!(default_contract.compiled.state_span.len > 0, "stateful contracts should expose a non-empty state layout");
 
@@ -2828,7 +2828,7 @@ fn build_sig_script_appends_dispatch_tag_for_single_entrypoint() {
             }
         }
     "#;
-    let artifact = sil_abi_artifact(source, &[]).expect("compile succeeds");
+    let artifact = compile_to_sil_abi_artifact(source, &[]).expect("compile succeeds");
     let sigscript = encode_single_entry_sig_script(&artifact, &[1.into(), vec![2u8; 4].into()]).expect("sigscript builds");
     let dispatch_tag =
         artifact.contract("Single").and_then(|contract| contract.entry("spend")).expect("entrypoint resolved").dispatch_tag;
@@ -3775,9 +3775,9 @@ fn runtime_supports_regular_struct_array_entrypoint_arguments_with_struct_signat
     "#;
 
     let mut compiled = compile_internal_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let original_artifact = sil_abi_artifact(source, &[]).expect("original interface compiles");
+    let original_artifact = compile_to_sil_abi_artifact(source, &[]).expect("original interface compiles");
     let old_dispatch_tag = single_contract(&original_artifact).entry("main").expect("main entry exists").dispatch_tag.into_bytes();
-    let interface_artifact = sil_abi_artifact(struct_signature_source, &[]).expect("struct interface compiles");
+    let interface_artifact = compile_to_sil_abi_artifact(struct_signature_source, &[]).expect("struct interface compiles");
     let dispatch_tag = single_contract(&interface_artifact).entry("main").expect("main entry exists").dispatch_tag.into_bytes();
     replace_compiled_interface(&mut compiled, struct_signature_source, old_dispatch_tag, dispatch_tag);
 
@@ -4224,9 +4224,9 @@ fn runtime_supports_regular_struct_array_non_entrypoint_arguments_with_struct_si
     "#;
 
     let mut compiled = compile_internal_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let original_artifact = sil_abi_artifact(source, &[]).expect("original interface compiles");
+    let original_artifact = compile_to_sil_abi_artifact(source, &[]).expect("original interface compiles");
     let old_dispatch_tag = single_contract(&original_artifact).entry("main").expect("main entry exists").dispatch_tag.into_bytes();
-    let interface_artifact = sil_abi_artifact(struct_signature_source, &[]).expect("struct interface compiles");
+    let interface_artifact = compile_to_sil_abi_artifact(struct_signature_source, &[]).expect("struct interface compiles");
     let dispatch_tag = single_contract(&interface_artifact).entry("main").expect("main entry exists").dispatch_tag.into_bytes();
     replace_compiled_interface(&mut compiled, struct_signature_source, old_dispatch_tag, dispatch_tag);
 
@@ -7200,7 +7200,7 @@ fn dispatch_tag_and_argument_encoding_match_kcc1_vector() {
         }
     "#;
 
-    let artifact = sil_abi_artifact(source, &[]).expect("compile succeeds");
+    let artifact = compile_to_sil_abi_artifact(source, &[]).expect("compile succeeds");
     let contract = artifact.contract("Test").expect("contract exists");
     let step = contract.entry("step").expect("step entrypoint exists");
     assert_eq!(step.params[1].ty, TypeArtifact::FixedBytes { len: 4 });
@@ -7231,7 +7231,7 @@ fn record_dispatch_tag_matches_kcc1_structural_type_vector() {
         }
     "#;
 
-    let artifact = sil_abi_artifact(source, &[]).expect("compile succeeds");
+    let artifact = compile_to_sil_abi_artifact(source, &[]).expect("compile succeeds");
     let dispense =
         artifact.contract("CoffeeMachine").and_then(|contract| contract.entry("dispense")).expect("dispense entrypoint exists");
     assert_eq!(
@@ -7266,7 +7266,7 @@ fn nested_record_dispatch_tags_hash_structural_type_preimages() {
         }
     "#;
 
-    let artifact = sil_abi_artifact(source, &[]).expect("compile succeeds");
+    let artifact = compile_to_sil_abi_artifact(source, &[]).expect("compile succeeds");
     let contract = artifact.contract("Test").expect("contract exists");
     let vectors = [
         ("scalar", "scalar({{int,byte[3]},bool[2]})"),
@@ -7326,7 +7326,8 @@ fn silverscript_abi_encodes_and_runs_nested_struct_entry_arguments() {
     "#;
 
     let artifact_constructor_args = [7.into()];
-    let abi = sil_abi_artifact(source, &artifact_constructor_args).expect("source compiles to a complete portable ABI artifact");
+    let abi =
+        compile_to_sil_abi_artifact(source, &artifact_constructor_args).expect("source compiles to a complete portable ABI artifact");
     abi.verify().expect("portable ABI matches the compiled contract");
 
     let coordinates = |x, y| {
@@ -7393,7 +7394,7 @@ fn artifact_values_compile_nested_constructor_arguments() {
         ArtifactValue::Text("ready".to_string()),
     ];
 
-    let abi = sil_abi_artifact(source, &args).expect("portable ABI constructor values compile");
+    let abi = compile_to_sil_abi_artifact(source, &args).expect("portable ABI constructor values compile");
     abi.verify().expect("portable ABI verifies");
     let contract = abi.contract("ArtifactConstructors").expect("contract exists");
     let bytecode = contract.compiled.bytecode.clone();
@@ -17352,14 +17353,14 @@ fn artifact_sigscript_builder_supports_constructor_sized_struct_array_fields() {
             }
         }
     "#;
-    let artifact = sil_abi_artifact(source, &[3.into()]).expect("contract compiles");
+    let artifact = compile_to_sil_abi_artifact(source, &[3.into()]).expect("contract compiles");
     let input = &artifact.contract("C").and_then(|contract| contract.entry("main")).expect("entrypoint exists").params[0];
     assert_eq!(input.ty, TypeArtifact::DynamicArray { item: Box::new(TypeArtifact::Struct { name: "Item".to_string() }) });
-    assert_eq!(artifact.states[0].fields[0].ty, TypeArtifact::FixedBytes { len: 3 });
+    assert_eq!(artifact.structs[0].fields[0].ty, TypeArtifact::FixedBytes { len: 3 });
 
     let json = serde_json::to_string(&artifact).expect("portable artifact serializes");
     let artifact: SilAbiArtifact = serde_json::from_str(&json).expect("portable artifact deserializes");
-    assert_eq!(artifact.states[0].fields[0].ty, TypeArtifact::FixedBytes { len: 3 });
+    assert_eq!(artifact.structs[0].fields[0].ty, TypeArtifact::FixedBytes { len: 3 });
     let items =
         ArtifactValue::Array(vec![ArtifactValue::Object(BTreeMap::from([("data".to_string(), vec![0xaau8, 0xbb, 0xcc].into())]))]);
     let sigscript = encode_single_entry_sig_script(&artifact, &[items]).expect("resolved ABI encodes the valid argument");
@@ -17381,7 +17382,7 @@ fn artifact_sigscript_builder_rejects_wrong_constructor_sized_struct_fields() {
             }
         }
     "#;
-    let artifact = sil_abi_artifact(source, &[3.into()]).expect("contract compiles");
+    let artifact = compile_to_sil_abi_artifact(source, &[3.into()]).expect("contract compiles");
     let item = |data: Vec<u8>| ArtifactValue::Object(BTreeMap::from([("data".to_string(), ArtifactValue::from(data))]));
     encode_single_entry_sig_script(&artifact, &[item(vec![0xaa, 0xbb, 0xcc])])
         .expect("the valid constructor-sized struct argument encodes");

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -19,7 +19,7 @@ use kaspa_txscript::{
     EngineCtx, EngineFlags, SeqCommitAccessor, TxScriptEngine, parse_script, pay_to_address_script, pay_to_script_hash_script,
     pay_to_script_hash_signature_script_with_flags, script_to_str, serialize_i64,
 };
-use silverscript_abi::{ArtifactValue, encode_contract_entry_sig_script};
+use silverscript_abi::{ArtifactValue, decode_hex, encode_contract_entry_sig_script};
 use silverscript_lang::ast::{ContractAst, Expr, ExprKind, Statement, format_contract_ast, parse_contract_ast, parse_type_ref};
 use silverscript_lang::compiler::{
     COMPILER_VERSION, CompileOptions, CompiledContract, CompilerError, CovenantDeclCallOptions, DispatchTag, FunctionAbiEntry,
@@ -7200,8 +7200,9 @@ fn silverscript_abi_encodes_and_runs_nested_struct_entry_arguments() {
     "#;
 
     let constructor_args = [Expr::int(7)];
+    let artifact_constructor_args = [ArtifactValue::Int(7)];
     let compiled = compile_contract(source, &constructor_args, CompileOptions::default()).expect("contract compiles");
-    let abi = sil_abi_artifact(source, &constructor_args).expect("source compiles to a complete portable ABI artifact");
+    let abi = sil_abi_artifact(source, &artifact_constructor_args).expect("source compiles to a complete portable ABI artifact");
     abi.verify().expect("portable ABI matches the compiled contract");
 
     let coordinates = |x, y| {
@@ -7229,6 +7230,50 @@ fn silverscript_abi_encodes_and_runs_nested_struct_entry_arguments() {
     let sigscript = encode_contract_entry_sig_script(&abi, "AbiStructs", "main", &args).expect("ABI encodes sigscript");
 
     run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect("ABI-generated sigscript executes");
+}
+
+#[test]
+fn artifact_values_compile_nested_constructor_arguments() {
+    let source = r#"
+        contract ArtifactConstructors(Config config, int[] values, byte[] payload, string label) {
+            struct Flags {
+                bool enabled;
+            }
+
+            struct Config {
+                int count;
+                Flags flags;
+            }
+
+            entry main() {
+                require(config.count == 7);
+                require(config.flags.enabled);
+                require(values.length == 2);
+                require(values[0] == 11);
+                require(values[1] == 12);
+                require(payload.length == 2);
+                require(payload[0] == 0xaa);
+                require(payload[1] == 0xbb);
+                require(label == "ready");
+            }
+        }
+    "#;
+    let args = vec![
+        ArtifactValue::Object(BTreeMap::from([
+            ("count".to_string(), ArtifactValue::Int(7)),
+            ("flags".to_string(), ArtifactValue::Object(BTreeMap::from([("enabled".to_string(), ArtifactValue::Bool(true))]))),
+        ])),
+        ArtifactValue::Array(vec![ArtifactValue::Int(11), ArtifactValue::Int(12)]),
+        ArtifactValue::Bytes(vec![0xaa, 0xbb]),
+        ArtifactValue::Text("ready".to_string()),
+    ];
+
+    let abi = sil_abi_artifact(source, &args).expect("portable ABI constructor values compile");
+    abi.verify().expect("portable ABI verifies");
+    let contract = abi.contract("ArtifactConstructors").expect("contract exists");
+    let bytecode = decode_hex(&contract.compiled.script_hex).expect("compiled script decodes");
+    let dispatch_tag = contract.entry("main").expect("entry exists").dispatch_tag.into_bytes();
+    run_bytecode_with_dispatch_tag(bytecode, dispatch_tag).expect("compiled constructor values execute");
 }
 
 #[test]

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -7035,7 +7035,8 @@ fn wrap_with_single_dispatch(compiled: &silverscript_abi::SilAbiArtifact, body: 
 }
 
 fn wrap_with_single_dispatch_and_state(compiled: &silverscript_abi::SilAbiArtifact, state: &[u8], body: &[u8]) -> Vec<u8> {
-    let [entrypoint] = single_contract(compiled).entries.as_slice() else {
+    let entries = &single_contract(compiled).entries;
+    let Some(entrypoint) = entries.values().next().filter(|_| entries.len() == 1) else {
         panic!("single-dispatch wrapper requires exactly one ABI entrypoint");
     };
     wrap_with_single_dispatch_tag(entrypoint.dispatch_tag.into_bytes(), state, body)
@@ -17193,12 +17194,7 @@ fn formatting_and_ast_round_trip_preserve_artifact() {
     assert_eq!(bytecode(&original), from_ast.bytecode);
     let original_entries = &single_contract(&original).entries;
     let ast_entries = &single_contract(&from_ast_artifact).entries;
-    assert_eq!(original_entries.len(), ast_entries.len());
-    for (original_entry, ast_entry) in original_entries.iter().zip(ast_entries) {
-        assert_eq!(original_entry.name, ast_entry.name);
-        assert_eq!(original_entry.dispatch_tag, ast_entry.dispatch_tag);
-        assert_eq!(original_entry.params, ast_entry.params);
-    }
+    assert_eq!(original_entries, ast_entries);
     assert_eq!(state_layout(&original), from_ast.state_layout);
 }
 
@@ -17379,11 +17375,11 @@ fn artifact_sigscript_builder_supports_constructor_sized_struct_array_fields() {
     let artifact = compile_to_sil_abi_artifact(source, &[3.into()]).expect("contract compiles");
     let input = &artifact.contract("C").and_then(|contract| contract.entry("main")).expect("entrypoint exists").params[0];
     assert_eq!(input.ty, TypeArtifact::DynamicArray { item: Box::new(TypeArtifact::Struct { name: "Item".to_string() }) });
-    assert_eq!(artifact.structs[0].fields[0].ty, TypeArtifact::FixedBytes { len: 3 });
+    assert_eq!(artifact.structs["Item"].fields[0].ty, TypeArtifact::FixedBytes { len: 3 });
 
     let json = serde_json::to_string(&artifact).expect("portable artifact serializes");
     let artifact: SilAbiArtifact = serde_json::from_str(&json).expect("portable artifact deserializes");
-    assert_eq!(artifact.structs[0].fields[0].ty, TypeArtifact::FixedBytes { len: 3 });
+    assert_eq!(artifact.structs["Item"].fields[0].ty, TypeArtifact::FixedBytes { len: 3 });
     let items =
         ArtifactValue::Array(vec![ArtifactValue::Object(BTreeMap::from([("data".to_string(), vec![0xaau8, 0xbb, 0xcc].into())]))]);
     let sigscript = encode_single_entry_sig_script(&artifact, &[items]).expect("resolved ABI encodes the valid argument");

--- a/silverscript-lang/tests/compiler_tests.rs
+++ b/silverscript-lang/tests/compiler_tests.rs
@@ -19,20 +19,27 @@ use kaspa_txscript::{
     EngineCtx, EngineFlags, SeqCommitAccessor, TxScriptEngine, parse_script, pay_to_address_script, pay_to_script_hash_script,
     pay_to_script_hash_signature_script_with_flags, script_to_str, serialize_i64,
 };
-use silverscript_abi::{ArtifactValue, decode_hex, encode_contract_entry_sig_script};
+use silverscript_abi::{ArtifactValue, SilAbiArtifact, TypeArtifact};
 use silverscript_lang::ast::{ContractAst, Expr, ExprKind, Statement, format_contract_ast, parse_contract_ast, parse_type_ref};
 use silverscript_lang::compiler::{
     COMPILER_VERSION, CompileOptions, CompiledContract, CompilerError, CovenantDeclCallOptions, DispatchTag, FunctionAbiEntry,
-    FunctionInputAbi, compile_contract, compile_contract_ast, compile_debug_expr, generated_covenant_auth_entrypoint_name,
-    sil_abi_artifact, struct_object,
+    FunctionInputAbi, compile_contract as compile_internal_contract, compile_contract_ast, compile_debug_expr,
+    generated_covenant_auth_entrypoint_name, sil_abi_artifact, struct_object,
 };
 use silverscript_lang::debug_info::StepKind;
 use silverscript_lang::template::template_hash;
 
-use crate::common::compiled_template_parts_and_hash;
+use common::{
+    build_sig_script_for_covenant_decl, bytecode, compile_contract, compiled_template_parts_and_hash, encode_entry_sig_script,
+    encode_single_entry_sig_script, entry_by_name, single_contract, state_layout,
+};
 
 fn script_builder() -> ScriptBuilder {
     ScriptBuilder::with_flags(EngineFlags { covenants_enabled: true, ..Default::default() })
+}
+
+fn artifact_object(fields: impl IntoIterator<Item = (&'static str, ArtifactValue)>) -> ArtifactValue {
+    fields.into_iter().map(|(name, value)| (name.to_string(), value)).collect::<BTreeMap<_, _>>().into()
 }
 
 #[test]
@@ -60,6 +67,27 @@ fn constructors_validate_argument_types() {
             "unexpected error for {constructor}: {err}"
         );
     }
+}
+
+#[test]
+fn artifact_with_options_preserves_compiled_output_and_state_layout() {
+    let source = r#"
+        contract Metadata(int initial) {
+            int value = initial;
+
+            entry main(int expected) {
+                require(value == expected);
+            }
+        }
+    "#;
+
+    let default_artifact = sil_abi_artifact(source, &[7.into()]).expect("default artifact compiles");
+    let default_contract = single_contract(&default_artifact);
+    assert!(default_contract.compiled.state_span.len > 0, "stateful contracts should expose a non-empty state layout");
+
+    let artifact = compile_contract(source, &[7.into()], CompileOptions { record_debug_infos: true, ..CompileOptions::default() })
+        .expect("artifact with debug recording compiles");
+    assert_eq!(artifact, default_artifact, "debug recording should not change the portable artifact");
 }
 
 fn pay_to_script_hash_signature_script(
@@ -262,8 +290,8 @@ fn accepts_missing_pragma_without_version_check() {
 #[test]
 fn compiled_contract_includes_compiler_version() {
     let source = pragma_source(None);
-    let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile succeeds");
-    assert_eq!(compiled.compiler_version, COMPILER_VERSION);
+    let artifact = compile_contract(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    assert_eq!(artifact.compiler_version, COMPILER_VERSION);
 }
 
 #[test]
@@ -317,15 +345,15 @@ fn accepts_constructor_args_with_matching_types() {
         }
     "#;
     let args = vec![
-        Expr::int(7),
-        Expr::bool(true),
-        Expr::string("hello".to_string()),
-        Expr::dynamic_bytes(vec![1u8; 10]),
-        Expr::byte(2),
-        Expr::bytes(vec![3u8; 4]),
-        Expr::bytes(vec![4u8; 32]),
-        Expr::bytes(vec![5u8; 65]),
-        Expr::bytes(vec![6u8; 64]),
+        7.into(),
+        true.into(),
+        "hello".into(),
+        vec![1u8; 10].into(),
+        2u8.into(),
+        vec![3u8; 4].into(),
+        vec![4u8; 32].into(),
+        vec![5u8; 65].into(),
+        vec![6u8; 64].into(),
     ];
     compile_contract(source, &args, CompileOptions::default()).expect("compile succeeds");
 }
@@ -349,10 +377,10 @@ fn supports_struct_contract_params_fields_and_constants() {
         }
     "#;
 
-    let args = vec![struct_object("Pair", vec![("amount", Expr::int(11)), ("code", Expr::bytes(vec![0xab, 0xcd]))])];
+    let args = vec![artifact_object([("amount", 11.into()), ("code", vec![0xabu8, 0xcd].into())])];
     let compiled = compile_contract(source, &args, CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "top-level struct param/field/constant contract should run: {result:?}");
 }
 
@@ -366,7 +394,7 @@ fn constructor_arguments_are_concrete_values_not_runtime_introspection() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::call("OpTxLockTime", vec![])], CompileOptions::default())
+    let err = compile_internal_contract(source, &[Expr::call("OpTxLockTime", vec![])], CompileOptions::default())
         .expect_err("constructor arguments must not evaluate runtime expressions");
     assert!(err.to_string().contains("constructor argument 'expected_lock_time' must be a concrete value"), "unexpected error: {err}");
     let contract = parse_contract_ast(source).expect("contract parses");
@@ -383,12 +411,12 @@ fn constructor_arguments_are_concrete_values_not_runtime_introspection() {
             }
         }
     "#;
-    let pair = struct_object("Pair", vec![("value", Expr::int(1))]);
+    let pair = artifact_object([("value", 1.into())]);
     compile_contract(struct_source, &[pair], CompileOptions::default())
         .expect("structs containing only concrete values remain valid constructor arguments");
 
     let runtime_pair = struct_object("Pair", vec![("value", Expr::call("OpTxLockTime", vec![]))]);
-    compile_contract(struct_source, &[runtime_pair], CompileOptions::default())
+    compile_internal_contract(struct_source, &[runtime_pair], CompileOptions::default())
         .expect_err("runtime expressions nested in constructor structs must be rejected");
 
     let array_source = r#"
@@ -398,12 +426,12 @@ fn constructor_arguments_are_concrete_values_not_runtime_introspection() {
             }
         }
     "#;
-    let literal_values = Expr::array(parse_type_ref("int[]").expect("array type parses"), vec![Expr::int(1)]);
+    let literal_values = ArtifactValue::Array(vec![1.into()]);
     compile_contract(array_source, &[literal_values], CompileOptions::default())
         .expect("arrays containing only concrete values remain valid constructor arguments");
 
     let runtime_values = Expr::array(parse_type_ref("int[]").expect("array type parses"), vec![Expr::call("OpTxLockTime", vec![])]);
-    compile_contract(array_source, &[runtime_values], CompileOptions::default())
+    compile_internal_contract(array_source, &[runtime_values], CompileOptions::default())
         .expect_err("runtime expressions nested in constructor arrays must be rejected");
 }
 
@@ -424,9 +452,9 @@ fn nested_struct_field_path_does_not_alias_underscored_field_name() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let outer = struct_object("Outer", vec![("a", struct_object("Inner", vec![("b", Expr::int(1))])), ("a_b", Expr::int(2))]);
-    let sigscript = compiled.build_sig_script("main", vec![outer]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let outer = artifact_object([("a", artifact_object([("b", 1.into())])), ("a_b", 2.into())]);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[outer]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_err(), "different nested and underscored fields must make the require fail");
 }
 
@@ -574,7 +602,7 @@ fn compile_contract_omits_debug_info_when_recording_disabled() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_internal_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     assert!(compiled.debug_info.is_none());
 }
 
@@ -592,7 +620,7 @@ fn compile_contract_emits_debug_info_scaffold_when_recording_enabled() {
     "#;
 
     let options = CompileOptions { record_debug_infos: true, ..Default::default() };
-    let compiled = compile_contract(source, &[Expr::int(11)], options).expect("compile succeeds");
+    let compiled = compile_internal_contract(source, &[Expr::int(11)], options).expect("compile succeeds");
     let debug_info = compiled.debug_info.expect("debug info should be present");
 
     assert!(!debug_info.steps.is_empty(), "debug recording should emit statement steps again");
@@ -625,7 +653,7 @@ fn compile_contract_debug_info_scaffold_records_dispatch_tag_entrypoint_ranges()
     "#;
 
     let options = CompileOptions { record_debug_infos: true, ..Default::default() };
-    let compiled = compile_contract(source, &[], options).expect("compile succeeds");
+    let compiled = compile_internal_contract(source, &[], options).expect("compile succeeds");
     let debug_info = compiled.debug_info.expect("debug info should be present");
 
     let function_a = debug_info.functions.iter().find(|function| function.name == "a").expect("function range for a");
@@ -653,7 +681,7 @@ fn compile_contract_debug_info_records_inline_boundaries_and_return_bindings() {
     "#;
 
     let options = CompileOptions { record_debug_infos: true, ..Default::default() };
-    let compiled = compile_contract(source, &[], options).expect("compile succeeds");
+    let compiled = compile_internal_contract(source, &[], options).expect("compile succeeds");
     let debug_info = compiled.debug_info.expect("debug info should be present");
     let rendered_steps = debug_info
         .steps
@@ -723,7 +751,7 @@ fn compile_contract_debug_info_preserves_structured_scope_inside_inline_calls() 
     "#;
 
     let options = CompileOptions { record_debug_infos: true, ..Default::default() };
-    let compiled = compile_contract(source, &[], options).expect("compile succeeds");
+    let compiled = compile_internal_contract(source, &[], options).expect("compile succeeds");
     let debug_info = compiled.debug_info.expect("debug info should be present");
 
     let inline_steps = debug_info
@@ -898,8 +926,8 @@ fn branch_heavy_if_else_logic_matches_rust_model_across_cases() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("branch-heavy contract should compile");
-    let bytecode_len = compiled.bytecode.len();
-    let (instruction_count, charged_op_count) = bytecode_op_counts(&compiled.bytecode);
+    let bytecode_len = bytecode(&compiled).len();
+    let (instruction_count, charged_op_count) = bytecode_op_counts(&bytecode(&compiled));
     println!("branch_maze {bytecode_len} / {instruction_count} / {charged_op_count}");
     // Snapshot these metrics exactly so compiler codegen changes must consciously
     // acknowledge their size impact on a branch-heavy stress case.
@@ -919,22 +947,22 @@ fn branch_heavy_if_else_logic_matches_rust_model_across_cases() {
 
     for (a, b, c, d) in cases {
         let (expected_x, expected_y, expected_z, expected_score) = branch_maze_expected(a, b, c, d);
-        let sigscript = compiled
-            .build_sig_script(
-                "main",
-                vec![
-                    Expr::int(a),
-                    Expr::int(b),
-                    Expr::int(c),
-                    Expr::int(d),
-                    Expr::int(expected_x),
-                    Expr::int(expected_y),
-                    Expr::int(expected_z),
-                    Expr::int(expected_score),
-                ],
-            )
-            .expect("sigscript builds");
-        let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
+        let sigscript = encode_entry_sig_script(
+            &compiled,
+            "main",
+            &[
+                ArtifactValue::Int(a),
+                ArtifactValue::Int(b),
+                ArtifactValue::Int(c),
+                ArtifactValue::Int(d),
+                ArtifactValue::Int(expected_x),
+                ArtifactValue::Int(expected_y),
+                ArtifactValue::Int(expected_z),
+                ArtifactValue::Int(expected_score),
+            ],
+        )
+        .expect("sigscript builds");
+        let result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript);
         assert!(
             result.is_ok(),
             "branch-heavy case ({a}, {b}, {c}, {d}) should match Rust model ({expected_x}, {expected_y}, {expected_z}, {expected_score}): {result:?}"
@@ -943,22 +971,22 @@ fn branch_heavy_if_else_logic_matches_rust_model_across_cases() {
 
     let (a, b, c, d) = cases[0];
     let (expected_x, expected_y, expected_z, expected_score) = branch_maze_expected(a, b, c, d);
-    let wrong_sigscript = compiled
-        .build_sig_script(
-            "main",
-            vec![
-                Expr::int(a),
-                Expr::int(b),
-                Expr::int(c),
-                Expr::int(d),
-                Expr::int(expected_x),
-                Expr::int(expected_y),
-                Expr::int(expected_z),
-                Expr::int(expected_score + 1),
-            ],
-        )
-        .expect("sigscript builds");
-    let err = run_bytecode_with_sigscript(compiled.bytecode.clone(), wrong_sigscript)
+    let wrong_sigscript = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[
+            ArtifactValue::Int(a),
+            ArtifactValue::Int(b),
+            ArtifactValue::Int(c),
+            ArtifactValue::Int(d),
+            ArtifactValue::Int(expected_x),
+            ArtifactValue::Int(expected_y),
+            ArtifactValue::Int(expected_z),
+            ArtifactValue::Int(expected_score + 1),
+        ],
+    )
+    .expect("sigscript builds");
+    let err = run_bytecode_with_sigscript(bytecode(&compiled).clone(), wrong_sigscript)
         .expect_err("branch-heavy case with wrong expected output should fail");
     assert!(format!("{err:?}").contains("Verify"), "wrong expected output should fail with verify error, got: {err:?}");
 }
@@ -1040,8 +1068,8 @@ fn sorting_network_over_fixed_array_matches_rust_model_across_cases() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("sorting-network contract should compile");
-    let bytecode_len = compiled.bytecode.len();
-    let (instruction_count, charged_op_count) = bytecode_op_counts(&compiled.bytecode);
+    let bytecode_len = bytecode(&compiled).len();
+    let (instruction_count, charged_op_count) = bytecode_op_counts(&bytecode(&compiled));
     println!("sorting_network {bytecode_len} / {instruction_count} / {charged_op_count}");
     assert_eq!(
         bytecode_len, 829,
@@ -1067,23 +1095,23 @@ fn sorting_network_over_fixed_array_matches_rust_model_across_cases() {
 
     for values in cases {
         let [expected_a, expected_b, expected_c, expected_d, expected_e, expected_f, expected_g, expected_h] = sorted_expected(values);
-        let sigscript = compiled
-            .build_sig_script(
-                "main",
-                vec![
-                    Expr::inferred_array(values.into_iter().map(Expr::int).collect()).expect("non-empty fixed int array"),
-                    Expr::int(expected_a),
-                    Expr::int(expected_b),
-                    Expr::int(expected_c),
-                    Expr::int(expected_d),
-                    Expr::int(expected_e),
-                    Expr::int(expected_f),
-                    Expr::int(expected_g),
-                    Expr::int(expected_h),
-                ],
-            )
-            .expect("sigscript builds");
-        let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
+        let sigscript = encode_entry_sig_script(
+            &compiled,
+            "main",
+            &[
+                ArtifactValue::Array(values.into_iter().map(ArtifactValue::Int).collect()),
+                ArtifactValue::Int(expected_a),
+                ArtifactValue::Int(expected_b),
+                ArtifactValue::Int(expected_c),
+                ArtifactValue::Int(expected_d),
+                ArtifactValue::Int(expected_e),
+                ArtifactValue::Int(expected_f),
+                ArtifactValue::Int(expected_g),
+                ArtifactValue::Int(expected_h),
+            ],
+        )
+        .expect("sigscript builds");
+        let result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript);
         assert!(result.is_ok(), "sorting-network case {values:?} should match Rust model: {result:?}");
     }
 }
@@ -1097,7 +1125,7 @@ fn rejects_constructor_args_with_wrong_scalar_types() {
             }
         }
     "#;
-    let args = vec![Expr::bool(true), Expr::int(1), Expr::bytes(vec![1u8])];
+    let args = vec![true.into(), 1.into(), vec![1u8].into()];
     assert!(compile_contract(source, &args, CompileOptions::default()).is_err());
 }
 
@@ -1110,13 +1138,7 @@ fn rejects_constructor_args_with_wrong_byte_lengths() {
             }
         }
     "#;
-    let args = vec![
-        Expr::bytes(vec![1u8; 2]),
-        Expr::bytes(vec![2u8; 3]),
-        Expr::bytes(vec![3u8; 31]),
-        Expr::bytes(vec![4u8; 63]),
-        Expr::bytes(vec![5u8; 66]),
-    ];
+    let args = vec![vec![1u8; 2].into(), vec![2u8; 3].into(), vec![3u8; 31].into(), vec![4u8; 63].into(), vec![5u8; 66].into()];
     assert!(compile_contract(source, &args, CompileOptions::default()).is_err());
 }
 
@@ -1149,7 +1171,7 @@ fn accepts_constructor_args_with_any_bytes_length() {
             }
         }
     "#;
-    let args = vec![Expr::dynamic_bytes(vec![9u8; 128])];
+    let args = vec![vec![9u8; 128].into()];
     compile_contract(source, &args, CompileOptions::default()).expect("compile succeeds");
 }
 
@@ -1163,8 +1185,8 @@ fn build_sig_script_builds_expected_script() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let args = vec![Expr::bytes(vec![1u8, 2, 3, 4]), Expr::int(7)];
-    let sigscript = compiled.build_sig_script("spend", args).expect("sigscript builds");
+    let args = vec![vec![1u8, 2, 3, 4].into(), 7.into()];
+    let sigscript = encode_entry_sig_script(&compiled, "spend", &args).expect("sigscript builds");
 
     let dispatch_tag = dispatch_tag_for(&compiled, "spend");
     let mut builder = script_builder();
@@ -1206,10 +1228,11 @@ fn byte_variable_from_int_literal_uses_raw_byte_push() {
         .add_op(OpTrue)
         .unwrap()
         .drain();
-    let expected = wrap_with_single_dispatch(&compiled, body);
-    assert_eq!(compiled.bytecode, expected);
+    let dispatch_tag = entry_by_name(&compiled, "main").expect("entrypoint resolved").dispatch_tag.into_bytes();
+    let expected = wrap_with_single_dispatch_tag(dispatch_tag, &[], &body);
+    assert_eq!(bytecode(&compiled), expected);
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok(), "byte int literal script should execute");
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok(), "byte int literal script should execute");
 }
 
 #[test]
@@ -1239,8 +1262,8 @@ fn byte_equality_uses_op_equal_not_op_numequal() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("byte equality should compile");
-    assert!(compiled.bytecode.iter().copied().any(|op| op == OpEqual), "byte equality should use OP_EQUAL");
-    assert!(!compiled.bytecode.iter().copied().any(|op| op == OpNumEqual), "byte equality should not use OP_NUMEQUAL");
+    assert!(bytecode(&compiled).iter().copied().any(|op| op == OpEqual), "byte equality should use OP_EQUAL");
+    assert!(!bytecode(&compiled).iter().copied().any(|op| op == OpNumEqual), "byte equality should not use OP_NUMEQUAL");
 }
 
 #[test]
@@ -1271,10 +1294,14 @@ fn byte_equality_with_rhs_int_literal_uses_raw_byte_push() {
         .add_op(OpTrue)
         .unwrap()
         .drain();
-    let expected = wrap_with_single_dispatch(&compiled, body);
-    assert_eq!(compiled.bytecode, expected);
+    let dispatch_tag = entry_by_name(&compiled, "main").expect("entrypoint resolved").dispatch_tag.into_bytes();
+    let expected = wrap_with_single_dispatch_tag(dispatch_tag, &[], &body);
+    assert_eq!(bytecode(&compiled), expected);
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok(), "byte equality with rhs literal should execute");
+    assert!(
+        run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok(),
+        "byte equality with rhs literal should execute"
+    );
 }
 
 #[test]
@@ -1371,10 +1398,10 @@ fn allows_arithmetic_after_signed_or_unsigned_byte_conversion() {
 
     let compiled =
         compile_contract(source, &[], CompileOptions::default()).expect("explicit byte conversions should allow arithmetic");
-    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    let opcodes = script_to_str(&bytecode(&compiled)).expect("compiled bytecode stringifies");
     assert_eq!(opcodes.matches("OpAdd").count(), 2, "converted byte arithmetic must emit OpAdd: {opcodes}");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok(), "converted byte arithmetic should execute");
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok(), "converted byte arithmetic should execute");
 }
 
 #[test]
@@ -1418,7 +1445,7 @@ fn allows_bitwise_operations_on_bytes() {
         let compiled = compile_contract(&source, &[], CompileOptions::default())
             .unwrap_or_else(|err| panic!("byte operands for {operator} should compile: {err}"));
         let dispatch_tag = dispatch_tag_for(&compiled, "main");
-        let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+        let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
         assert!(result.is_ok(), "byte operands for {operator} should execute: {result:?}");
     }
 }
@@ -1488,22 +1515,22 @@ fn allows_bitwise_operations_on_dynamic_byte_arrays_and_checks_size_at_runtime()
         let compiled = compile_contract(&source, &[], CompileOptions::default())
             .unwrap_or_else(|err| panic!("dynamic byte arrays for {operator} should compile: {err}"));
 
-        let sigscript = compiled
-            .build_sig_script(
-                "main",
-                vec![Expr::dynamic_bytes(vec![0x12, 0x34]), Expr::dynamic_bytes(vec![0x4d, 0x0f]), Expr::dynamic_bytes(expected)],
-            )
-            .expect("matching dynamic byte-array arguments should build");
-        let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
+        let sigscript = encode_entry_sig_script(
+            &compiled,
+            "main",
+            &[ArtifactValue::Bytes(vec![0x12, 0x34]), ArtifactValue::Bytes(vec![0x4d, 0x0f]), ArtifactValue::Bytes(expected)],
+        )
+        .expect("matching dynamic byte-array arguments should build");
+        let result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript);
         assert!(result.is_ok(), "matching dynamic byte arrays for {operator} should execute: {result:?}");
 
-        let sigscript = compiled
-            .build_sig_script(
-                "main",
-                vec![Expr::dynamic_bytes(vec![0x12, 0x34]), Expr::dynamic_bytes(vec![0x4d]), Expr::dynamic_bytes(vec![0x00, 0x00])],
-            )
-            .expect("different-sized dynamic byte-array arguments should build");
-        let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
+        let sigscript = encode_entry_sig_script(
+            &compiled,
+            "main",
+            &[ArtifactValue::Bytes(vec![0x12, 0x34]), ArtifactValue::Bytes(vec![0x4d]), ArtifactValue::Bytes(vec![0x00, 0x00])],
+        )
+        .expect("different-sized dynamic byte-array arguments should build");
+        let result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript);
         assert!(result.is_err(), "different-sized dynamic byte arrays for {operator} should fail at runtime");
     }
 }
@@ -1518,7 +1545,7 @@ fn build_sig_script_rejects_unknown_function() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let result = compiled.build_sig_script("missing", vec![Expr::int(1)]);
+    let result = encode_entry_sig_script(&compiled, "missing", &[ArtifactValue::Int(1)]);
     assert!(result.is_err());
 }
 
@@ -1539,7 +1566,7 @@ fn disallow_comparing_byte_array_to_byte_constant() {
     "#;
 
     assert!(
-        compile_contract(source, &[Expr::bytes(vec![1u8; 32]), Expr::byte(0)], CompileOptions::default()).is_err(),
+        compile_contract(source, &[ArtifactValue::Bytes(vec![1u8; 32]), ArtifactValue::Byte(0)], CompileOptions::default()).is_err(),
         "comparing byte[32] to byte should be rejected without cast"
     );
 }
@@ -1557,7 +1584,7 @@ fn disallow_comparing_dynamic_and_fixed_byte_arrays_without_cast_in_contract_sco
     "#;
 
     assert!(
-        compile_contract(source, &[Expr::dynamic_bytes(vec![0x12])], CompileOptions::default()).is_err(),
+        compile_contract(source, &[ArtifactValue::Bytes(vec![0x12])], CompileOptions::default()).is_err(),
         "comparing byte[] to byte[2] should be rejected without cast"
     );
 }
@@ -1574,7 +1601,7 @@ fn allow_comparing_dynamic_and_fixed_byte_arrays_with_cast_in_contract_scope() {
         }
     "#;
 
-    compile_contract(source, &[Expr::dynamic_bytes(vec![0x12])], CompileOptions::default())
+    compile_contract(source, &[ArtifactValue::Bytes(vec![0x12])], CompileOptions::default())
         .expect("comparing byte[] to byte[2] should be allowed with cast");
 }
 
@@ -1623,8 +1650,8 @@ fn script_pubkey_constructors_return_correct_fixed_dimension_types() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("script-pubkey constructors should compile");
-    let sigscript = compiled.build_sig_script("main", vec![]).expect("signature script should build");
-    run_bytecode_with_sigscript(compiled.bytecode, sigscript)
+    let sigscript = encode_single_entry_sig_script(&compiled, &[]).expect("signature script should build");
+    run_bytecode_with_sigscript(bytecode(&compiled), sigscript)
         .expect("script-pubkey constructor results should have their declared lengths after conversion to byte[]");
 }
 
@@ -1657,8 +1684,8 @@ fn fixed_size_hash_builtins_return_their_declared_lengths() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("fixed-size hash builtins should compile");
-    let sigscript = compiled.build_sig_script("main", vec![]).expect("signature script should build");
-    run_bytecode_with_sigscript(compiled.bytecode, sigscript)
+    let sigscript = encode_single_entry_sig_script(&compiled, &[]).expect("signature script should build");
+    run_bytecode_with_sigscript(bytecode(&compiled), sigscript)
         .expect("fixed-size hash builtin results should have their declared lengths after conversion to byte[]");
 }
 
@@ -1683,7 +1710,7 @@ fn introspection_fields_and_direct_lock_opcodes_emit_and_execute() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("all indexed introspection fields should compile");
-    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode should stringify");
+    let opcodes = script_to_str(&bytecode(&compiled)).expect("compiled bytecode should stringify");
     for opcode in [
         "OpTxInputAmount",
         "OpTxInputSpk",
@@ -1701,7 +1728,7 @@ fn introspection_fields_and_direct_lock_opcodes_emit_and_execute() {
 
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
     let (tx, mut entries) = build_basic_opcode_tx(sigscript);
-    entries[0].script_public_key = ScriptPublicKey::new(0, compiled.bytecode.clone().into());
+    entries[0].script_public_key = ScriptPublicKey::new(0, bytecode(&compiled).clone().into());
     let reused_values = SigHashReusedValuesUnsync::new();
     let sig_cache = Cache::new(10_000);
     let populated = PopulatedTransaction::new(&tx, entries);
@@ -2195,9 +2222,9 @@ fn byte_array_to_fixed_byte_array_cast_compiles_without_num2bin() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("byte[] to byte[32] cast should compile");
-    assert!(!compiled.bytecode.iter().copied().any(|op| op == OpNum2Bin), "byte[] to byte[32] cast should not emit OpNum2Bin");
+    assert!(!bytecode(&compiled).iter().copied().any(|op| op == OpNum2Bin), "byte[] to byte[32] cast should not emit OpNum2Bin");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok(), "byte[] to byte[32] cast should execute");
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok(), "byte[] to byte[32] cast should execute");
 }
 
 #[test]
@@ -2311,10 +2338,10 @@ fn bool_cast_accepts_only_a_singular_byte_as_its_source() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("byte-to-bool casts should compile");
-    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    let opcodes = script_to_str(&bytecode(&compiled)).expect("compiled bytecode stringifies");
     assert_eq!(opcodes.matches("OpIf").count(), 1, "byte-to-bool casts should not add branching beyond dispatch: {opcodes}");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "byte-to-bool casts should preserve VM truthiness: {result:?}");
 }
 
@@ -2360,7 +2387,7 @@ fn encodes_non_byte_array_literal_cast_in_contract_field() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("non-byte array literal cast should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
     assert!(
-        run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok(),
+        run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok(),
         "encoded non-byte array literal cast should execute"
     );
 }
@@ -2525,7 +2552,7 @@ fn build_sig_script_rejects_wrong_argument_count() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let result = compiled.build_sig_script("spend", vec![Expr::int(1)]);
+    let result = encode_entry_sig_script(&compiled, "spend", &[ArtifactValue::Int(1)]);
     assert!(result.is_err());
 }
 
@@ -2539,7 +2566,7 @@ fn build_sig_script_rejects_wrong_argument_type() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let result = compiled.build_sig_script("spend", vec![Expr::bytes(vec![1u8; 3])]);
+    let result = encode_entry_sig_script(&compiled, "spend", &[ArtifactValue::Bytes(vec![1u8; 3])]);
     assert!(result.is_err());
 }
 
@@ -2556,14 +2583,13 @@ fn build_sig_script_for_covenant_decl_routes_to_hidden_auth_entrypoint() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[Expr::int(7)], CompileOptions::default()).expect("compile succeeds");
-    let args = vec![struct_object("State", vec![("value", Expr::int(8))])];
+    let compiled = compile_contract(source, &[ArtifactValue::Int(7)], CompileOptions::default()).expect("compile succeeds");
+    let args = vec![artifact_object([("value", 8.into())])];
 
-    let actual = compiled
-        .build_sig_script_for_covenant_decl("step", args.clone(), CovenantDeclCallOptions { is_leader: false })
+    let actual = build_sig_script_for_covenant_decl(&compiled, "step", args.clone(), CovenantDeclCallOptions { is_leader: false })
         .expect("covenant sigscript builds");
-    let expected =
-        compiled.build_sig_script(&generated_covenant_auth_entrypoint_name("step"), args).expect("hidden entrypoint sigscript builds");
+    let expected = encode_entry_sig_script(&compiled, &generated_covenant_auth_entrypoint_name("step"), &args)
+        .expect("hidden entrypoint sigscript builds");
 
     assert_eq!(actual, expected);
 }
@@ -2581,20 +2607,19 @@ fn build_sig_script_for_covenant_decl_routes_to_hidden_cov_entrypoints() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[Expr::int(7)], CompileOptions::default()).expect("compile succeeds");
-    let leader_args =
-        vec![Expr::array(parse_type_ref("State[]").unwrap(), vec![struct_object("State", vec![("value", Expr::int(8))])])];
+    let compiled = compile_contract(source, &[ArtifactValue::Int(7)], CompileOptions::default()).expect("compile succeeds");
+    let leader_args = vec![ArtifactValue::Array(vec![artifact_object([("value", 8.into())])])];
 
-    let leader = compiled
-        .build_sig_script_for_covenant_decl("rebalance", leader_args.clone(), CovenantDeclCallOptions { is_leader: true })
-        .expect("leader sigscript builds");
-    let expected_leader = compiled.build_sig_script("__leader_rebalance", leader_args).expect("hidden leader sigscript builds");
+    let leader =
+        build_sig_script_for_covenant_decl(&compiled, "rebalance", leader_args.clone(), CovenantDeclCallOptions { is_leader: true })
+            .expect("leader sigscript builds");
+    let expected_leader =
+        encode_entry_sig_script(&compiled, "__leader_rebalance", &leader_args).expect("hidden leader sigscript builds");
     assert_eq!(leader, expected_leader);
 
-    let delegate = compiled
-        .build_sig_script_for_covenant_decl("rebalance", vec![], CovenantDeclCallOptions { is_leader: false })
+    let delegate = build_sig_script_for_covenant_decl(&compiled, "rebalance", vec![], CovenantDeclCallOptions { is_leader: false })
         .expect("delegate sigscript builds");
-    let expected_delegate = compiled.build_sig_script("__delegate", vec![]).expect("hidden delegate sigscript builds");
+    let expected_delegate = encode_entry_sig_script(&compiled, "__delegate", &[]).expect("hidden delegate sigscript builds");
     assert_eq!(delegate, expected_delegate);
 }
 
@@ -2609,7 +2634,7 @@ fn build_sig_script_for_covenant_decl_rejects_unknown_declaration() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let result = compiled.build_sig_script_for_covenant_decl("missing", vec![], CovenantDeclCallOptions { is_leader: false });
+    let result = build_sig_script_for_covenant_decl(&compiled, "missing", vec![], CovenantDeclCallOptions { is_leader: false });
     assert!(result.is_err());
 }
 
@@ -2701,7 +2726,7 @@ fn rejects_external_call_without_entrypoint() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let result = compiled.build_sig_script("helper", vec![Expr::int(1)]);
+    let result = encode_entry_sig_script(&compiled, "helper", &[ArtifactValue::Int(1)]);
     assert!(result.is_err());
 }
 
@@ -2778,7 +2803,7 @@ fn build_sig_script_rejects_mismatched_bytes_length() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let result = compiled.build_sig_script("spend", vec![Expr::bytes(vec![1u8; 5])]);
+    let result = encode_entry_sig_script(&compiled, "spend", &[ArtifactValue::Bytes(vec![1u8; 5])]);
     assert!(result.is_err());
 
     let source = r#"
@@ -2789,7 +2814,7 @@ fn build_sig_script_rejects_mismatched_bytes_length() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let result = compiled.build_sig_script("spend", vec![Expr::bytes(vec![1u8; 4])]);
+    let result = encode_entry_sig_script(&compiled, "spend", &[ArtifactValue::Bytes(vec![1u8; 4])]);
     assert!(result.is_err());
 }
 
@@ -2803,12 +2828,19 @@ fn build_sig_script_appends_dispatch_tag_for_single_entrypoint() {
             }
         }
     "#;
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("spend", vec![1.into(), vec![2u8; 4].into()]).expect("sigscript builds");
-    let dispatch_tag = compiled.entry_by_name("spend").expect("entrypoint resolved").dispatch_tag;
+    let artifact = sil_abi_artifact(source, &[]).expect("compile succeeds");
+    let sigscript = encode_single_entry_sig_script(&artifact, &[1.into(), vec![2u8; 4].into()]).expect("sigscript builds");
+    let dispatch_tag =
+        artifact.contract("Single").and_then(|contract| contract.entry("spend")).expect("entrypoint resolved").dispatch_tag;
 
-    let expected =
-        script_builder().add_i64(1).unwrap().add_data_with_push_opcode(&[2u8; 4]).unwrap().add_data(&dispatch_tag).unwrap().drain();
+    let expected = script_builder()
+        .add_i64(1)
+        .unwrap()
+        .add_data_with_push_opcode(&[2u8; 4])
+        .unwrap()
+        .add_data(dispatch_tag.as_bytes())
+        .unwrap()
+        .drain();
     assert_eq!(sigscript, expected);
 }
 
@@ -2836,7 +2868,7 @@ fn compiles_struct_sugar_for_locals_calls_and_field_access() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "script should execute successfully: {result:?}");
 }
 
@@ -2867,7 +2899,7 @@ fn compiles_struct_return_types_in_inline_calls() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "struct-return inline call should execute successfully: {result:?}");
 }
 
@@ -2888,8 +2920,8 @@ fn build_sig_script_supports_struct_entrypoint_arguments() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let arg = struct_object("S", vec![("a", Expr::int(0)), ("b", Expr::string("12345"))]);
-    let sigscript = compiled.build_sig_script("main", vec![arg]).expect("sigscript builds");
+    let arg = artifact_object([("a", 0.into()), ("b", "12345".into())]);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[arg]).expect("sigscript builds");
 
     let expected = script_builder()
         .add_i64(0)
@@ -2917,8 +2949,8 @@ fn build_sig_script_supports_state_entrypoint_arguments() {
     "#;
 
     let compiled = compile_contract(source, &[5.into(), vec![1u8, 2u8].into()], CompileOptions::default()).expect("compile succeeds");
-    let arg = struct_object("State", vec![("x", Expr::int(9)), ("y", Expr::bytes(vec![0x34, 0x12]))]);
-    let sigscript = compiled.build_sig_script("main", vec![arg]).expect("sigscript builds");
+    let arg = artifact_object([("x", 9.into()), ("y", vec![0x34u8, 0x12].into())]);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[arg]).expect("sigscript builds");
 
     let expected = script_builder()
         .add_i64(9)
@@ -2944,12 +2976,9 @@ fn build_sig_script_supports_sig_array_arguments() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sig_a = vec![0x11u8; 65];
     let sig_b = vec![0x22u8; 65];
-    let sigscript = compiled
-        .build_sig_script(
-            "main",
-            vec![Expr::array(parse_type_ref("sig[]").unwrap(), vec![Expr::bytes(sig_a.clone()), Expr::bytes(sig_b.clone())])],
-        )
-        .expect("sigscript builds");
+    let sigscript =
+        encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Array(vec![sig_a.clone().into(), sig_b.clone().into()])])
+            .expect("sigscript builds");
 
     let mut encoded = sig_a;
     encoded.extend(sig_b);
@@ -2958,43 +2987,25 @@ fn build_sig_script_supports_sig_array_arguments() {
     assert_eq!(sigscript, expected);
 }
 
-fn struct_array_arg<'i>(values: Vec<(i64, Vec<u8>)>) -> Expr<'i> {
-    Expr::array(
-        parse_type_ref("S[]").unwrap(),
-        values.into_iter().map(|(a, b)| struct_object("S", vec![("a", Expr::int(a)), ("b", Expr::bytes(b))])).collect(),
-    )
+fn struct_array_arg(values: Vec<(i64, Vec<u8>)>) -> ArtifactValue {
+    ArtifactValue::Array(values.into_iter().map(|(a, b)| artifact_object([("a", a.into()), ("b", b.into())])).collect())
 }
 
-fn fixed_struct_array_arg<'i>(values: Vec<(i64, Vec<u8>)>) -> Expr<'i> {
-    let mut type_ref = parse_type_ref("S[]").unwrap();
-    type_ref.array_dims[0] = silverscript_lang::ast::ArrayDim::Fixed(values.len());
-    Expr::array(
-        type_ref,
-        values.into_iter().map(|(a, b)| struct_object("S", vec![("a", Expr::int(a)), ("b", Expr::bytes(b))])).collect(),
-    )
+fn fixed_struct_array_arg(values: Vec<(i64, Vec<u8>)>) -> ArtifactValue {
+    struct_array_arg(values)
 }
 
-fn state_array_arg<'i>(values: Vec<i64>) -> Expr<'i> {
-    Expr::array(
-        parse_type_ref("State[]").unwrap(),
-        values.into_iter().map(|value| struct_object("State", vec![("value", Expr::int(value))])).collect(),
-    )
+fn state_array_arg(values: Vec<i64>) -> ArtifactValue {
+    ArtifactValue::Array(values.into_iter().map(|value| artifact_object([("value", value.into())])).collect())
 }
 
-fn state_array_arg_x<'i>(values: Vec<i64>) -> Expr<'i> {
-    Expr::array(
-        parse_type_ref("State[]").unwrap(),
-        values.into_iter().map(|value| struct_object("State", vec![("x", Expr::int(value))])).collect(),
-    )
+fn state_array_arg_x(values: Vec<i64>) -> ArtifactValue {
+    ArtifactValue::Array(values.into_iter().map(|value| artifact_object([("x", value.into())])).collect())
 }
 
-fn matrix_state_array_arg<'i>(values: Vec<(i64, Vec<u8>)>) -> Expr<'i> {
-    Expr::array(
-        parse_type_ref("State[]").unwrap(),
-        values
-            .into_iter()
-            .map(|(amount, owner)| struct_object("State", vec![("amount", Expr::int(amount)), ("owner", Expr::bytes(owner))]))
-            .collect(),
+fn matrix_state_array_arg(values: Vec<(i64, Vec<u8>)>) -> ArtifactValue {
+    ArtifactValue::Array(
+        values.into_iter().map(|(amount, owner)| artifact_object([("amount", amount.into()), ("owner", owner.into())])).collect(),
     )
 }
 
@@ -3003,11 +3014,10 @@ fn replace_compiled_interface<'i>(
     source: &'i str,
     entrypoint_name: &str,
     inputs: &[(&str, &str)],
+    dispatch_tag: DispatchTag,
 ) {
     let old_dispatch_tag = compiled.abi[0].dispatch_tag;
     compiled.ast = parse_contract_ast(source).expect("interface parses");
-    // Do not rely on the dispatch tag in tests using this synthetic interface.
-    let dispatch_tag = [0u8; 4];
     compiled.abi = vec![FunctionAbiEntry {
         name: entrypoint_name.to_string(),
         inputs: inputs
@@ -3029,9 +3039,9 @@ fn replace_compiled_interface<'i>(
 fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
     struct Case {
         source: &'static str,
-        constructor_args: Vec<Expr<'static>>,
+        constructor_args: Vec<ArtifactValue>,
         function_name: &'static str,
-        args: Vec<Expr<'static>>,
+        args: Vec<ArtifactValue>,
         options: CovenantDeclCallOptions,
         generated_covenant_entrypoint_name: &'static str,
     }
@@ -3153,9 +3163,9 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(4)],
+            constructor_args: vec![ArtifactValue::Int(4)],
             function_name: "split",
-            args: vec![state_array_arg(vec![11]), Expr::int(3)],
+            args: vec![state_array_arg(vec![11]), ArtifactValue::Int(3)],
             options: CovenantDeclCallOptions { is_leader: false },
             generated_covenant_entrypoint_name: "__split",
         },
@@ -3170,9 +3180,9 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(2), Expr::int(3)],
+            constructor_args: vec![ArtifactValue::Int(2), ArtifactValue::Int(3)],
             function_name: "transition_ok",
-            args: vec![state_array_arg(vec![10, 11]), Expr::int(1)],
+            args: vec![state_array_arg(vec![10, 11]), ArtifactValue::Int(1)],
             options: CovenantDeclCallOptions { is_leader: true },
             generated_covenant_entrypoint_name: "__leader_transition_ok",
         },
@@ -3187,7 +3197,7 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(2), Expr::int(3)],
+            constructor_args: vec![ArtifactValue::Int(2), ArtifactValue::Int(3)],
             function_name: "transition_ok",
             args: vec![],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3204,9 +3214,9 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(7)],
+            constructor_args: vec![ArtifactValue::Int(7)],
             function_name: "bump",
-            args: vec![Expr::int(2)],
+            args: vec![ArtifactValue::Int(2)],
             options: CovenantDeclCallOptions { is_leader: false },
             generated_covenant_entrypoint_name: "__bump",
         },
@@ -3221,7 +3231,7 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(4), Expr::int(10)],
+            constructor_args: vec![ArtifactValue::Int(4), ArtifactValue::Int(10)],
             function_name: "fanout",
             args: vec![state_array_arg(vec![11, 12])],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3238,7 +3248,7 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(10)],
+            constructor_args: vec![ArtifactValue::Int(10)],
             function_name: "bump_or_terminate",
             args: vec![state_array_arg(vec![13])],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3256,9 +3266,9 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![ArtifactValue::Int(4), ArtifactValue::Int(10), ArtifactValue::Bytes(owner.clone())],
             function_name: "step",
-            args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())]), Expr::int(0)],
+            args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())]), ArtifactValue::Int(0)],
             options: CovenantDeclCallOptions { is_leader: false },
             generated_covenant_entrypoint_name: "__step",
         },
@@ -3274,7 +3284,7 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![ArtifactValue::Int(4), ArtifactValue::Int(10), ArtifactValue::Bytes(owner.clone())],
             function_name: "step",
             args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())])],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3292,9 +3302,9 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![ArtifactValue::Int(4), ArtifactValue::Int(10), ArtifactValue::Bytes(owner.clone())],
             function_name: "step",
-            args: vec![Expr::int(1)],
+            args: vec![ArtifactValue::Int(1)],
             options: CovenantDeclCallOptions { is_leader: false },
             generated_covenant_entrypoint_name: "__step",
         },
@@ -3310,9 +3320,14 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "step",
-            args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())]), Expr::int(0)],
+            args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())]), ArtifactValue::Int(0)],
             options: CovenantDeclCallOptions { is_leader: true },
             generated_covenant_entrypoint_name: "__leader_step",
         },
@@ -3328,7 +3343,12 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "step",
             args: vec![],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3347,9 +3367,14 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "step",
-            args: vec![Expr::int(1)],
+            args: vec![ArtifactValue::Int(1)],
             options: CovenantDeclCallOptions { is_leader: true },
             generated_covenant_entrypoint_name: "__leader_step",
         },
@@ -3366,7 +3391,12 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "step",
             args: vec![],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3384,7 +3414,7 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![ArtifactValue::Int(4), ArtifactValue::Int(10), ArtifactValue::Bytes(owner.clone())],
             function_name: "step",
             args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())])],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3402,7 +3432,12 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "step",
             args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())])],
             options: CovenantDeclCallOptions { is_leader: true },
@@ -3420,7 +3455,12 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "step",
             args: vec![],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3438,23 +3478,23 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
                     }
                 }
             "#,
-            constructor_args: vec![Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![ArtifactValue::Int(10), ArtifactValue::Bytes(owner.clone())],
             function_name: "step",
-            args: vec![Expr::int(1)],
+            args: vec![ArtifactValue::Int(1)],
             options: CovenantDeclCallOptions { is_leader: false },
             generated_covenant_entrypoint_name: "__step",
         },
         Case {
             source: matrix_singleton_transition_source,
-            constructor_args: vec![Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![ArtifactValue::Int(10), ArtifactValue::Bytes(owner.clone())],
             function_name: "step",
-            args: vec![Expr::int(1)],
+            args: vec![ArtifactValue::Int(1)],
             options: CovenantDeclCallOptions { is_leader: false },
             generated_covenant_entrypoint_name: "__step",
         },
         Case {
             source: matrix_singleton_terminate_source,
-            constructor_args: vec![Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![ArtifactValue::Int(10), ArtifactValue::Bytes(owner.clone())],
             function_name: "step",
             args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())])],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3462,7 +3502,7 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
         },
         Case {
             source: matrix_fanout_verification_source,
-            constructor_args: vec![Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![ArtifactValue::Int(4), ArtifactValue::Int(10), ArtifactValue::Bytes(owner.clone())],
             function_name: "step",
             args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())])],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3470,15 +3510,25 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
         },
         Case {
             source: matrix_auth_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "auth_verification_multi",
-            args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())]), Expr::int(0)],
+            args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())]), ArtifactValue::Int(0)],
             options: CovenantDeclCallOptions { is_leader: false },
             generated_covenant_entrypoint_name: "__auth_verification_multi",
         },
         Case {
             source: matrix_auth_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "auth_verification_single",
             args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())])],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3486,23 +3536,38 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
         },
         Case {
             source: matrix_auth_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "auth_transition",
-            args: vec![Expr::int(1)],
+            args: vec![ArtifactValue::Int(1)],
             options: CovenantDeclCallOptions { is_leader: false },
             generated_covenant_entrypoint_name: "__auth_transition",
         },
         Case {
             source: matrix_cov_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "cov_verification",
-            args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())]), Expr::int(0)],
+            args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())]), ArtifactValue::Int(0)],
             options: CovenantDeclCallOptions { is_leader: true },
             generated_covenant_entrypoint_name: "__leader_cov_verification",
         },
         Case {
             source: matrix_cov_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "cov_verification",
             args: vec![],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3510,15 +3575,25 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
         },
         Case {
             source: matrix_cov_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "cov_transition",
-            args: vec![Expr::int(1)],
+            args: vec![ArtifactValue::Int(1)],
             options: CovenantDeclCallOptions { is_leader: true },
             generated_covenant_entrypoint_name: "__leader_cov_transition",
         },
         Case {
             source: matrix_cov_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "cov_transition",
             args: vec![],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3526,7 +3601,12 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
         },
         Case {
             source: matrix_auth_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "inferred_auth",
             args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())])],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3534,7 +3614,12 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
         },
         Case {
             source: matrix_cov_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "inferred_cov",
             args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())])],
             options: CovenantDeclCallOptions { is_leader: true },
@@ -3542,7 +3627,12 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
         },
         Case {
             source: matrix_cov_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "inferred_cov",
             args: vec![],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3550,23 +3640,38 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
         },
         Case {
             source: matrix_auth_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "inferred_transition",
-            args: vec![Expr::int(1)],
+            args: vec![ArtifactValue::Int(1)],
             options: CovenantDeclCallOptions { is_leader: false },
             generated_covenant_entrypoint_name: "__inferred_transition",
         },
         Case {
             source: matrix_auth_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "singleton_transition",
-            args: vec![Expr::int(1)],
+            args: vec![ArtifactValue::Int(1)],
             options: CovenantDeclCallOptions { is_leader: false },
             generated_covenant_entrypoint_name: "__singleton_transition",
         },
         Case {
             source: matrix_auth_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "singleton_terminate",
             args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())])],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3574,7 +3679,12 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
         },
         Case {
             source: matrix_auth_source,
-            constructor_args: vec![Expr::int(2), Expr::int(4), Expr::int(10), Expr::bytes(owner.clone())],
+            constructor_args: vec![
+                ArtifactValue::Int(2),
+                ArtifactValue::Int(4),
+                ArtifactValue::Int(10),
+                ArtifactValue::Bytes(owner.clone()),
+            ],
             function_name: "fanout_verification",
             args: vec![matrix_state_array_arg(vec![(11, next_owner.clone())])],
             options: CovenantDeclCallOptions { is_leader: false },
@@ -3584,8 +3694,7 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
 
     for case in cases {
         let compiled = compile_contract(case.source, &case.constructor_args, CompileOptions::default()).expect("compile succeeds");
-        let sigscript = compiled
-            .build_sig_script_for_covenant_decl(case.function_name, case.args.clone(), case.options)
+        let sigscript = build_sig_script_for_covenant_decl(&compiled, case.function_name, case.args.clone(), case.options)
             .expect("covenant declaration sigscript builds");
         let generated_entrypoint_name = if case.generated_covenant_entrypoint_name.starts_with("__leader_")
             || case.generated_covenant_entrypoint_name == "__delegate"
@@ -3595,7 +3704,7 @@ fn build_sig_script_for_covenant_decl_supports_all_covenant_ast_examples() {
             generated_covenant_auth_entrypoint_name(case.function_name)
         };
         let expected =
-            compiled.build_sig_script(&generated_entrypoint_name, case.args).expect("generated entrypoint sigscript builds");
+            encode_entry_sig_script(&compiled, &generated_entrypoint_name, &case.args).expect("generated entrypoint sigscript builds");
         assert_eq!(sigscript, expected, "covenant declaration sigscript should match generated entrypoint for {}", case.function_name);
     }
 }
@@ -3620,8 +3729,9 @@ fn runtime_rejects_regular_struct_array_entrypoint_arguments_without_struct_sign
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let main_param_types: Vec<String> = compiled
+    let lowered = compile_internal_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("portable artifact compiles");
+    let main_param_types: Vec<String> = lowered
         .ast
         .functions
         .iter()
@@ -3633,8 +3743,7 @@ fn runtime_rejects_regular_struct_array_entrypoint_arguments_without_struct_sign
         .collect();
     assert_eq!(main_param_types, vec!["int[]".to_string(), "byte[2][]".to_string()]);
 
-    let err = compiled
-        .build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
+    let err = encode_entry_sig_script(&compiled, "main", &[struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
         .expect_err("struct[] arguments should be rejected when the entrypoint signature is not struct-typed");
     assert!(err.to_string().contains("expects 2 arguments"), "unexpected error: {err}");
 }
@@ -3676,8 +3785,10 @@ fn runtime_supports_regular_struct_array_entrypoint_arguments_with_struct_signat
         }
     "#;
 
-    let mut compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    replace_compiled_interface(&mut compiled, struct_signature_source, "main", &[("x", "S[]")]);
+    let mut compiled = compile_internal_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let interface_artifact = sil_abi_artifact(struct_signature_source, &[]).expect("struct interface compiles");
+    let dispatch_tag = single_contract(&interface_artifact).entry("main").expect("main entry exists").dispatch_tag.into_bytes();
+    replace_compiled_interface(&mut compiled, struct_signature_source, "main", &[("x", "S[]")], dispatch_tag);
 
     let main_param_types: Vec<String> = compiled
         .ast
@@ -3691,9 +3802,9 @@ fn runtime_supports_regular_struct_array_entrypoint_arguments_with_struct_signat
         .collect();
     assert_eq!(main_param_types, vec!["S[]".to_string()]);
 
-    let sigscript = compiled
-        .build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
-        .expect("sigscript builds");
+    let sigscript =
+        encode_entry_sig_script(&interface_artifact, "main", &[struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
+            .expect("sigscript builds");
     let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
 
     assert!(result.is_ok(), "regular struct[] entrypoint arg should execute successfully: {result:?}");
@@ -3718,8 +3829,9 @@ fn runtime_supports_direct_struct_array_entrypoint_signature() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let f_param_types: Vec<String> = compiled
+    let lowered = compile_internal_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("portable artifact compiles");
+    let f_param_types: Vec<String> = lowered
         .ast
         .functions
         .iter()
@@ -3731,10 +3843,9 @@ fn runtime_supports_direct_struct_array_entrypoint_signature() {
         .collect();
     assert_eq!(f_param_types, vec!["S[]".to_string()]);
 
-    let sigscript = compiled
-        .build_sig_script("f", vec![struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
+    let sigscript = encode_entry_sig_script(&compiled, "f", &[struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
         .expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
 
     assert!(result.is_ok(), "direct struct[] entrypoint signature should execute successfully: {result:?}");
 }
@@ -3779,7 +3890,7 @@ fn runtime_rejects_mismatched_dynamic_struct_array_leaf_counts_before_append() {
         .unwrap()
         .drain();
 
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_err(), "mismatched struct-array leaf counts must fail before the entrypoint body");
 }
 
@@ -3799,7 +3910,7 @@ fn codegen_reuses_dynamic_struct_array_leaf_sizes_for_cardinality_validation() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    let opcodes = script_to_str(&bytecode(&compiled)).expect("compiled bytecode stringifies");
 
     assert_eq!(opcodes.matches("OpSize").count(), 2, "each flattened struct-array leaf should be sized once: {opcodes}");
 }
@@ -3846,10 +3957,10 @@ fn runtime_validates_cardinality_for_deeply_nested_struct_array_leaves() {
             .drain()
     };
 
-    let valid = run_bytecode_with_sigscript(compiled.bytecode.clone(), build_sigscript(4));
+    let valid = run_bytecode_with_sigscript(bytecode(&compiled).clone(), build_sigscript(4));
     assert!(valid.is_ok(), "equal leaf cardinalities across nested fixed-width layouts should execute: {valid:?}");
 
-    let malformed = run_bytecode_with_sigscript(compiled.bytecode, build_sigscript(8));
+    let malformed = run_bytecode_with_sigscript(bytecode(&compiled), build_sigscript(8));
     assert!(malformed.is_err(), "a surplus element in a deeply nested leaf must be rejected");
 }
 
@@ -3870,19 +3981,13 @@ fn runtime_keeps_cardinality_groups_separate_for_multiple_struct_array_params() 
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let first = Expr::array(
-        parse_type_ref("Item[]").unwrap(),
-        vec![struct_object("Item", vec![("number", Expr::int(1)), ("tag", Expr::bytes(vec![1, 2]))])],
-    );
-    let second = Expr::array(
-        parse_type_ref("Item[]").unwrap(),
-        vec![
-            struct_object("Item", vec![("number", Expr::int(2)), ("tag", Expr::bytes(vec![3, 4]))]),
-            struct_object("Item", vec![("number", Expr::int(3)), ("tag", Expr::bytes(vec![5, 6]))]),
-        ],
-    );
-    let sigscript = compiled.build_sig_script("main", vec![first, second]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let first = ArtifactValue::Array(vec![artifact_object([("number", 1.into()), ("tag", vec![1u8, 2].into())])]);
+    let second = ArtifactValue::Array(vec![
+        artifact_object([("number", 2.into()), ("tag", vec![3u8, 4].into())]),
+        artifact_object([("number", 3.into()), ("tag", vec![5u8, 6].into())]),
+    ]);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[first, second]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
 
     assert!(result.is_ok(), "separate struct-array parameters may have different lengths: {result:?}");
 }
@@ -3903,18 +4008,16 @@ fn build_sig_script_enforces_fixed_struct_array_length() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    compiled
-        .build_sig_script("main", vec![fixed_struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
+    encode_entry_sig_script(&compiled, "main", &[fixed_struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
         .expect("correctly sized struct array should encode");
 
-    let err = compiled
-        .build_sig_script("main", vec![fixed_struct_array_arg(vec![(7, vec![0x01, 0x02])])])
+    let err = encode_entry_sig_script(&compiled, "main", &[fixed_struct_array_arg(vec![(7, vec![0x01, 0x02])])])
         .expect_err("wrongly sized struct array should be rejected");
-    assert!(err.to_string().contains("size mismatch"), "unexpected error: {err}");
+    assert!(err.to_string().contains("expects 2 bytes"), "unexpected error: {err}");
 }
 
 #[test]
-fn build_sig_script_rejects_structurally_identical_array_element_type() {
+fn artifact_sigscript_accepts_structurally_identical_object_values() {
     let source = r#"
         contract C() {
             struct S {
@@ -3934,14 +4037,10 @@ fn build_sig_script_rejects_structurally_identical_array_element_type() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let arg = Expr::array(
-        parse_type_ref("T[]").unwrap(),
-        vec![struct_object("T", vec![("a", Expr::int(7)), ("b", Expr::bytes(vec![0x01, 0x02]))])],
-    );
-    let err = compiled
-        .build_sig_script("main", vec![arg])
-        .expect_err("a structurally identical struct array must retain its nominal element type");
-    assert!(err.to_string().contains("expected struct 'S', got 'T'"), "unexpected error: {err}");
+    let arg = ArtifactValue::Array(vec![artifact_object([("a", 7.into()), ("b", vec![0x01u8, 0x02].into())])]);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[arg])
+        .expect("portable object values are structural and do not carry a source struct name");
+    run_bytecode_with_sigscript(bytecode(&compiled), sigscript).expect("the structurally compatible object value executes");
 }
 
 #[test]
@@ -3961,8 +4060,9 @@ fn runtime_supports_struct_array_append_value_length_without_assignment() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02])])]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript =
+        encode_entry_sig_script(&compiled, "main", &[struct_array_arg(vec![(7, vec![0x01, 0x02])])]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
 
     assert!(result.is_ok(), "struct[] append result length should be usable without assignment: {result:?}");
 }
@@ -3993,8 +4093,9 @@ fn runtime_supports_struct_array_append_assignment_from_different_source() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02])])]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript =
+        encode_entry_sig_script(&compiled, "main", &[struct_array_arg(vec![(7, vec![0x01, 0x02])])]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
 
     assert!(result.is_ok(), "struct[] append assignment from a different source should execute successfully: {result:?}");
 }
@@ -4024,8 +4125,9 @@ fn runtime_supports_struct_array_append_value_expression() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02])])]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript =
+        encode_entry_sig_script(&compiled, "main", &[struct_array_arg(vec![(7, vec![0x01, 0x02])])]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
 
     assert!(result.is_ok(), "struct[] append value expression should execute successfully: {result:?}");
 }
@@ -4054,8 +4156,9 @@ fn runtime_rejects_regular_struct_array_non_entrypoint_arguments_without_struct_
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let main_param_types: Vec<String> = compiled
+    let lowered = compile_internal_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("portable artifact compiles");
+    let main_param_types: Vec<String> = lowered
         .ast
         .functions
         .iter()
@@ -4067,7 +4170,7 @@ fn runtime_rejects_regular_struct_array_non_entrypoint_arguments_without_struct_
         .collect();
     assert_eq!(main_param_types, vec!["int[]".to_string(), "byte[2][]".to_string()]);
 
-    let verify_param_types: Vec<String> = compiled
+    let verify_param_types: Vec<String> = lowered
         .ast
         .functions
         .iter()
@@ -4079,8 +4182,7 @@ fn runtime_rejects_regular_struct_array_non_entrypoint_arguments_without_struct_
         .collect();
     assert_eq!(verify_param_types, vec!["int[]".to_string(), "byte[2][]".to_string()]);
 
-    let err = compiled
-        .build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
+    let err = encode_entry_sig_script(&compiled, "main", &[struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
         .expect_err("struct[] arguments should be rejected when entrypoint and internal function signatures are not struct-typed");
     assert!(err.to_string().contains("expects 2 arguments"), "unexpected error: {err}");
 }
@@ -4130,8 +4232,10 @@ fn runtime_supports_regular_struct_array_non_entrypoint_arguments_with_struct_si
         }
     "#;
 
-    let mut compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    replace_compiled_interface(&mut compiled, struct_signature_source, "main", &[("x", "S[]")]);
+    let mut compiled = compile_internal_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let interface_artifact = sil_abi_artifact(struct_signature_source, &[]).expect("struct interface compiles");
+    let dispatch_tag = single_contract(&interface_artifact).entry("main").expect("main entry exists").dispatch_tag.into_bytes();
+    replace_compiled_interface(&mut compiled, struct_signature_source, "main", &[("x", "S[]")], dispatch_tag);
 
     let main_param_types: Vec<String> = compiled
         .ast
@@ -4157,9 +4261,9 @@ fn runtime_supports_regular_struct_array_non_entrypoint_arguments_with_struct_si
         .collect();
     assert_eq!(verify_param_types, vec!["S[]".to_string()]);
 
-    let sigscript = compiled
-        .build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
-        .expect("sigscript builds");
+    let sigscript =
+        encode_entry_sig_script(&interface_artifact, "main", &[struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
+            .expect("sigscript builds");
     let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
 
     assert!(result.is_ok(), "regular struct[] arg should flow through non-entrypoint calls at runtime: {result:?}");
@@ -4213,8 +4317,9 @@ fn runtime_supports_direct_struct_array_non_entrypoint_signature() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let verify_param_types: Vec<String> = compiled
+    let lowered = compile_internal_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("portable artifact compiles");
+    let verify_param_types: Vec<String> = lowered
         .ast
         .functions
         .iter()
@@ -4226,10 +4331,10 @@ fn runtime_supports_direct_struct_array_non_entrypoint_signature() {
         .collect();
     assert_eq!(verify_param_types, vec!["S[]".to_string()]);
 
-    let sigscript = compiled
-        .build_sig_script("main", vec![struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
-        .expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript =
+        encode_entry_sig_script(&compiled, "main", &[struct_array_arg(vec![(7, vec![0x01, 0x02]), (9, vec![0x03, 0x04])])])
+            .expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
 
     assert!(result.is_ok(), "direct struct[] non-entrypoint signature should execute successfully: {result:?}");
 }
@@ -4435,8 +4540,8 @@ fn build_sig_script_rejects_struct_argument_with_wrong_field_type() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let arg = struct_object("S", vec![("a", Expr::string("hello")), ("b", Expr::string("world"))]);
-    let result = compiled.build_sig_script("main", vec![arg]);
+    let arg = artifact_object([("a", "hello".into()), ("b", "world".into())]);
+    let result = encode_single_entry_sig_script(&compiled, &[arg]);
     assert!(result.is_err());
 }
 
@@ -4460,7 +4565,7 @@ fn compiles_struct_destructuring_and_runs() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "struct destructuring runtime failed: {}", result.unwrap_err());
 }
 
@@ -4524,7 +4629,7 @@ fn compiles_function_call_assignment_and_verifies() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
 
@@ -4545,9 +4650,9 @@ fn function_call_statement_evaluates_and_drops_unused_return_expression() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let asm = script_to_str(&compiled.bytecode).expect("script should stringify");
+    let asm = script_to_str(&bytecode(&compiled)).expect("script should stringify");
     assert!(asm.contains("OpAdd OpDrop"), "unused inline return expression should be evaluated and dropped: {asm}");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -4671,7 +4776,7 @@ fn allows_calling_void_function() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
 
@@ -4718,8 +4823,8 @@ fn function_call_in_require_statement() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("expression-position helper call should compile");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::int(4)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(4)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "expression-position helper call should execute successfully: {}", result.unwrap_err());
 }
 
@@ -4738,8 +4843,8 @@ fn single_return_helper_call_can_participate_in_expression() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("single-return helper call should compile");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::int(4)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(4)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "single-return helper call should execute successfully: {}", result.unwrap_err());
 }
 
@@ -4779,7 +4884,7 @@ fn rejects_calling_later_defined_function() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("forward call should now compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "first");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "forward call should execute successfully: {}", result.unwrap_err());
 }
 
@@ -4859,7 +4964,7 @@ fn multi_return_helper_call_assignment_remains_valid() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("tuple call assignment should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "tuple call assignment should execute successfully: {}", result.unwrap_err());
 }
 
@@ -4880,7 +4985,7 @@ fn tuple_return_field_access_can_initialize_variable_and_run() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("tuple field access should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "tuple field access variable initializer should execute successfully: {}", result.unwrap_err());
 }
 
@@ -4900,7 +5005,7 @@ fn tuple_return_field_access_can_be_used_in_require_and_run() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("tuple field access in require should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "tuple field access in require should execute successfully: {}", result.unwrap_err());
 }
 
@@ -4920,7 +5025,7 @@ fn tuple_return_field_access_allows_parenthesized_single_return_type() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("f() : (int) should allow f().0");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "single-element tuple field access should execute successfully: {}", result.unwrap_err());
 }
 
@@ -5007,7 +5112,7 @@ fn allows_call_chain_with_earlier_defined_functions() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
 
@@ -5041,7 +5146,7 @@ fn allows_call_chain_with_later_defined_functions() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
 
@@ -5104,7 +5209,7 @@ fn allows_calling_void_function_fails() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_err());
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_err());
 }
 
 #[test]
@@ -5173,7 +5278,7 @@ fn single_return_signature_without_parentheses_compiles_and_runs() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "single bare return type should execute successfully: {}", result.unwrap_err());
 }
 
@@ -5194,7 +5299,7 @@ fn single_return_signature_without_parentheses_supports_direct_variable_definiti
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "direct variable definition assignment should execute successfully: {}", result.unwrap_err());
 }
 
@@ -5215,7 +5320,7 @@ fn single_return_statement_without_parentheses_compiles_and_runs() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "single bare return statement should execute successfully: {}", result.unwrap_err());
 }
 
@@ -5259,7 +5364,7 @@ fn array_literal_codegen_uses_declared_element_type() {
     let compiled = compile_contract(source, &[], CompileOptions { record_debug_infos: true, ..CompileOptions::default() })
         .expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "array literals should use their declared element type: {}", result.unwrap_err());
 }
 
@@ -5284,7 +5389,7 @@ fn bool_array_literal_normalizes_runtime_elements_to_one_byte() {
             .add_data(&dispatch_tag_for(&compiled, "main"))
             .unwrap()
             .drain();
-        let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+        let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
         assert!(result.is_ok(), "bool[] literal witness {witness:#04x} should normalize to 0x{expected}: {result:?}");
     }
 }
@@ -5305,8 +5410,8 @@ fn runtime_and_compile_time_false_have_identical_bool_array_encoding() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("check", vec![Expr::bool(true)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_entry_sig_script(&compiled, "check", &[ArtifactValue::Bool(true)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "runtime and compile-time false should have identical bool[] encoding: {result:?}");
 }
 
@@ -5325,7 +5430,7 @@ fn bool_array_append_normalizes_runtime_elements_to_one_byte() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript =
         script_builder().add_data_with_push_opcode(&[2]).unwrap().add_data(&dispatch_tag_for(&compiled, "main")).unwrap().drain();
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "truthy bool[] append elements should be normalized to 0x01: {result:?}");
 }
 
@@ -5341,8 +5446,8 @@ fn int_array_literal_normalizes_runtime_elements_to_eight_bytes() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::int(1)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(1)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "int[] literal elements should each occupy eight bytes: {result:?}");
 }
 
@@ -5359,8 +5464,8 @@ fn int_array_append_normalizes_runtime_elements_to_eight_bytes() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::int(1)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(1)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "int[] append elements should each occupy eight bytes: {result:?}");
 }
 
@@ -5384,8 +5489,9 @@ fn struct_array_bool_and_int_leaves_use_fixed_width_encoding() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::bool(true), Expr::int(1)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript =
+        encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Bool(true), ArtifactValue::Int(1)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "flattened struct array leaves should retain bool/int element widths: {result:?}");
 }
 
@@ -5404,8 +5510,9 @@ fn nested_bool_and_int_array_literals_use_fixed_width_encoding() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::bool(true), Expr::int(1)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript =
+        encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Bool(true), ArtifactValue::Int(1)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "nested array literals should normalize their scalar elements: {result:?}");
 }
 
@@ -5429,7 +5536,7 @@ fn constant_and_contract_field_arrays_use_fixed_width_encoding() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "compile-time array encoders should use the canonical scalar widths: {result:?}");
 }
 
@@ -5445,10 +5552,10 @@ fn bool_and_int_array_sigscript_arguments_use_fixed_width_encoding() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let flags = Expr::array(parse_type_ref("bool[2]").expect("type parses"), vec![Expr::bool(true), Expr::bool(false)]);
-    let numbers = Expr::array(parse_type_ref("int[2]").expect("type parses"), vec![Expr::int(1), Expr::int(0)]);
-    let sigscript = compiled.build_sig_script("main", vec![flags, numbers]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let flags = ArtifactValue::Array(vec![true.into(), false.into()]);
+    let numbers = ArtifactValue::Array(vec![1.into(), 0.into()]);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[flags, numbers]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "signature-script array encoding should use the canonical scalar widths: {result:?}");
 }
 
@@ -5493,7 +5600,7 @@ fn compiles_int_array_length_to_expected_script() {
         .drain();
 
     let expected = wrap_with_single_dispatch(&compiled, expected);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -5546,7 +5653,7 @@ fn compiles_int_array_append_to_expected_script() {
         .drain();
 
     let expected = wrap_with_single_dispatch(&compiled, expected);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -5664,30 +5771,30 @@ fn branchy_three_slot_splice_repro_matches_current_codegen_shape() {
         }
     "#;
     let args = vec![
-        Expr::bytes(vec![0x11u8; 32]),
-        Expr::bytes({
+        ArtifactValue::Bytes(vec![0x11u8; 32]),
+        ArtifactValue::Bytes({
             let mut route_templates = Vec::with_capacity(32 * 9);
             for byte in 0x12u8..=0x1au8 {
                 route_templates.extend_from_slice(&[byte; 32]);
             }
             route_templates
         }),
-        Expr::bytes(vec![0x21u8; 32]),
-        Expr::bytes(vec![0x22u8; 32]),
-        Expr::bytes(vec![0u8; 64]),
-        Expr::int(0),
-        Expr::int(0),
-        Expr::int(600),
-        Expr::bytes(vec![1u8; 4]),
-        Expr::int(-1),
-        Expr::int(12),
-        Expr::int(28),
-        Expr::int(0),
-        Expr::int(0),
-        Expr::int(3),
+        ArtifactValue::Bytes(vec![0x21u8; 32]),
+        ArtifactValue::Bytes(vec![0x22u8; 32]),
+        ArtifactValue::Bytes(vec![0u8; 64]),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(600),
+        ArtifactValue::Bytes(vec![1u8; 4]),
+        ArtifactValue::Int(-1),
+        ArtifactValue::Int(12),
+        ArtifactValue::Int(28),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(0),
+        ArtifactValue::Int(3),
     ];
     let compiled = compile_contract(source, &args, CompileOptions::default()).expect("compile succeeds");
-    let asm = script_to_str(&compiled.bytecode).expect("compiled bytecode should stringify");
+    let asm = script_to_str(&bytecode(&compiled)).expect("compiled bytecode should stringify");
 
     // This is a reduced repro for the chess pawn blowup on the current branch.
     // This used to explode because branch-mutated splice
@@ -5695,7 +5802,7 @@ fn branchy_three_slot_splice_repro_matches_current_codegen_shape() {
     // into a very large opcode shape. With array locals kept on the stack, the
     // same source should stay close to the old master-size range instead of
     // ballooning into thousands of bytes and OpPick instructions.
-    assert!(compiled.bytecode.len() < 1000, "script should stay compact, got {}", compiled.bytecode.len());
+    assert!(bytecode(&compiled).len() < 1000, "script should stay compact, got {}", bytecode(&compiled).len());
     assert!(asm.matches("OpPick").count() < 120, "OpPick count should stay bounded, got {}", asm.matches("OpPick").count());
     assert!(asm.matches("OpSubstr").count() <= 24, "OpSubstr count should stay near master, got {}", asm.matches("OpSubstr").count());
     assert!(
@@ -5759,7 +5866,7 @@ fn compiles_int_array_index_to_expected_script() {
         .drain();
 
     let expected = wrap_with_single_dispatch(&compiled, expected);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -5781,7 +5888,7 @@ fn runs_array_append_runtime_examples() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "array append runtime example failed: {}", result.unwrap_err());
 }
 
@@ -5799,7 +5906,7 @@ fn runs_array_append_value_length_without_assignment() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "array append result length should be usable without assignment: {result:?}");
 }
 
@@ -5817,7 +5924,7 @@ fn runs_int_array_append_length_runtime_example() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "int[] append length runtime example failed: {}", result.unwrap_err());
 }
 
@@ -5835,7 +5942,7 @@ fn runs_slice_with_explicit_end_bounds() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "slice runtime should succeed: {}", result.unwrap_err());
 }
 
@@ -5859,7 +5966,7 @@ fn runs_slice_reconstruction_and_compare_runtime_example() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "slice reconstruction runtime should succeed: {}", result.unwrap_err());
 }
 
@@ -5953,7 +6060,7 @@ fn allows_concat_of_int_arrays_with_plus() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "int[] concatenation runtime failed: {}", result.unwrap_err());
 }
 
@@ -5975,7 +6082,7 @@ fn allows_concat_of_byte_arrays_with_plus() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "byte[] concatenation runtime failed: {}", result.unwrap_err());
 }
 
@@ -5992,7 +6099,7 @@ fn concatenated_byte_array_literal_has_element_length() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "byte[] literal concatenation should have two elements: {}", result.unwrap_err());
 }
 
@@ -6016,7 +6123,7 @@ fn allows_concat_of_fixed_size_byte_array_elements_with_plus() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "byte[N][] concatenation runtime failed: {}", result.unwrap_err());
 }
 
@@ -6035,10 +6142,10 @@ fn composite_array_index_uses_its_result_type_for_bytewise_operations() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    assert!(!compiled.bytecode.contains(&OpNum2Bin), "an indexed byte array element is already byte-encoded");
+    assert!(!bytecode(&compiled).contains(&OpNum2Bin), "an indexed byte array element is already byte-encoded");
 
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "composite array indexing should use bytewise operations: {}", result.unwrap_err());
 }
 
@@ -6063,7 +6170,7 @@ fn allows_concat_of_bool_arrays_with_plus() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "bool[] concatenation runtime failed: {}", result.unwrap_err());
 }
 
@@ -6089,7 +6196,7 @@ fn allows_concat_of_pubkey_arrays_with_plus() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "pubkey[] concatenation runtime failed: {}", result.unwrap_err());
 }
 
@@ -6145,7 +6252,7 @@ fn compiles_bytes20_array_append_without_num2bin() {
         .drain();
 
     let expected = wrap_with_single_dispatch(&compiled, expected);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -6165,7 +6272,7 @@ fn runs_bytes20_array_runtime_example() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "byte[20] array runtime example failed: {}", result.unwrap_err());
 }
 
@@ -6185,7 +6292,7 @@ fn allows_array_equality_comparison() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "array equality runtime failed: {}", result.unwrap_err());
 }
 
@@ -6205,7 +6312,7 @@ fn fails_array_equality_comparison() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_err());
 }
 
@@ -6273,7 +6380,7 @@ fn allows_array_inequality_with_different_sizes() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "array inequality runtime failed: {}", result.unwrap_err());
 }
 
@@ -6295,7 +6402,7 @@ fn runs_array_for_loop_example() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "array for-loop runtime failed: {}", result.unwrap_err());
 }
 
@@ -6316,9 +6423,9 @@ fn runs_array_for_loop_with_length_guard() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
 
-    let sigscript = compiled.build_sig_script("main", vec![vec![1i64, 2i64, 3i64, 4i64].into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[vec![1i64, 2i64, 3i64, 4i64].into()]).expect("sigscript builds");
 
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "array for-loop length-guard runtime failed: {}", result.unwrap_err());
 }
 
@@ -6349,7 +6456,7 @@ fn runs_array_loop_and_function_calls_example() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "array/loop/function-call example failed: {}", result.unwrap_err());
 }
 
@@ -6558,16 +6665,17 @@ fn runs_runtime_bounded_for_loop_example() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
-    let sigscript = compiled.build_sig_script("main", vec![2.into(), 4.into(), 2.into(), 3.into()]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[2.into(), 4.into(), 2.into(), 3.into()]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript);
     assert!(result.is_ok(), "runtime-bounded for-loop should honor end-exclusive bounds: {}", result.unwrap_err());
 
-    let sigscript = compiled.build_sig_script("main", vec![5.into(), 8.into(), 3.into(), 7.into()]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[5.into(), 8.into(), 3.into(), 7.into()]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript);
     assert!(result.is_ok(), "runtime-bounded for-loop should allow ranges up to max iterations: {}", result.unwrap_err());
 
-    let sigscript = compiled.build_sig_script("main", vec![4.into(), 2.into(), 0.into(), (-1).into()]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript =
+        encode_entry_sig_script(&compiled, "main", &[4.into(), 2.into(), 0.into(), (-1).into()]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "runtime-bounded for-loop should skip iterations when start >= end: {}", result.unwrap_err());
 }
 
@@ -6593,8 +6701,8 @@ fn runtime_for_loop_snapshots_compound_bound_expressions_before_the_body() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![0.into(), 3.into()]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[0.into(), 3.into()]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "mutating variables used by bound expressions must not change the snapshotted range: {result:?}");
 }
 
@@ -6611,7 +6719,7 @@ fn runtime_for_loop_evaluates_each_bound_expression_once() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode should stringify");
+    let opcodes = script_to_str(&bytecode(&compiled)).expect("compiled bytecode should stringify");
     assert_eq!(opcodes.matches("OpTxInputCount").count(), 1, "the start expression must be evaluated once: {opcodes}");
     assert_eq!(opcodes.matches("OpTxOutputCount").count(), 1, "the end expression must be evaluated once: {opcodes}");
 }
@@ -6629,8 +6737,8 @@ fn rejects_runtime_for_loop_range_above_max_iterations() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![2.into(), 6.into()]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[2.into(), 6.into()]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_err(), "runtime-bounded for-loop should fail when end - start exceeds max iterations");
 }
 
@@ -6649,7 +6757,7 @@ fn allows_array_assignment_with_compatible_types() {
     let options = CompileOptions::default();
     let compiled = compile_contract(source, &[], options).expect("compile succeeds");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "array assignment runtime failed: {}", result.unwrap_err());
 }
 
@@ -6675,16 +6783,27 @@ fn inline_pubkey_param_reassignment_compiles_and_runs() {
     let a = vec![0x11u8; 32];
     let b = vec![0x22u8; 32];
 
-    let sigscript_take_b = compiled
-        .build_sig_script("main", vec![Expr::bytes(a.clone()), Expr::bytes(b.clone()), Expr::bytes(b.clone()), Expr::bool(true)])
-        .expect("sigscript builds");
-    let result_take_b = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_take_b);
+    let sigscript_take_b = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[
+            ArtifactValue::Bytes(a.clone()),
+            ArtifactValue::Bytes(b.clone()),
+            ArtifactValue::Bytes(b.clone()),
+            ArtifactValue::Bool(true),
+        ],
+    )
+    .expect("sigscript builds");
+    let result_take_b = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_take_b);
     assert!(result_take_b.is_ok(), "inline pubkey reassignment should allow taking the second value: {}", result_take_b.unwrap_err());
 
-    let sigscript_keep_a = compiled
-        .build_sig_script("main", vec![Expr::bytes(a.clone()), Expr::bytes(b), Expr::bytes(a), Expr::bool(false)])
-        .expect("sigscript builds");
-    let result_keep_a = run_bytecode_with_sigscript(compiled.bytecode, sigscript_keep_a);
+    let sigscript_keep_a = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Bytes(a.clone()), ArtifactValue::Bytes(b), ArtifactValue::Bytes(a), ArtifactValue::Bool(false)],
+    )
+    .expect("sigscript builds");
+    let result_keep_a = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_keep_a);
     assert!(
         result_keep_a.is_ok(),
         "inline pubkey reassignment should preserve the first value when branch is skipped: {}",
@@ -6738,8 +6857,9 @@ fn locking_bytecode_p2pk_matches_pay_to_address_script() {
     expected.extend_from_slice(&spk.version().to_be_bytes());
     expected.extend_from_slice(spk.script());
 
-    let sigscript = compiled.build_sig_script("main", vec![pubkey.into(), Expr::dynamic_bytes(expected)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript =
+        encode_entry_sig_script(&compiled, "main", &[pubkey.into(), ArtifactValue::Bytes(expected)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "p2pk locking bytecode mismatch: {}", result.unwrap_err());
 }
 
@@ -6762,8 +6882,9 @@ fn locking_bytecode_p2sh_matches_pay_to_address_script() {
     expected.extend_from_slice(&spk.version().to_be_bytes());
     expected.extend_from_slice(spk.script());
 
-    let sigscript = compiled.build_sig_script("main", vec![hash.into(), Expr::dynamic_bytes(expected)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript =
+        encode_entry_sig_script(&compiled, "main", &[hash.into(), ArtifactValue::Bytes(expected)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "p2sh locking bytecode mismatch: {}", result.unwrap_err());
 }
 
@@ -6785,10 +6906,9 @@ fn locking_bytecode_p2sh_from_redeem_script_matches_pay_to_script_hash_script() 
     expected.extend_from_slice(&spk.version().to_be_bytes());
     expected.extend_from_slice(spk.script());
 
-    let sigscript = compiled
-        .build_sig_script("main", vec![Expr::dynamic_bytes(redeem_script), Expr::dynamic_bytes(expected)])
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Bytes(redeem_script), ArtifactValue::Bytes(expected)])
         .expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "p2sh-from-redeem-script locking bytecode mismatch: {}", result.unwrap_err());
 }
 
@@ -6885,8 +7005,8 @@ fn build_covenant_opcode_tx(sigscript: Vec<u8>, covenant_id_a: Hash, covenant_id
     (tx, entries)
 }
 
-fn dispatch_tag_for(compiled: &CompiledContract<'_>, function_name: &str) -> DispatchTag {
-    compiled.entry_by_name(function_name).expect("entrypoint resolved").dispatch_tag
+fn dispatch_tag_for(compiled: &silverscript_abi::SilAbiArtifact, function_name: &str) -> DispatchTag {
+    entry_by_name(compiled, function_name).expect("entrypoint resolved").dispatch_tag.into_bytes()
 }
 
 fn dispatch_tag_for_preimage(preimage: &str) -> DispatchTag {
@@ -6894,15 +7014,18 @@ fn dispatch_tag_for_preimage(preimage: &str) -> DispatchTag {
     hash.as_bytes()[..4].try_into().expect("a BLAKE3 hash contains a four-byte dispatch tag")
 }
 
-fn wrap_with_single_dispatch(compiled: &CompiledContract<'_>, body: Vec<u8>) -> Vec<u8> {
+fn wrap_with_single_dispatch(compiled: &silverscript_abi::SilAbiArtifact, body: Vec<u8>) -> Vec<u8> {
     wrap_with_single_dispatch_and_state(compiled, &[], &body)
 }
 
-fn wrap_with_single_dispatch_and_state(compiled: &CompiledContract<'_>, state: &[u8], body: &[u8]) -> Vec<u8> {
-    let [entrypoint] = compiled.abi.as_slice() else {
+fn wrap_with_single_dispatch_and_state(compiled: &silverscript_abi::SilAbiArtifact, state: &[u8], body: &[u8]) -> Vec<u8> {
+    let [entrypoint] = single_contract(compiled).entries.as_slice() else {
         panic!("single-dispatch wrapper requires exactly one ABI entrypoint");
     };
-    let dispatch_tag = entrypoint.dispatch_tag;
+    wrap_with_single_dispatch_tag(entrypoint.dispatch_tag.into_bytes(), state, body)
+}
+
+fn wrap_with_single_dispatch_tag(dispatch_tag: DispatchTag, state: &[u8], body: &[u8]) -> Vec<u8> {
     let mut builder = script_builder();
     if !state.is_empty() {
         builder.add_op(OpToAltStack).unwrap();
@@ -6921,7 +7044,7 @@ fn wrap_with_single_dispatch_and_state(compiled: &CompiledContract<'_>, state: &
     builder.drain()
 }
 
-fn stateless_single_dispatch_body_opcodes(compiled: &CompiledContract<'_>, function_name: &str) -> Vec<u8> {
+fn stateless_single_dispatch_body_opcodes(compiled: &silverscript_abi::SilAbiArtifact, function_name: &str) -> Vec<u8> {
     let dispatch_tag = dispatch_tag_for(compiled, function_name);
     let prefix = script_builder()
         .add_op(OpDup)
@@ -6935,7 +7058,8 @@ fn stateless_single_dispatch_body_opcodes(compiled: &CompiledContract<'_>, funct
         .add_op(OpDrop)
         .unwrap()
         .drain();
-    let body = compiled.bytecode.strip_prefix(prefix.as_slice()).expect("single-dispatch prefix should be present");
+    let bytecode = bytecode(compiled);
+    let body = bytecode.strip_prefix(prefix.as_slice()).expect("single-dispatch prefix should be present");
     let body = body.strip_suffix(&[OpElse, OpReturn, OpEndIf]).expect("single-dispatch suffix should be present");
 
     parse_script::<PopulatedTransaction<'static>, SigHashReusedValuesUnsync>(body)
@@ -6953,8 +7077,7 @@ fn compiles_with_kcc1_dispatch_tag_for_single_entrypoint() {
         }
     "#;
 
-    let contract = parse_contract_ast(source).expect("ast parsed");
-    let compiled = compile_contract_ast(&contract, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
     let body = script_builder()
         .add_i64(1)
@@ -6972,13 +7095,14 @@ fn compiles_with_kcc1_dispatch_tag_for_single_entrypoint() {
         .add_op(OpTrue)
         .unwrap()
         .drain();
-    let expected = wrap_with_single_dispatch(&compiled, body);
+    let dispatch_tag = entry_by_name(&compiled, "main").expect("entrypoint resolved").dispatch_tag.into_bytes();
+    let expected = wrap_with_single_dispatch_tag(dispatch_tag, &[], &body);
 
-    assert_eq!(compiled.bytecode, expected);
-    assert_eq!(compiled.state_layout.start, 0);
-    assert_eq!(compiled.state_layout.len, 0);
-    assert!(!compiled.bytecode.contains(&OpToAltStack));
-    assert!(!compiled.bytecode.contains(&OpFromAltStack));
+    assert_eq!(bytecode(&compiled), expected);
+    assert_eq!(state_layout(&compiled).start, 0);
+    assert_eq!(state_layout(&compiled).len, 0);
+    assert!(!bytecode(&compiled).contains(&OpToAltStack));
+    assert!(!bytecode(&compiled).contains(&OpFromAltStack));
 }
 
 #[test]
@@ -6990,10 +7114,9 @@ fn compiles_stateless_multiple_entrypoints_with_kcc1_dispatch_tags() {
         }
     "#;
 
-    let contract = parse_contract_ast(source).expect("ast parsed");
-    let compiled = compile_contract_ast(&contract, &[], CompileOptions::default()).expect("compile succeeds");
-    let dispatch_tag_a = compiled.entry_by_name("a").expect("entrypoint resolved").dispatch_tag;
-    let dispatch_tag_b = compiled.entry_by_name("b").expect("entrypoint resolved").dispatch_tag;
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let dispatch_tag_a = entry_by_name(&compiled, "a").expect("entrypoint resolved").dispatch_tag.into_bytes();
+    let dispatch_tag_b = entry_by_name(&compiled, "b").expect("entrypoint resolved").dispatch_tag.into_bytes();
 
     let body_a = script_builder()
         .add_i64(1)
@@ -7056,16 +7179,16 @@ fn compiles_stateless_multiple_entrypoints_with_kcc1_dispatch_tags() {
         .unwrap()
         .drain();
 
-    assert_eq!(compiled.bytecode, expected_bytecode);
-    assert_eq!(compiled.state_layout.start, 0);
-    assert_eq!(compiled.state_layout.len, 0);
-    assert!(!compiled.bytecode.contains(&OpToAltStack));
-    assert!(!compiled.bytecode.contains(&OpFromAltStack));
+    assert_eq!(bytecode(&compiled), expected_bytecode);
+    assert_eq!(state_layout(&compiled).start, 0);
+    assert_eq!(state_layout(&compiled).len, 0);
+    assert!(!bytecode(&compiled).contains(&OpToAltStack));
+    assert!(!bytecode(&compiled).contains(&OpFromAltStack));
 
-    let sigscript = compiled.build_sig_script("a", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "a", &[]).expect("sigscript builds");
     let expected = script_builder().add_data(&dispatch_tag_a).unwrap().drain();
     assert_eq!(sigscript, expected);
-    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript).is_ok());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled), sigscript).is_ok());
 }
 
 #[test]
@@ -7084,16 +7207,17 @@ fn dispatch_tag_and_argument_encoding_match_kcc1_vector() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let step = compiled.entry_by_name("step").expect("step entrypoint exists");
-    assert_eq!(step.inputs[1].type_name, "byte[4]");
-    assert_eq!(step.dispatch_tag, [0x2c, 0x49, 0xed, 0x65]);
+    let artifact = sil_abi_artifact(source, &[]).expect("compile succeeds");
+    let contract = artifact.contract("Test").expect("contract exists");
+    let step = contract.entry("step").expect("step entrypoint exists");
+    assert_eq!(step.params[1].ty, TypeArtifact::FixedBytes { len: 4 });
+    assert_eq!(step.dispatch_tag.into_bytes(), [0x2c, 0x49, 0xed, 0x65]);
 
-    let sigscript = compiled
-        .build_sig_script("step", vec![Expr::int(17), Expr::bytes(vec![1, 2, 3, 4]), Expr::bool(true), Expr::byte(1)])
+    let sigscript = encode_entry_sig_script(&artifact, "step", &[17.into(), vec![1u8, 2, 3, 4].into(), true.into(), 1u8.into()])
         .expect("KCC-01 vector sigscript builds");
     assert!(sigscript.ends_with(&[0x04, 0x2c, 0x49, 0xed, 0x65]));
-    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript).is_ok());
+    let bytecode = contract.compiled.bytecode.clone();
+    assert!(run_bytecode_with_sigscript(bytecode, sigscript).is_ok());
 }
 
 #[test]
@@ -7114,13 +7238,17 @@ fn record_dispatch_tag_matches_kcc1_structural_type_vector() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let dispense = compiled.entry_by_name("dispense").expect("dispense entrypoint exists");
-    assert_eq!(dispense.inputs[0].type_name, "CoffeeOrder[]");
-    assert_eq!(dispense.dispatch_tag, [0x67, 0x6b, 0x1a, 0x86]);
+    let artifact = sil_abi_artifact(source, &[]).expect("compile succeeds");
+    let dispense =
+        artifact.contract("CoffeeMachine").and_then(|contract| contract.entry("dispense")).expect("dispense entrypoint exists");
+    assert_eq!(
+        dispense.params[0].ty,
+        TypeArtifact::DynamicArray { item: Box::new(TypeArtifact::Struct { name: "CoffeeOrder".to_string() }) }
+    );
+    assert_eq!(dispense.dispatch_tag.into_bytes(), [0x67, 0x6b, 0x1a, 0x86]);
 
     let json = serde_json::to_string(dispense).expect("ABI entry serializes");
-    assert_eq!(serde_json::from_str::<serde_json::Value>(&json).unwrap()["dispatch_tag"], serde_json::json!([103, 107, 26, 134]));
+    assert_eq!(serde_json::from_str::<serde_json::Value>(&json).unwrap()["dispatch_tag"], "676b1a86");
 }
 
 #[test]
@@ -7145,7 +7273,8 @@ fn nested_record_dispatch_tags_hash_structural_type_preimages() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let artifact = sil_abi_artifact(source, &[]).expect("compile succeeds");
+    let contract = artifact.contract("Test").expect("contract exists");
     let vectors = [
         ("scalar", "scalar({{int,byte[3]},bool[2]})"),
         ("dynamic", "dynamic({{int,byte[3]},bool[2]}[])"),
@@ -7153,7 +7282,11 @@ fn nested_record_dispatch_tags_hash_structural_type_preimages() {
     ];
 
     for (entrypoint, preimage) in vectors {
-        assert_eq!(dispatch_tag_for(&compiled, entrypoint), dispatch_tag_for_preimage(preimage), "preimage: {preimage}");
+        assert_eq!(
+            contract.entry(entrypoint).expect("entrypoint exists").dispatch_tag.into_bytes(),
+            dispatch_tag_for_preimage(preimage),
+            "preimage: {preimage}"
+        );
     }
 }
 
@@ -7199,9 +7332,7 @@ fn silverscript_abi_encodes_and_runs_nested_struct_entry_arguments() {
         }
     "#;
 
-    let constructor_args = [Expr::int(7)];
-    let artifact_constructor_args = [ArtifactValue::Int(7)];
-    let compiled = compile_contract(source, &constructor_args, CompileOptions::default()).expect("contract compiles");
+    let artifact_constructor_args = [7.into()];
     let abi = sil_abi_artifact(source, &artifact_constructor_args).expect("source compiles to a complete portable ABI artifact");
     abi.verify().expect("portable ABI matches the compiled contract");
 
@@ -7227,9 +7358,10 @@ fn silverscript_abi_encodes_and_runs_nested_struct_entry_arguments() {
             item(40, 41, 42, [0x41, 0x42, 0x43, 0x44], false),
         ]),
     ];
-    let sigscript = encode_contract_entry_sig_script(&abi, "AbiStructs", "main", &args).expect("ABI encodes sigscript");
+    let sigscript = encode_single_entry_sig_script(&abi, &args).expect("ABI encodes sigscript");
+    let bytecode = abi.contract("AbiStructs").expect("contract exists").compiled.bytecode.clone();
 
-    run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect("ABI-generated sigscript executes");
+    run_bytecode_with_sigscript(bytecode, sigscript).expect("ABI-generated sigscript executes");
 }
 
 #[test]
@@ -7271,7 +7403,7 @@ fn artifact_values_compile_nested_constructor_arguments() {
     let abi = sil_abi_artifact(source, &args).expect("portable ABI constructor values compile");
     abi.verify().expect("portable ABI verifies");
     let contract = abi.contract("ArtifactConstructors").expect("contract exists");
-    let bytecode = decode_hex(&contract.compiled.script_hex).expect("compiled script decodes");
+    let bytecode = contract.compiled.bytecode.clone();
     let dispatch_tag = contract.entry("main").expect("entry exists").dispatch_tag.into_bytes();
     run_bytecode_with_dispatch_tag(bytecode, dispatch_tag).expect("compiled constructor values execute");
 }
@@ -7361,8 +7493,8 @@ fn compiles_basic_arithmetic_and_verifies() {
 
     let expected = wrap_with_single_dispatch(&compiled, body);
 
-    assert_eq!(compiled.bytecode, expected);
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert_eq!(bytecode(&compiled), expected);
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -7395,8 +7527,8 @@ fn compiles_contract_constants_and_verifies() {
 
     let expected = wrap_with_single_dispatch(&compiled, body);
 
-    assert_eq!(compiled.bytecode, expected);
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert_eq!(bytecode(&compiled), expected);
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -7437,7 +7569,7 @@ fn compiles_contract_fields_as_script_prolog() {
         .drain();
     let expected = wrap_with_single_dispatch_and_state(&compiled, &state, &body);
 
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -7456,7 +7588,7 @@ fn runs_contract_with_fields_prolog() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -7478,18 +7610,18 @@ fn runs_dispatch_tag_dispatch_with_contract_fields() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    assert_eq!(compiled.state_layout.start, 1);
-    assert!(compiled.state_layout.len > 0);
-    assert_eq!(compiled.bytecode.first().copied(), Some(OpToAltStack));
-    assert!(compiled.bytecode.contains(&OpFromAltStack));
+    assert_eq!(state_layout(&compiled).start, 1);
+    assert!(state_layout(&compiled).len > 0);
+    assert_eq!(bytecode(&compiled).first().copied(), Some(OpToAltStack));
+    assert!(bytecode(&compiled).contains(&OpFromAltStack));
 
-    let sigscript_a = compiled.build_sig_script("a", vec![]).expect("sigscript a builds");
-    let sigscript_b = compiled.build_sig_script("b", vec![]).expect("sigscript b builds");
+    let sigscript_a = encode_entry_sig_script(&compiled, "a", &[]).expect("sigscript a builds");
+    let sigscript_b = encode_entry_sig_script(&compiled, "b", &[]).expect("sigscript b builds");
 
-    let result_a = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_a);
+    let result_a = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_a);
     assert!(result_a.is_ok(), "entrypoint a runtime failed: {}", result_a.unwrap_err());
 
-    let result_b = run_bytecode_with_sigscript(compiled.bytecode, sigscript_b);
+    let result_b = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_b);
     assert!(result_b.is_ok(), "entrypoint b runtime failed: {}", result_b.unwrap_err());
 }
 
@@ -7569,13 +7701,13 @@ fn compiles_validate_output_state_to_expected_script() {
         .unwrap()
         .add_op(OpTxInputScriptSigLen)
         .unwrap()
-        .add_i64(compiled.bytecode.len() as i64)
+        .add_i64(bytecode(&compiled).len() as i64)
         .unwrap()
         .add_op(OpSub)
         .unwrap()
         .add_op(OpDup)
         .unwrap()
-        .add_i64(compiled.state_layout.start as i64)
+        .add_i64(state_layout(&compiled).start as i64)
         .unwrap()
         .add_op(OpAdd)
         .unwrap()
@@ -7601,7 +7733,7 @@ fn compiles_validate_output_state_to_expected_script() {
         .unwrap()
         // Precompute state_end - bytecode_size, where
         // state_end = dispatch prefix + len(<x><y>) = 13.
-        .add_i64(13 - compiled.bytecode.len() as i64)
+        .add_i64(13 - bytecode(&compiled).len() as i64)
         .unwrap()
         // start offset of REST_OF_SCRIPT inside sigscript
         .add_op(OpAdd)
@@ -7678,11 +7810,11 @@ fn compiles_validate_output_state_to_expected_script() {
         .unwrap()
         .drain();
 
-    let (state, body) = expected.split_at(compiled.state_layout.len);
+    let (state, body) = expected.split_at(state_layout(&compiled).len);
     let expected = wrap_with_single_dispatch_and_state(&compiled, state, body);
 
-    let actual_ops = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
-    assert_eq!(compiled.bytecode, expected, "actual opcodes: {actual_ops}");
+    let actual_ops = script_to_str(&bytecode(&compiled)).expect("compiled bytecode stringifies");
+    assert_eq!(bytecode(&compiled), expected, "actual opcodes: {actual_ops}");
 }
 
 #[test]
@@ -7701,14 +7833,14 @@ fn runs_validate_output_state() {
     let input_compiled =
         compile_contract(source, &[5.into(), vec![1u8, 2u8].into()], CompileOptions::default()).expect("compile succeeds");
 
-    let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&input_compiled, "main", &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
 
     let output_compiled =
         compile_contract(source, &[6.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -7729,7 +7861,8 @@ fn validate_output_state_normalizes_runtime_bool_fields() {
         }
     "#;
 
-    let input_compiled = compile_contract(source, &[Expr::bool(false)], CompileOptions::default()).expect("input contract compiles");
+    let input_compiled =
+        compile_contract(source, &[ArtifactValue::Bool(false)], CompileOptions::default()).expect("input contract compiles");
     let raw_truthy_arg = script_builder()
         .add_data_with_push_opcode(&[2])
         .unwrap()
@@ -7737,13 +7870,14 @@ fn validate_output_state_normalizes_runtime_bool_fields() {
         .unwrap()
         .drain();
     let signature_script =
-        pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), raw_truthy_arg).expect("P2SH signature script builds");
+        pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), raw_truthy_arg).expect("P2SH signature script builds");
     let input = test_input(0, signature_script);
 
-    let output_compiled = compile_contract(source, &[Expr::bool(true)], CompileOptions::default()).expect("output contract compiles");
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let output_compiled =
+        compile_contract(source, &[ArtifactValue::Bool(true)], CompileOptions::default()).expect("output contract compiles");
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
     let output =
-        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&output_compiled.bytecode), covenant: None };
+        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&bytecode(&output_compiled)), covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
 
@@ -7768,14 +7902,14 @@ fn runs_validate_output_state_with_state_variable() {
     let input_compiled =
         compile_contract(source, &[5.into(), vec![1u8, 2u8].into()], CompileOptions::default()).expect("compile succeeds");
 
-    let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&input_compiled, "main", &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
 
     let output_compiled =
         compile_contract(source, &[6.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -7786,31 +7920,31 @@ fn runs_validate_output_state_with_state_variable() {
 
 fn run_read_input_state_with_template_case(
     reader_source: &str,
-    reader_constructor_args: &[Expr<'static>],
-    target_input_compiled: &CompiledContract<'_>,
+    reader_constructor_args: &[ArtifactValue],
+    target_input_compiled: &silverscript_abi::SilAbiArtifact,
 ) -> Result<(), kaspa_txscript_errors::TxScriptError> {
     run_read_input_state_with_template_case_with_input_spk(
         reader_source,
         reader_constructor_args,
         target_input_compiled,
-        pay_to_script_hash_script(&target_input_compiled.bytecode),
+        pay_to_script_hash_script(&bytecode(target_input_compiled)),
     )
 }
 
 fn run_read_input_state_with_template_case_with_input_spk(
     reader_source: &str,
-    reader_constructor_args: &[Expr<'static>],
-    target_input_compiled: &CompiledContract<'_>,
+    reader_constructor_args: &[ArtifactValue],
+    target_input_compiled: &silverscript_abi::SilAbiArtifact,
     input1_spk: ScriptPublicKey,
 ) -> Result<(), kaspa_txscript_errors::TxScriptError> {
     let reader_compiled =
         compile_contract(reader_source, reader_constructor_args, CompileOptions::default()).expect("compile reader succeeds");
 
     let input0 = test_input(0, dispatch_tag_sigscript(dispatch_tag_for(&reader_compiled, "main")));
-    let input1 = test_input(1, sigscript_push_bytecode(&target_input_compiled.bytecode));
+    let input1 = test_input(1, sigscript_push_bytecode(&bytecode(target_input_compiled)));
     let output = TransactionOutput {
         value: 1000,
-        script_public_key: ScriptPublicKey::new(0, reader_compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&reader_compiled).clone().into()),
         covenant: None,
     };
     let tx = Transaction::new(1, vec![input0.clone(), input1], vec![output.clone()], 0, Default::default(), 0, vec![]);
@@ -7824,7 +7958,7 @@ fn run_validate_output_state_with_template_case(
     template_prefix: Vec<u8>,
     template_suffix: Vec<u8>,
     expected_template_hash: Vec<u8>,
-    output_compiled: &CompiledContract,
+    output_compiled: &silverscript_abi::SilAbiArtifact,
 ) -> Result<(), kaspa_txscript_errors::TxScriptError> {
     let mux_source = format!(
         r#"
@@ -7858,12 +7992,12 @@ fn run_validate_output_state_with_template_case(
     )
     .expect("compile mux succeeds");
 
-    let sigscript = mux_input_compiled.build_sig_script("routeToA", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(mux_input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&mux_input_compiled, "routeToA", &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&mux_input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
 
-    let input_spk = pay_to_script_hash_script(&mux_input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&mux_input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -7890,7 +8024,7 @@ fn runs_validate_output_state_with_template() {
 
     let target_a0 = compile_contract(
         target_source,
-        &[vec![0x11u8; 32].into(), vec![0x33u8; 32].into(), Expr::int(0x1111_1111_1111_1111), vec![0x55u8, 0x66u8].into()],
+        &[vec![0x11u8; 32].into(), vec![0x33u8; 32].into(), ArtifactValue::Int(0x1111_1111_1111_1111), vec![0x55u8, 0x66u8].into()],
         CompileOptions::default(),
     )
     .expect("compile target succeeds");
@@ -7935,12 +8069,12 @@ fn runs_validate_output_state_with_template() {
     )
     .expect("compile mux succeeds");
 
-    let sigscript = mux_input_compiled.build_sig_script("routeToA", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(mux_input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&mux_input_compiled, "routeToA", &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&mux_input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
 
-    let input_spk = pay_to_script_hash_script(&mux_input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&target_output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&mux_input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&target_output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -7963,9 +8097,9 @@ fn template_hash_matches_all_template_builtins() {
     let target_input = compile_contract(target_source, &[7.into()], CompileOptions::default()).expect("compile target input succeeds");
     let target_output =
         compile_contract(target_source, &[8.into()], CompileOptions::default()).expect("compile target output succeeds");
-    let layout = target_input.state_layout;
-    let prefix = &target_input.bytecode[..layout.start];
-    let suffix = &target_input.bytecode[layout.start + layout.len..];
+    let layout = state_layout(&target_input);
+    let prefix = &bytecode(&target_input)[..layout.start];
+    let suffix = &bytecode(&target_input)[layout.start + layout.len..];
     let prefix_hex = prefix.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
     let suffix_hex = suffix.iter().map(|byte| format!("{byte:02x}")).collect::<String>();
 
@@ -8013,16 +8147,16 @@ fn template_hash_matches_all_template_builtins() {
         suffix.len(),
     );
     let verifier = compile_contract(&verifier_source, &[], CompileOptions::default()).expect("compile verifier succeeds");
-    let verifier_sigscript = verifier.build_sig_script("main", vec![]).expect("verifier sigscript builds");
-    let verifier_sigscript = pay_to_script_hash_signature_script(verifier.bytecode.clone(), verifier_sigscript).unwrap();
+    let verifier_sigscript = encode_single_entry_sig_script(&verifier, &[]).expect("verifier sigscript builds");
+    let verifier_sigscript = pay_to_script_hash_signature_script(bytecode(&verifier).clone(), verifier_sigscript).unwrap();
 
     let verifier_input = test_input(0, verifier_sigscript);
-    let target_input_tx = test_input(1, sigscript_push_bytecode(&target_input.bytecode));
+    let target_input_tx = test_input(1, sigscript_push_bytecode(&bytecode(&target_input)));
     let output =
-        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&target_output.bytecode), covenant: None };
+        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&bytecode(&target_output)), covenant: None };
     let tx = Transaction::new(1, vec![verifier_input, target_input_tx], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let verifier_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&verifier.bytecode), 0, tx.is_coinbase(), None);
-    let target_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&target_input.bytecode), 0, tx.is_coinbase(), None);
+    let verifier_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&bytecode(&verifier)), 0, tx.is_coinbase(), None);
+    let target_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&bytecode(&target_input)), 0, tx.is_coinbase(), None);
 
     let result = execute_input(tx, vec![verifier_utxo, target_utxo], 0);
     assert!(result.is_ok(), "templateHash should match all state template builtins: {}", result.unwrap_err());
@@ -8052,15 +8186,16 @@ fn template_hash_matches_all_template_builtins() {
     );
     let invalid_verifier =
         compile_contract(&invalid_verifier_source, &[], CompileOptions::default()).expect("compile invalid verifier succeeds");
-    let invalid_sigscript = invalid_verifier.build_sig_script("main", vec![]).expect("invalid verifier sigscript builds");
-    let invalid_sigscript = pay_to_script_hash_signature_script(invalid_verifier.bytecode.clone(), invalid_sigscript).unwrap();
+    let invalid_sigscript = encode_single_entry_sig_script(&invalid_verifier, &[]).expect("invalid verifier sigscript builds");
+    let invalid_sigscript = pay_to_script_hash_signature_script(bytecode(&invalid_verifier).clone(), invalid_sigscript).unwrap();
     let invalid_input = test_input(0, invalid_sigscript);
-    let target_input_tx = test_input(1, sigscript_push_bytecode(&target_input.bytecode));
+    let target_input_tx = test_input(1, sigscript_push_bytecode(&bytecode(&target_input)));
     let output =
-        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&target_output.bytecode), covenant: None };
+        TransactionOutput { value: 1000, script_public_key: pay_to_script_hash_script(&bytecode(&target_output)), covenant: None };
     let tx = Transaction::new(1, vec![invalid_input, target_input_tx], vec![output.clone()], 0, Default::default(), 0, vec![]);
-    let invalid_verifier_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&invalid_verifier.bytecode), 0, tx.is_coinbase(), None);
-    let target_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&target_input.bytecode), 0, tx.is_coinbase(), None);
+    let invalid_verifier_utxo =
+        UtxoEntry::new(1000, pay_to_script_hash_script(&bytecode(&invalid_verifier)), 0, tx.is_coinbase(), None);
+    let target_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&bytecode(&target_input)), 0, tx.is_coinbase(), None);
 
     assert!(execute_input(tx, vec![invalid_verifier_utxo, target_utxo], 0).is_err(), "incorrect template lengths must fail");
 }
@@ -8107,7 +8242,7 @@ fn runs_validate_output_state_with_template_using_passed_struct_layout() {
 
     let target_a0 = compile_contract(
         &target_source,
-        &[vec![0x55u8, 0x66u8].into(), Expr::int(0x1111_1111_1111_1111), vec![0x33u8; 32].into()],
+        &[vec![0x55u8, 0x66u8].into(), ArtifactValue::Int(0x1111_1111_1111_1111), vec![0x33u8; 32].into()],
         CompileOptions::default(),
     )
     .expect("compile target succeeds");
@@ -8156,12 +8291,13 @@ fn runs_validate_output_state_with_template_using_passed_struct_layout() {
     let mux_input_compiled = compile_contract(&mux_source, &[5.into(), vec![0x10u8, 0x20u8].into()], CompileOptions::default())
         .expect("compile mux succeeds");
 
-    let sigscript = mux_input_compiled.build_sig_script("routeToA", vec![target_hash_value.clone().into()]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(mux_input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript =
+        encode_entry_sig_script(&mux_input_compiled, "routeToA", &[target_hash_value.clone().into()]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&mux_input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
 
-    let input_spk = pay_to_script_hash_script(&mux_input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&target_output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&mux_input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&target_output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8173,12 +8309,12 @@ fn runs_validate_output_state_with_template_using_passed_struct_layout() {
         result.unwrap_err()
     );
 
-    let a_sigscript = target_output_compiled.build_sig_script("noop", vec![]).expect("A sigscript builds");
-    let a_sigscript = pay_to_script_hash_signature_script(target_output_compiled.bytecode.clone(), a_sigscript).unwrap();
+    let a_sigscript = encode_entry_sig_script(&target_output_compiled, "noop", &[]).expect("A sigscript builds");
+    let a_sigscript = pay_to_script_hash_signature_script(bytecode(&target_output_compiled).clone(), a_sigscript).unwrap();
     let a_input = test_input(0, a_sigscript);
     let a_output = TransactionOutput { value: 1000, script_public_key: ScriptPublicKey::new(0, vec![OpTrue].into()), covenant: None };
     let a_tx = Transaction::new(1, vec![a_input], vec![a_output], 0, Default::default(), 0, vec![]);
-    let a_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&target_output_compiled.bytecode), 0, a_tx.is_coinbase(), None);
+    let a_utxo = UtxoEntry::new(1000, pay_to_script_hash_script(&bytecode(&target_output_compiled)), 0, a_tx.is_coinbase(), None);
     let a_result = execute_input(a_tx, vec![a_utxo], 0);
     assert!(
         a_result.is_ok(),
@@ -8204,7 +8340,7 @@ fn validate_output_state_with_template_rejects_wrong_template_hash() {
 
     let target = compile_contract(
         target_source,
-        &[vec![0x11u8; 32].into(), vec![0x33u8; 32].into(), Expr::int(0x1111_1111_1111_1111), vec![0x55u8, 0x66u8].into()],
+        &[vec![0x11u8; 32].into(), vec![0x33u8; 32].into(), ArtifactValue::Int(0x1111_1111_1111_1111), vec![0x55u8, 0x66u8].into()],
         CompileOptions::default(),
     )
     .expect("compile target succeeds");
@@ -8240,7 +8376,7 @@ fn validate_output_state_with_template_rejects_wrong_template_parts() {
 
     let target = compile_contract(
         target_source,
-        &[vec![0x11u8; 32].into(), vec![0x33u8; 32].into(), Expr::int(0x1111_1111_1111_1111), vec![0x55u8, 0x66u8].into()],
+        &[vec![0x11u8; 32].into(), vec![0x33u8; 32].into(), ArtifactValue::Int(0x1111_1111_1111_1111), vec![0x55u8, 0x66u8].into()],
         CompileOptions::default(),
     )
     .expect("compile target succeeds");
@@ -8275,7 +8411,7 @@ fn validate_output_state_with_template_rejects_wrong_output_script() {
 
     let target = compile_contract(
         target_source,
-        &[vec![0x11u8; 32].into(), vec![0x33u8; 32].into(), Expr::int(0x1111_1111_1111_1111), vec![0x55u8, 0x66u8].into()],
+        &[vec![0x11u8; 32].into(), vec![0x33u8; 32].into(), ArtifactValue::Int(0x1111_1111_1111_1111), vec![0x55u8, 0x66u8].into()],
         CompileOptions::default(),
     )
     .expect("compile target succeeds");
@@ -8308,7 +8444,7 @@ fn validate_output_state_with_template_rejects_different_target_state_layout() {
 
     let target = compile_contract(
         target_source,
-        &[vec![0x11u8; 32].into(), vec![0x33u8; 32].into(), Expr::int(0x1111_1111_1111_1111)],
+        &[vec![0x11u8; 32].into(), vec![0x33u8; 32].into(), ArtifactValue::Int(0x1111_1111_1111_1111)],
         CompileOptions::default(),
     )
     .expect("compile different-layout target succeeds");
@@ -8347,9 +8483,9 @@ contract Sweep(int BOUND, byte[64] init_board) {
     let bounds = [4i64, 8i64, 12i64];
     let mut lens = Vec::new();
     for b in bounds {
-        let args = [Expr::int(b), Expr::bytes(vec![0u8; 64])];
+        let args = [b.into(), vec![0u8; 64].into()];
         let compiled = compile_contract(SOURCE, &args, CompileOptions::default()).expect("compile succeeds");
-        lens.push(compiled.bytecode.len());
+        lens.push(bytecode(&compiled).len());
     }
 
     // Monotonic growth, and no doubling behavior in this range.
@@ -8376,12 +8512,12 @@ fn validate_output_state_accepts_state_value_from_array_index() {
     "#;
 
     let input_compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = input_compiled.build_sig_script("main", vec![state_array_arg_x(vec![6])]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&input_compiled, "main", &[state_array_arg_x(vec![6])]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let output_compiled = compile_contract(source, &[6.into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8409,12 +8545,12 @@ fn validate_output_state_accepts_state_value_from_inline_returned_array() {
     "#;
 
     let input_compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = input_compiled.build_sig_script("main", vec![state_array_arg_x(vec![6])]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&input_compiled, "main", &[state_array_arg_x(vec![6])]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let output_compiled = compile_contract(source, &[6.into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8441,12 +8577,12 @@ fn read_input_state_accepts_self_state_under_dispatch_tag_dispatch() {
     "#;
 
     let input_compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&input_compiled, "main", &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let output_compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8470,10 +8606,10 @@ fn read_input_state_int_addition_uses_numeric_semantics() {
     "#;
 
     let compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(compiled.bytecode.clone(), sigscript).expect("p2sh sigscript wraps");
+    let sigscript = encode_single_entry_sig_script(&compiled, &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&compiled).clone(), sigscript).expect("p2sh sigscript wraps");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&compiled));
     let output = TransactionOutput { value: 1000, script_public_key: input_spk.clone(), covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8506,14 +8642,14 @@ fn read_input_state_accepts_three_field_state_under_dispatch_tag_dispatch() {
     let input_compiled =
         compile_contract(source, &[5.into(), vec![0x34u8, 0x12u8].into(), vec![1u8; 32].into()], CompileOptions::default())
             .expect("compile succeeds");
-    let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&input_compiled, "main", &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let output_compiled =
         compile_contract(source, &[5.into(), vec![0x34u8, 0x12u8].into(), vec![1u8; 32].into()], CompileOptions::default())
             .expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8543,13 +8679,13 @@ fn read_input_state_accepts_pubkey_and_bool_fields_under_dispatch_tag_dispatch()
 
     let input_compiled =
         compile_contract(source, &[true.into(), vec![2u8; 32].into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&input_compiled, "main", &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let output_compiled =
         compile_contract(source, &[true.into(), vec![2u8; 32].into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8560,12 +8696,12 @@ fn read_input_state_accepts_pubkey_and_bool_fields_under_dispatch_tag_dispatch()
 
 #[test]
 fn read_input_state_runtime_preserves_supported_field_types_across_contract_shapes() {
-    let run_case = |source: &str, args: Vec<Expr<'_>>, label: &str| {
+    let run_case = |source: &str, args: Vec<ArtifactValue>, label: &str| {
         let compiled = compile_contract(source, &args, CompileOptions::default()).unwrap_or_else(|err| panic!("{label}: {err:?}"));
-        let sigscript = compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-        let sigscript = pay_to_script_hash_signature_script(compiled.bytecode.clone(), sigscript).expect("p2sh sigscript wraps");
+        let sigscript = encode_entry_sig_script(&compiled, "main", &[]).expect("sigscript builds");
+        let sigscript = pay_to_script_hash_signature_script(bytecode(&compiled).clone(), sigscript).expect("p2sh sigscript wraps");
         let input = test_input(0, sigscript);
-        let input_spk = pay_to_script_hash_script(&compiled.bytecode);
+        let input_spk = pay_to_script_hash_script(&bytecode(&compiled));
         let output = TransactionOutput { value: 1000, script_public_key: input_spk.clone(), covenant: None };
         let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
         let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8610,7 +8746,7 @@ fn read_input_state_runtime_preserves_supported_field_types_across_contract_shap
                 }
             }
         "#,
-        vec![Expr::try_from(vec![Expr::int(1), Expr::int(2)]).unwrap()],
+        vec![ArtifactValue::Array(vec![1.into(), 2.into()])],
         "int[2] fields should preserve array indexing semantics",
     );
 
@@ -8650,7 +8786,7 @@ fn read_input_state_runtime_preserves_supported_field_types_across_contract_shap
                 }
             }
         "#,
-        vec![Expr::try_from(vec![Expr::bool(true), Expr::bool(false)]).unwrap()],
+        vec![ArtifactValue::Array(vec![true.into(), false.into()])],
         "bool[2] fields should preserve array indexing semantics",
     );
 
@@ -8746,12 +8882,12 @@ fn read_input_state_runtime_preserves_supported_field_types_across_contract_shap
 
 #[test]
 fn read_input_state_runtime_preserves_supported_field_types_with_single_entrypoint_dispatch() {
-    let run_case = |source: &str, args: Vec<Expr<'_>>, label: &str| {
+    let run_case = |source: &str, args: Vec<ArtifactValue>, label: &str| {
         let compiled = compile_contract(source, &args, CompileOptions::default()).unwrap_or_else(|err| panic!("{label}: {err:?}"));
-        let sigscript = compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-        let sigscript = pay_to_script_hash_signature_script(compiled.bytecode.clone(), sigscript).expect("p2sh sigscript wraps");
+        let sigscript = encode_single_entry_sig_script(&compiled, &[]).expect("sigscript builds");
+        let sigscript = pay_to_script_hash_signature_script(bytecode(&compiled).clone(), sigscript).expect("p2sh sigscript wraps");
         let input = test_input(0, sigscript);
-        let input_spk = pay_to_script_hash_script(&compiled.bytecode);
+        let input_spk = pay_to_script_hash_script(&bytecode(&compiled));
         let output = TransactionOutput { value: 1000, script_public_key: input_spk.clone(), covenant: None };
         let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
         let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8835,12 +8971,12 @@ fn read_input_state_scalar_byte_round_trips_at_runtime() {
         }
     "#;
 
-    let compiled =
-        compile_contract(source, &[Expr::byte(7), vec![2u8; 32].into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(compiled.bytecode.clone(), sigscript).expect("p2sh sigscript wraps");
+    let compiled = compile_contract(source, &[ArtifactValue::Byte(7), vec![2u8; 32].into()], CompileOptions::default())
+        .expect("compile succeeds");
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&compiled).clone(), sigscript).expect("p2sh sigscript wraps");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&compiled));
     let output = TransactionOutput { value: 1000, script_public_key: input_spk.clone(), covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8866,13 +9002,12 @@ fn validate_output_state_accepts_state_under_dispatch_tag_dispatch() {
     "#;
 
     let input_compiled = compile_contract(source, &[5.into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript =
-        input_compiled.build_sig_script("main", vec![struct_object("State", vec![("x", Expr::int(6))])]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&input_compiled, "main", &[artifact_object([("x", 6.into())])]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let output_compiled = compile_contract(source, &[6.into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8902,22 +9037,19 @@ fn validate_output_state_accepts_three_field_state_under_dispatch_tag_dispatch()
     let input_compiled =
         compile_contract(source, &[5.into(), vec![0x34u8, 0x12u8].into(), vec![1u8; 32].into()], CompileOptions::default())
             .expect("compile succeeds");
-    let sigscript = input_compiled
-        .build_sig_script(
-            "main",
-            vec![struct_object(
-                "State",
-                vec![("amount", Expr::int(6)), ("code", Expr::bytes(vec![0xabu8, 0xcdu8])), ("owner", Expr::bytes(vec![2u8; 32]))],
-            )],
-        )
-        .expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(
+        &input_compiled,
+        "main",
+        &[artifact_object([("amount", 6.into()), ("code", vec![0xabu8, 0xcdu8].into()), ("owner", vec![2u8; 32].into())])],
+    )
+    .expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let output_compiled =
         compile_contract(source, &[6.into(), vec![0xabu8, 0xcdu8].into(), vec![2u8; 32].into()], CompileOptions::default())
             .expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8955,11 +9087,11 @@ fn debug_validate_output_state_accepts_current_byte32_fields() {
     )
     .expect("compile succeeds");
 
-    let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_single_entry_sig_script(&input_compiled, &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -8985,14 +9117,13 @@ fn validate_output_state_accepts_pubkey_field_under_dispatch_tag_dispatch() {
     "#;
 
     let input_compiled = compile_contract(source, &[vec![1u8; 32].into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = input_compiled
-        .build_sig_script("main", vec![struct_object("State", vec![("owner", Expr::bytes(vec![2u8; 32]))])])
+    let sigscript = encode_entry_sig_script(&input_compiled, "main", &[artifact_object([("owner", vec![2u8; 32].into())])])
         .expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let output_compiled = compile_contract(source, &[vec![2u8; 32].into()], CompileOptions::default()).expect("compile succeeds");
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -9044,7 +9175,7 @@ fn runs_state_variable_and_internal_function_argument() {
 
     let compiled = compile_contract(source, &[5.into(), vec![1u8, 2u8].into()], CompileOptions::default()).expect("compile succeeds");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "script should execute successfully: {result:?}");
 }
 
@@ -9086,7 +9217,7 @@ fn byte_hex_literal_is_a_scalar_numeral() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("scalar byte hex literal should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -9106,7 +9237,7 @@ fn hex_literals_are_numerals_for_int_and_byte() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("hex numerals should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -9136,7 +9267,7 @@ fn hex_literal_over_eight_bytes_requires_an_immediate_byte_array_cast() {
     let compiled =
         compile_contract(&source, &[], CompileOptions::default()).expect("immediately cast nine-byte literal should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -9161,7 +9292,7 @@ fn fixed_byte_sequence_types_accept_immediate_hex_literals() {
 
     let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("direct fixed byte-sequence casts should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -9236,7 +9367,7 @@ fn compiles_read_input_state_to_expected_script() {
         .add_op(OpTxInputScriptSigLen)
         .unwrap()
         // this.bytecodeSize
-        .add_i64(compiled.bytecode.len() as i64)
+        .add_i64(bytecode(&compiled).len() as i64)
         .unwrap()
         // base = sig_len - bytecode_size
         .add_op(OpSub)
@@ -9255,7 +9386,7 @@ fn compiles_read_input_state_to_expected_script() {
         .add_op(OpTxInputScriptSigLen)
         .unwrap()
         // this.bytecodeSize
-        .add_i64(compiled.bytecode.len() as i64)
+        .add_i64(bytecode(&compiled).len() as i64)
         .unwrap()
         // base = sig_len - bytecode_size
         .add_op(OpSub)
@@ -9296,7 +9427,7 @@ fn compiles_read_input_state_to_expected_script() {
         .add_op(OpTxInputScriptSigLen)
         .unwrap()
         // this.bytecodeSize
-        .add_i64(compiled.bytecode.len() as i64)
+        .add_i64(bytecode(&compiled).len() as i64)
         .unwrap()
         // base = sig_len - bytecode_size
         .add_op(OpSub)
@@ -9315,7 +9446,7 @@ fn compiles_read_input_state_to_expected_script() {
         .add_op(OpTxInputScriptSigLen)
         .unwrap()
         // this.bytecodeSize
-        .add_i64(compiled.bytecode.len() as i64)
+        .add_i64(bytecode(&compiled).len() as i64)
         .unwrap()
         // base = sig_len - bytecode_size
         .add_op(OpSub)
@@ -9356,12 +9487,12 @@ fn compiles_read_input_state_to_expected_script() {
         .unwrap()
         .drain();
 
-    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
+    let asm = script_to_str(&bytecode(&compiled)).expect("stringifies");
     assert_eq!(asm.matches("OpTxInputScriptSigSubstr").count(), 2, "should read two state fields");
     assert_eq!(asm.matches("OpGreaterThan").count(), 1, "should compare x numerically");
     assert_eq!(asm.matches("OpEqual").count(), 2, "should compare y bytewise in addition to dispatch");
     assert!(
-        compiled.bytecode.ends_with(&[OpDrop, OpDrop, OpTrue, OpElse, OpReturn, OpEndIf]),
+        bytecode(&compiled).ends_with(&[OpDrop, OpDrop, OpTrue, OpElse, OpReturn, OpEndIf]),
         "expected stack cleanup for active state before the dispatch epilogue"
     );
 }
@@ -9387,11 +9518,11 @@ fn runs_read_input_state() {
         compile_contract(source, &[8.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
 
     let input0 = test_input(0, dispatch_tag_sigscript(dispatch_tag_for(&active_compiled, "main")));
-    let input1 = test_input(1, sigscript_push_bytecode(&input1_compiled.bytecode));
+    let input1 = test_input(1, sigscript_push_bytecode(&bytecode(&input1_compiled)));
 
     let output = TransactionOutput {
         value: 1000,
-        script_public_key: ScriptPublicKey::new(0, active_compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&active_compiled).clone().into()),
         covenant: None,
     };
     let tx = Transaction::new(1, vec![input0.clone(), input1], vec![output.clone()], 0, Default::default(), 0, vec![]);
@@ -9422,11 +9553,11 @@ fn runs_read_input_state_into_state_variable() {
         compile_contract(source, &[8.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
 
     let input0 = test_input(0, dispatch_tag_sigscript(dispatch_tag_for(&active_compiled, "main")));
-    let input1 = test_input(1, sigscript_push_bytecode(&input1_compiled.bytecode));
+    let input1 = test_input(1, sigscript_push_bytecode(&bytecode(&input1_compiled)));
 
     let output = TransactionOutput {
         value: 1000,
-        script_public_key: ScriptPublicKey::new(0, active_compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&active_compiled).clone().into()),
         covenant: None,
     };
     let tx = Transaction::new(1, vec![input0.clone(), input1], vec![output.clone()], 0, Default::default(), 0, vec![]);
@@ -9460,10 +9591,10 @@ fn runs_read_input_state_as_internal_function_argument() {
         compile_contract(source, &[8.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
 
     let input0 = test_input(0, dispatch_tag_sigscript(dispatch_tag_for(&active_compiled, "main")));
-    let input1 = test_input(1, sigscript_push_bytecode(&input1_compiled.bytecode));
+    let input1 = test_input(1, sigscript_push_bytecode(&bytecode(&input1_compiled)));
     let output = TransactionOutput {
         value: 1000,
-        script_public_key: ScriptPublicKey::new(0, active_compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&active_compiled).clone().into()),
         covenant: None,
     };
     let tx = Transaction::new(1, vec![input0, input1], vec![output.clone()], 0, Default::default(), 0, vec![]);
@@ -9939,11 +10070,11 @@ fn validate_output_state_lowers_nested_state_literal_in_state_field_order() {
         compile_contract(source, &[5.into(), 3.into(), 4.into()], CompileOptions::default()).expect("compile succeeds");
     let output_compiled =
         compile_contract(source, &[6.into(), 7.into(), 8.into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_single_entry_sig_script(&input_compiled, &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -9975,11 +10106,11 @@ fn validate_output_state_with_state_identifier() {
         compile_contract(source, &[5.into(), 3.into(), 4.into()], CompileOptions::default()).expect("compile succeeds");
     let output_compiled =
         compile_contract(source, &[6.into(), 7.into(), 8.into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_single_entry_sig_script(&input_compiled, &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -10088,13 +10219,13 @@ fn fails_validate_output_state_with_wrong_output_index() {
     let expected_output_state =
         compile_contract(source, &[6.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
 
-    let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_single_entry_sig_script(&input_compiled, &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
 
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let matching_spk = pay_to_script_hash_script(&expected_output_state.bytecode);
-    let wrong_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let matching_spk = pay_to_script_hash_script(&bytecode(&expected_output_state));
+    let wrong_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
 
     let output0 = TransactionOutput { value: 1000, script_public_key: wrong_spk, covenant: None };
     let output1 = TransactionOutput { value: 1000, script_public_key: matching_spk, covenant: None };
@@ -10123,12 +10254,12 @@ fn fails_validate_output_state_with_mismatched_next_state_fields() {
     let wrong_output_state =
         compile_contract(source, &[7.into(), vec![0x34u8, 0x12u8].into()], CompileOptions::default()).expect("compile succeeds");
 
-    let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_single_entry_sig_script(&input_compiled, &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
 
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let wrong_output_spk = pay_to_script_hash_script(&wrong_output_state.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let wrong_output_spk = pay_to_script_hash_script(&bytecode(&wrong_output_state));
     let output = TransactionOutput { value: 1000, script_public_key: wrong_output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(1000, input_spk, 0, tx.is_coinbase(), None);
@@ -10194,7 +10325,7 @@ fn rejects_validate_output_state_with_unknown_state_field() {
 fn assert_compiled_body(source: &str, body: Vec<u8>) {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
     let expected = wrap_with_single_dispatch(&compiled, body);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -10237,7 +10368,7 @@ fn check_sig_ecdsa_lowers_to_matching_opcode() {
         .unwrap()
         .drain();
     let expected = wrap_with_single_dispatch(&compiled, expected);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -10274,7 +10405,7 @@ fn checksigfromstack_lowers_to_matching_opcode() {
         .unwrap()
         .drain();
     let expected = wrap_with_single_dispatch(&compiled, expected);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -10311,7 +10442,7 @@ fn check_msg_sig_ecdsa_lowers_to_matching_opcode() {
         .unwrap()
         .drain();
     let expected = wrap_with_single_dispatch(&compiled, expected);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -10440,8 +10571,8 @@ fn g16_verify_lowers_to_groth16_precompile() {
     let compiled = compile_contract(
         source,
         &[
-            Expr::dynamic_bytes(verifying_key.clone()),
-            Expr::dynamic_bytes(proof.clone()),
+            ArtifactValue::Bytes(verifying_key.clone()),
+            ArtifactValue::Bytes(proof.clone()),
             public_inputs[0].clone().into(),
             public_inputs[1].clone().into(),
         ],
@@ -10469,7 +10600,7 @@ fn g16_verify_lowers_to_groth16_precompile() {
         .add_op(OpTrue)
         .unwrap()
         .drain();
-    assert_eq!(compiled.bytecode, wrap_with_single_dispatch(&compiled, body));
+    assert_eq!(bytecode(&compiled), wrap_with_single_dispatch(&compiled, body));
 }
 
 #[test]
@@ -10564,19 +10695,19 @@ fn g16_verify_executes_with_fixture_and_rejects_tampered_input() {
     "#;
     let (verifying_key, proof, public_inputs) = kaspa_txscript::zk_precompiles::tests::helpers::load_groth_fields();
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let build_args = |inputs: &[Vec<u8>]| -> Vec<Expr<'static>> {
-        let mut args = vec![Expr::dynamic_bytes(verifying_key.clone()), Expr::dynamic_bytes(proof.clone())];
+    let build_args = |inputs: &[Vec<u8>]| -> Vec<ArtifactValue> {
+        let mut args = vec![verifying_key.clone().into(), proof.clone().into()];
         args.extend(inputs.iter().cloned().map(Into::into));
         args
     };
 
-    let sigscript = compiled.build_sig_script("verify", build_args(&public_inputs)).expect("sigscript builds");
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript).is_ok(), "valid Groth16 proof should pass");
+    let sigscript = encode_entry_sig_script(&compiled, "verify", &build_args(&public_inputs)).expect("sigscript builds");
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript).is_ok(), "valid Groth16 proof should pass");
 
     let mut tampered_inputs = public_inputs;
     tampered_inputs[0][0] ^= 0x01;
-    let sigscript = compiled.build_sig_script("verify", build_args(&tampered_inputs)).expect("sigscript builds");
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript).is_err(), "tampered public input should fail");
+    let sigscript = encode_entry_sig_script(&compiled, "verify", &build_args(&tampered_inputs)).expect("sigscript builds");
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript).is_err(), "tampered public input should fail");
 }
 
 #[test]
@@ -10615,8 +10746,8 @@ fn r0_succinct_verify_lowers_hash_aliases_to_zk_precompile() {
                 control_id.clone().into(),
                 claim.clone().into(),
                 control_index.clone().into(),
-                Expr::dynamic_bytes(control_digests.clone()),
-                Expr::dynamic_bytes(seal.clone()),
+                ArtifactValue::Bytes(control_digests.clone()),
+                ArtifactValue::Bytes(seal.clone()),
                 journal.clone().into(),
             ],
             CompileOptions::default(),
@@ -10650,9 +10781,9 @@ fn r0_succinct_verify_lowers_hash_aliases_to_zk_precompile() {
             .unwrap()
             .drain();
         let expected = wrap_with_single_dispatch(&compiled, expected);
-        let asm = script_to_str(&compiled.bytecode).expect("R0 succinct script should stringify");
+        let asm = script_to_str(&bytecode(&compiled)).expect("R0 succinct script should stringify");
         assert!(asm.contains("OpZkPrecompile OpDrop"), "void verifier result should be dropped: {asm}");
-        assert_eq!(compiled.bytecode, expected, "{call_name} lowered unexpectedly");
+        assert_eq!(bytecode(&compiled), expected, "{call_name} lowered unexpectedly");
     }
 }
 
@@ -10693,7 +10824,7 @@ fn r0_g16_verify_lowers_with_sdk_verifier_fragment() {
     let image_id = [0x33u8; 32];
     let compiled = compile_contract(
         source,
-        &[journal_hash.clone().into(), Expr::dynamic_bytes(proof.clone()), image_id.to_vec().into()],
+        &[journal_hash.clone().into(), ArtifactValue::Bytes(proof.clone()), image_id.to_vec().into()],
         CompileOptions::default(),
     )
     .expect("compile succeeds");
@@ -10707,9 +10838,9 @@ fn r0_g16_verify_lowers_with_sdk_verifier_fragment() {
     expected_builder.add_op(OpTrue).unwrap();
     let expected = wrap_with_single_dispatch(&compiled, expected_builder.drain());
 
-    let asm = script_to_str(&compiled.bytecode).expect("R0 Groth16 script should stringify");
+    let asm = script_to_str(&bytecode(&compiled)).expect("R0 Groth16 script should stringify");
     assert!(asm.contains("OpZkPrecompile OpDrop"), "void verifier result should be dropped: {asm}");
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -10754,7 +10885,7 @@ fn value_returning_builtin_statement_discards_result() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("value-returning builtin statement should compile");
-    let asm = script_to_str(&compiled.bytecode).expect("builtin statement script should stringify");
+    let asm = script_to_str(&bytecode(&compiled)).expect("builtin statement script should stringify");
     assert!(
         asm.ends_with("OpSHA256 OpDrop OpTrue OpElse OpReturn OpEndIf"),
         "builtin statement result should be discarded before the dispatch epilogue: {asm}"
@@ -10777,7 +10908,7 @@ fn discarded_helper_return_expressions_are_evaluated_and_dropped() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("discarded helper returns should compile");
-    let asm = script_to_str(&compiled.bytecode).expect("script should stringify");
+    let asm = script_to_str(&bytecode(&compiled)).expect("script should stringify");
     assert_eq!(asm.matches("OpSHA256").count(), 2, "both return expressions must be evaluated: {asm}");
     assert_eq!(asm.matches("OpDrop").count(), 3, "both discarded return values plus the dispatch tag must be dropped: {asm}");
 }
@@ -10803,7 +10934,7 @@ fn discarded_nested_helper_return_expression_is_evaluated() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("nested discarded return should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_err(), "the nested discarded division by zero must execute");
 }
 
@@ -10973,19 +11104,19 @@ fn r0_succinct_verify_runtime_checks_each_hash_with_fixture() {
         let compiled = compile_contract(&source, &[image_id.clone().into(), control_id.clone().into()], CompileOptions::default())
             .expect("compile succeeds");
 
-        let sigscript = compiled
-            .build_sig_script(
-                "main",
-                vec![
-                    claim.clone().into(),
-                    control_index.clone().into(),
-                    Expr::dynamic_bytes(control_digests.clone()),
-                    Expr::dynamic_bytes(seal.clone()),
-                    journal.clone().into(),
-                ],
-            )
-            .expect("sigscript builds");
-        let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+        let sigscript = encode_entry_sig_script(
+            &compiled,
+            "main",
+            &[
+                claim.clone().into(),
+                control_index.clone().into(),
+                ArtifactValue::Bytes(control_digests.clone()),
+                ArtifactValue::Bytes(seal.clone()),
+                journal.clone().into(),
+            ],
+        )
+        .expect("sigscript builds");
+        let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
         assert!(result.is_ok(), "{call_name} should execute successfully: {result:?}");
     }
 }
@@ -11010,11 +11141,10 @@ fn r0_g16_verify_executes_with_fixture() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled
-        .build_sig_script("main", vec![journal_hash.into(), Expr::dynamic_bytes(proof), image_id.into()])
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[journal_hash.into(), ArtifactValue::Bytes(proof), image_id.into()])
         .expect("sigscript builds");
 
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "R0 Groth16 verifier should execute successfully: {result:?}");
 }
 
@@ -11112,7 +11242,7 @@ fn checksigfromstack_executes_schnorr_signature_verification() {
         )
         .expect("compile succeeds");
         let dispatch_tag = dispatch_tag_for(&compiled, "main");
-        run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag)
+        run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag)
     };
 
     assert!(run(valid_signature.clone()).is_ok(), "valid Schnorr data signature should pass");
@@ -11138,10 +11268,13 @@ fn checksigfromstack_false_result_can_be_asserted() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
     let run = |signature: Vec<u8>| {
-        let sigscript = compiled
-            .build_sig_script("main", vec![signature.into(), digest.as_bytes().to_vec().into(), public_key.clone().into()])
-            .expect("sigscript builds");
-        run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript)
+        let sigscript = encode_entry_sig_script(
+            &compiled,
+            "main",
+            &[signature.into(), digest.as_bytes().to_vec().into(), public_key.clone().into()],
+        )
+        .expect("sigscript builds");
+        run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript)
     };
 
     let valid_result = run(valid_signature);
@@ -11173,7 +11306,7 @@ fn check_msg_sig_ecdsa_executes_ecdsa_signature_verification() {
         )
         .expect("compile succeeds");
         let dispatch_tag = dispatch_tag_for(&compiled, "main");
-        run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag)
+        run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag)
     };
 
     assert!(run(valid_signature.clone()).is_ok(), "valid ECDSA data signature should pass");
@@ -12088,7 +12221,7 @@ fn executes_opcode_builtins_basic() {
         let dispatch_tag = dispatch_tag_for(&compiled, "main");
         let sigscript = dispatch_tag_sigscript(dispatch_tag);
         let (tx, entries) = build_basic_opcode_tx(sigscript);
-        let result = run_bytecode_with_tx_and_covenants(compiled.bytecode, tx, entries, None);
+        let result = run_bytecode_with_tx_and_covenants(bytecode(&compiled), tx, entries, None);
         assert!(result.is_ok(), "opcode builtin {name} failed: {}", result.unwrap_err());
     }
 }
@@ -12129,7 +12262,7 @@ fn template_hash_matches_canonical_rust_and_sil_vectors() {
 
         let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("templateHash should compile");
         let dispatch_tag = dispatch_tag_for(&compiled, "main");
-        let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+        let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
         assert!(result.is_ok(), "templateHash should match canonical vector {expected_hex}: {result:?}");
     }
 }
@@ -12146,7 +12279,7 @@ fn template_hash_binds_prefix_suffix_boundary() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("templateHash should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "templateHash should commit to the prefix/suffix boundary: {result:?}");
 }
 
@@ -12182,7 +12315,7 @@ fn executes_opcode_builtins_covenants() {
     let covenant_id_b = Hash::from_bytes(*b"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
     let (tx, entries) = build_covenant_opcode_tx(sigscript, covenant_id_a, covenant_id_b);
 
-    let result = run_bytecode_with_tx_and_covenants(compiled.bytecode, tx, entries, None);
+    let result = run_bytecode_with_tx_and_covenants(bytecode(&compiled), tx, entries, None);
     assert!(result.is_ok(), "opcode builtins covenants failed: {}", result.unwrap_err());
 }
 
@@ -12222,7 +12355,7 @@ fn executes_opcode_chainblock_seq_commit() {
     let block = Hash::from_bytes(*b"0123456789abcdef0123456789abcdef");
     let commitment = Hash::from_bytes(*b"fedcba9876543210fedcba9876543210");
     let accessor = MockSeqCommitAccessor { block, commitment };
-    let result = run_bytecode_with_tx_and_covenants(compiled.bytecode, tx, entries, Some(&accessor));
+    let result = run_bytecode_with_tx_and_covenants(bytecode(&compiled), tx, entries, Some(&accessor));
     assert!(result.is_ok(), "chainblock seq commit failed: {}", result.unwrap_err());
 }
 
@@ -12270,8 +12403,8 @@ fn compiles_if_else_and_verifies() {
 
     let expected = wrap_with_single_dispatch(&compiled, body);
 
-    assert_eq!(compiled.bytecode, expected);
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert_eq!(bytecode(&compiled), expected);
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -12307,8 +12440,8 @@ fn compiles_require_age_daa_to_csv_and_verifies() {
         .drain();
     let expected = wrap_with_single_dispatch(&compiled, body);
 
-    assert_eq!(compiled.bytecode, expected);
-    assert!(run_bytecode_with_tx(compiled.bytecode, dispatch_tag, 0, 20).is_ok());
+    assert_eq!(bytecode(&compiled), expected);
+    assert!(run_bytecode_with_tx(bytecode(&compiled), dispatch_tag, 0, 20).is_ok());
 }
 
 #[test]
@@ -12343,8 +12476,8 @@ fn compiles_require_tx_daa_to_bounded_cltv_and_verifies() {
         .drain();
     let expected = wrap_with_single_dispatch(&compiled, body);
 
-    assert_eq!(compiled.bytecode, expected);
-    assert!(run_bytecode_with_tx(compiled.bytecode, dispatch_tag, 10, 0).is_ok());
+    assert_eq!(bytecode(&compiled), expected);
+    assert!(run_bytecode_with_tx(bytecode(&compiled), dispatch_tag, 10, 0).is_ok());
 }
 
 #[test]
@@ -12380,8 +12513,8 @@ fn compiles_require_tx_time_to_lower_bounded_cltv_and_verifies() {
         .drain();
     let expected = wrap_with_single_dispatch(&compiled, body);
 
-    assert_eq!(compiled.bytecode, expected);
-    assert!(run_bytecode_with_tx(compiled.bytecode, dispatch_tag, threshold as u64, 0).is_ok());
+    assert_eq!(bytecode(&compiled), expected);
+    assert!(run_bytecode_with_tx(bytecode(&compiled), dispatch_tag, threshold as u64, 0).is_ok());
 }
 
 #[test]
@@ -12399,10 +12532,13 @@ fn signed_arithmetic_and_comparisons_match_rust_for_small_values() {
                 if matches!(operator, "/" | "%") && b == 0 {
                     continue;
                 }
-                let sigscript = compiled
-                    .build_sig_script("main", vec![Expr::int(a), Expr::int(b), Expr::int(oracle(a, b))])
-                    .expect("arithmetic signature script builds");
-                run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript)
+                let sigscript = encode_entry_sig_script(
+                    &compiled,
+                    "main",
+                    &[ArtifactValue::Int(a), ArtifactValue::Int(b), ArtifactValue::Int(oracle(a, b))],
+                )
+                .expect("arithmetic signature script builds");
+                run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript)
                     .unwrap_or_else(|error| panic!("operator={operator} a={a} b={b}: {error:?}"));
             }
         }
@@ -12420,9 +12556,9 @@ fn signed_arithmetic_and_comparisons_match_rust_for_small_values() {
         let expected = oracle(-7, 3);
         let source = format!("contract C() {{ entry main(int a, int b) {{ require((a {operator} b) == {expected}); }} }}");
         let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("comparison contract compiles");
-        let sigscript =
-            compiled.build_sig_script("main", vec![Expr::int(-7), Expr::int(3)]).expect("comparison signature script builds");
-        run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect("comparison agrees with Rust");
+        let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Int(-7), ArtifactValue::Int(3)])
+            .expect("comparison signature script builds");
+        run_bytecode_with_sigscript(bytecode(&compiled), sigscript).expect("comparison agrees with Rust");
     }
 }
 
@@ -12451,7 +12587,7 @@ fn boolean_operators_use_vm_truthiness_for_noncanonical_values() {
                     .add_data(&dispatch_tag_for(&compiled, "main"))
                     .unwrap()
                     .drain();
-                run_bytecode_with_sigscript(compiled.bytecode, sigscript).unwrap_or_else(|error| {
+                run_bytecode_with_sigscript(bytecode(&compiled), sigscript).unwrap_or_else(|error| {
                     panic!("operator={operator} left={left:?} right={right:?} expected={expected}: {error:?}")
                 });
             }
@@ -12469,19 +12605,19 @@ fn relative_age_rejects_out_of_range_static_and_dynamic_values() {
 
     let largest_in_range = "contract C() { entry main() { require(this.ageDaa >= 4294967295); } }";
     let compiled = compile_contract(largest_in_range, &[], CompileOptions::default()).expect("2^32 - 1 remains valid");
-    let sigscript = compiled.build_sig_script("main", vec![]).expect("signature script builds");
-    run_bytecode_with_sigscript_and_time(compiled.bytecode, sigscript, 0, 0)
+    let sigscript = encode_single_entry_sig_script(&compiled, &[]).expect("signature script builds");
+    run_bytecode_with_sigscript_and_time(bytecode(&compiled), sigscript, 0, 0)
         .expect_err("the largest 32-bit requirement must reject sequence zero");
 
     let dynamic_source = "contract C() { entry main(int age) { require(this.ageDaa >= age); } }";
     let compiled = compile_contract(dynamic_source, &[], CompileOptions::default()).expect("dynamic age contract compiles");
     for invalid in [-1, 1_i64 << 32] {
-        let sigscript = compiled.build_sig_script("main", vec![Expr::int(invalid)]).expect("signature script builds");
-        run_bytecode_with_sigscript_and_time(compiled.bytecode.clone(), sigscript, 0, 0)
+        let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Int(invalid)]).expect("signature script builds");
+        run_bytecode_with_sigscript_and_time(bytecode(&compiled).clone(), sigscript, 0, 0)
             .expect_err("out-of-range runtime age must be rejected before CSV");
     }
-    let sigscript = compiled.build_sig_script("main", vec![Expr::int(0)]).expect("signature script builds");
-    run_bytecode_with_sigscript_and_time(compiled.bytecode, sigscript, 0, 0).expect("zero age must remain valid");
+    let sigscript = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(0)]).expect("signature script builds");
+    run_bytecode_with_sigscript_and_time(bytecode(&compiled), sigscript, 0, 0).expect("zero age must remain valid");
 }
 
 #[test]
@@ -12508,21 +12644,23 @@ fn absolute_daa_and_time_locks_enforce_consensus_domains() {
         compile_contract("contract C() { entry main(int value) { require(tx.daa >= value); } }", &[], CompileOptions::default())
             .expect("dynamic DAA contract compiles");
     for invalid in [-1, threshold] {
-        let sigscript = dynamic_daa.build_sig_script("main", vec![Expr::int(invalid)]).expect("DAA sigscript builds");
-        run_bytecode_with_sigscript_and_time(dynamic_daa.bytecode.clone(), sigscript, threshold as u64 - 1, 0)
+        let sigscript = encode_entry_sig_script(&dynamic_daa, "main", &[ArtifactValue::Int(invalid)]).expect("DAA sigscript builds");
+        run_bytecode_with_sigscript_and_time(bytecode(&dynamic_daa).clone(), sigscript, threshold as u64 - 1, 0)
             .expect_err("runtime DAA domain guard must reject the value");
     }
-    let sigscript = dynamic_daa.build_sig_script("main", vec![Expr::int(42)]).expect("DAA sigscript builds");
-    run_bytecode_with_sigscript_and_time(dynamic_daa.bytecode, sigscript, 42, 0).expect("valid DAA lock must satisfy CLTV");
+    let sigscript = encode_entry_sig_script(&dynamic_daa, "main", &[ArtifactValue::Int(42)]).expect("DAA sigscript builds");
+    run_bytecode_with_sigscript_and_time(bytecode(&dynamic_daa), sigscript, 42, 0).expect("valid DAA lock must satisfy CLTV");
 
     let dynamic_time =
         compile_contract("contract C() { entry main(temporal value) { require(tx.time >= value); } }", &[], CompileOptions::default())
             .expect("dynamic time contract compiles");
-    let invalid_sigscript = dynamic_time.build_sig_script("main", vec![Expr::temporal(threshold - 1)]).expect("time sigscript builds");
-    run_bytecode_with_sigscript_and_time(dynamic_time.bytecode.clone(), invalid_sigscript, threshold as u64, 0)
+    let invalid_sigscript =
+        encode_entry_sig_script(&dynamic_time, "main", &[ArtifactValue::Int(threshold - 1)]).expect("time sigscript builds");
+    run_bytecode_with_sigscript_and_time(bytecode(&dynamic_time).clone(), invalid_sigscript, threshold as u64, 0)
         .expect_err("runtime timestamp domain guard must reject a DAA-domain value");
-    let valid_sigscript = dynamic_time.build_sig_script("main", vec![Expr::temporal(threshold)]).expect("time sigscript builds");
-    run_bytecode_with_sigscript_and_time(dynamic_time.bytecode, valid_sigscript, threshold as u64, 0)
+    let valid_sigscript =
+        encode_entry_sig_script(&dynamic_time, "main", &[ArtifactValue::Int(threshold)]).expect("time sigscript builds");
+    run_bytecode_with_sigscript_and_time(bytecode(&dynamic_time), valid_sigscript, threshold as u64, 0)
         .expect("valid timestamp lock must satisfy CLTV");
 }
 
@@ -12553,8 +12691,8 @@ fn temporal_literals_use_milliseconds_and_are_separate_from_daa_age() {
     let unix_milliseconds = 1_893_456_000_000;
     assert!(unix_milliseconds >= 500_000_000_000, "the consensus threshold must classify this as a timestamp");
     let compiled = compile_contract(date_source, &[], CompileOptions::default()).expect("date contract compiles");
-    let sigscript = compiled.build_sig_script("main", vec![]).expect("signature script builds");
-    run_bytecode_with_sigscript_and_time(compiled.bytecode, sigscript, unix_milliseconds, 0)
+    let sigscript = encode_single_entry_sig_script(&compiled, &[]).expect("signature script builds");
+    run_bytecode_with_sigscript_and_time(bytecode(&compiled), sigscript, unix_milliseconds, 0)
         .expect("the millisecond timestamp must satisfy CLTV");
 }
 
@@ -12670,8 +12808,8 @@ fn compiles_reused_variables_and_verifies() {
 
     let expected = wrap_with_single_dispatch(&compiled, body);
 
-    assert_eq!(compiled.bytecode, expected);
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert_eq!(bytecode(&compiled), expected);
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -12714,7 +12852,7 @@ fn return_reused_local_is_stored_once_and_reused() {
         .drain();
 
     let expected = wrap_with_single_dispatch(&compiled, expected);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -12735,7 +12873,7 @@ fn compiles_sigscript_inputs_and_verifies() {
     builder.add_data(&dispatch_tag).unwrap();
     let sigscript = builder.drain();
 
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "sigscript test failed: {}", result.unwrap_err());
 }
 
@@ -12766,10 +12904,10 @@ fn compiles_bytecode_size_and_runs_sum_array() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let expected_size = compiled.bytecode.len() as i64;
-    let sigscript = compiled.build_sig_script("main", vec![Expr::int(expected_size)]).expect("sigscript builds");
+    let expected_size = bytecode(&compiled).len() as i64;
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Int(expected_size)]).expect("sigscript builds");
 
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "script size contract failed: {}", result.unwrap_err());
 }
 
@@ -12793,10 +12931,10 @@ fn compiles_bytecode_size_data_prefix_small_script() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let expected_prefix = data_prefix_for_size(compiled.bytecode.len());
-    let sigscript = compiled.build_sig_script("main", vec![Expr::dynamic_bytes(expected_prefix)]).expect("sigscript builds");
+    let expected_prefix = data_prefix_for_size(bytecode(&compiled).len());
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Bytes(expected_prefix)]).expect("sigscript builds");
 
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "bytecodeSizeDataPrefix small failed: {}", result.unwrap_err());
 }
 
@@ -12814,10 +12952,10 @@ fn compiles_bytecode_size_data_prefix_medium_script() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let expected_prefix = data_prefix_for_size(compiled.bytecode.len());
-    let sigscript = compiled.build_sig_script("main", vec![Expr::dynamic_bytes(expected_prefix)]).expect("sigscript builds");
+    let expected_prefix = data_prefix_for_size(bytecode(&compiled).len());
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Bytes(expected_prefix)]).expect("sigscript builds");
 
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "bytecodeSizeDataPrefix medium failed: {}", result.unwrap_err());
 }
 
@@ -12835,10 +12973,10 @@ fn compiles_bytecode_size_data_prefix_large_script() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    let expected_prefix = data_prefix_for_size(compiled.bytecode.len());
-    let sigscript = compiled.build_sig_script("main", vec![Expr::dynamic_bytes(expected_prefix)]).expect("sigscript builds");
+    let expected_prefix = data_prefix_for_size(bytecode(&compiled).len());
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Bytes(expected_prefix)]).expect("sigscript builds");
 
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "bytecodeSizeDataPrefix large failed: {}", result.unwrap_err());
 }
 
@@ -12859,7 +12997,7 @@ fn compiles_sigscript_reused_inputs_and_verifies() {
     builder.add_data(&dispatch_tag).unwrap();
     let sigscript = builder.drain();
 
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "sigscript reuse test failed: {}", result.unwrap_err());
 }
 
@@ -12881,7 +13019,7 @@ fn compiles_sigscript_inputs_and_fails_on_wrong_sum() {
     builder.add_data(&dispatch_tag).unwrap();
     let sigscript = builder.drain();
 
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_err());
 }
 
@@ -12902,7 +13040,7 @@ fn compiles_sigscript_reused_inputs_and_fails_on_wrong_value() {
     builder.add_data(&dispatch_tag).unwrap();
     let sigscript = builder.drain();
 
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_err());
 }
 
@@ -12931,13 +13069,13 @@ fn entrypoints_validate_fixed_array_argument_sizes_at_runtime() {
         builder.drain()
     };
 
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript("bytes", &[1, 2, 3])).is_ok());
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript("bytes", &[1, 2])).is_err());
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript("bytes", &[1, 2, 3, 4])).is_err());
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript("ints", &[0; 16])).is_ok());
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript("ints", &[0; 8])).is_err());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript("bytes", &[1, 2, 3])).is_ok());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript("bytes", &[1, 2])).is_err());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript("bytes", &[1, 2, 3, 4])).is_err());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript("ints", &[0; 16])).is_ok());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript("ints", &[0; 8])).is_err());
 
-    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
+    let asm = script_to_str(&bytecode(&compiled)).expect("stringifies");
     assert_eq!(asm.matches("OpSize").count(), 2, "each entrypoint should validate its fixed-array argument: {asm}");
 }
 
@@ -12978,27 +13116,28 @@ fn entrypoints_validate_fixed_width_scalar_argument_sizes_at_runtime() {
             .drain();
         let dispatch_tag = dispatch_tag_for(&compiled, "main");
         let expected = wrap_with_single_dispatch(&compiled, body);
-        assert_eq!(compiled.bytecode, expected, "unexpected ABI validation bytecode for {type_name}");
+        assert_eq!(bytecode(&compiled), expected, "unexpected ABI validation bytecode for {type_name}");
 
         let sigscript =
             |size: usize| script_builder().add_data_with_push_opcode(&vec![1; size]).unwrap().add_data(&dispatch_tag).unwrap().drain();
         assert!(
-            run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript(expected_size)).is_ok(),
+            run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript(expected_size)).is_ok(),
             "{type_name} should accept exactly {expected_size} bytes"
         );
         if type_name == "byte" {
-            let zero_sigscript = compiled.build_sig_script("main", vec![Expr::byte(0)]).expect("zero byte sigscript builds");
+            let zero_sigscript =
+                encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Byte(0)]).expect("zero byte sigscript builds");
             assert!(
-                run_bytecode_with_sigscript(compiled.bytecode.clone(), zero_sigscript).is_ok(),
+                run_bytecode_with_sigscript(bytecode(&compiled).clone(), zero_sigscript).is_ok(),
                 "the typed builder must preserve byte(0) as a one-byte stack item"
             );
         }
         assert!(
-            run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript(expected_size - 1)).is_err(),
+            run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript(expected_size - 1)).is_err(),
             "{type_name} should reject a short value"
         );
         assert!(
-            run_bytecode_with_sigscript(compiled.bytecode, sigscript(expected_size + 1)).is_err(),
+            run_bytecode_with_sigscript(bytecode(&compiled), sigscript(expected_size + 1)).is_err(),
             "{type_name} should reject a long value"
         );
     }
@@ -13038,13 +13177,13 @@ fn entrypoint_int_argument_accepts_below_nine_bytes_and_rejects_nine() {
         .drain();
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
     let expected = wrap_with_single_dispatch(&compiled, body);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 
     let sigscript =
         |size: usize| script_builder().add_data_with_push_opcode(&vec![1; size]).unwrap().add_data(&dispatch_tag).unwrap().drain();
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript(0)).is_ok());
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript(8)).is_ok());
-    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript(9)).is_err());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript(0)).is_ok());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript(8)).is_ok());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled), sigscript(9)).is_err());
 }
 
 #[test]
@@ -13081,14 +13220,14 @@ fn entrypoint_bool_argument_accepts_at_most_one_byte() {
         .drain();
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
     let expected = wrap_with_single_dispatch(&compiled, body);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 
     let sigscript =
         |size: usize| script_builder().add_data_with_push_opcode(&vec![1; size]).unwrap().add_data(&dispatch_tag).unwrap().drain();
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript(0)).is_ok());
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript(1)).is_ok());
-    assert!(run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript(2)).is_err());
-    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript(9)).is_err());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript(0)).is_ok());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript(1)).is_ok());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript(2)).is_err());
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled), sigscript(9)).is_err());
 }
 
 #[test]
@@ -13103,7 +13242,7 @@ fn compile_time_length_for_fixed_size_int_array() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
-    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
+    let asm = script_to_str(&bytecode(&compiled)).expect("stringifies");
     assert!(!asm.contains("OpSize"), "fixed-size array length should be compile-time, got asm: {asm}");
     assert!(asm.contains("Op5 Op5 OpNumEqual OpVerify"), "expected compile-time length comparison, got asm: {asm}");
 }
@@ -13120,7 +13259,7 @@ fn compile_time_length_for_fixed_size_byte_array() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
-    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
+    let asm = script_to_str(&bytecode(&compiled)).expect("stringifies");
     assert!(!asm.contains("OpSize"), "fixed-size byte-array length should be compile-time, got asm: {asm}");
     assert!(asm.contains("Op3 Op3 OpNumEqual OpVerify"), "expected compile-time length comparison, got asm: {asm}");
 }
@@ -13139,7 +13278,7 @@ fn compile_time_length_for_inferred_array_sizes() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
-    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
+    let asm = script_to_str(&bytecode(&compiled)).expect("stringifies");
     assert!(!asm.contains("OpSize"), "inferred fixed-array lengths should be compile-time, got asm: {asm}");
     assert!(asm.contains("Op4 Op4 OpNumEqual OpVerify"), "expected byte-array compile-time length, got asm: {asm}");
     assert!(asm.contains("Op3 Op3 OpNumEqual OpVerify"), "expected int-array compile-time length, got asm: {asm}");
@@ -13257,7 +13396,7 @@ fn accepts_well_typed_constant_dependencies_on_constructor_params_and_constants(
     let compiled =
         compile_contract(source, &[3.into()], CompileOptions::default()).expect("well-typed constant dependencies should compile");
     let sigscript = dispatch_tag_sigscript(dispatch_tag_for(&compiled, "main"));
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "constant dependencies should retain their runtime value: {result:?}");
 }
 
@@ -13328,7 +13467,7 @@ fn compile_time_length_with_constant_size() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
-    let asm = script_to_str(&compiled.bytecode).expect("stringifies");
+    let asm = script_to_str(&bytecode(&compiled)).expect("stringifies");
     assert!(!asm.contains("OpSize"), "constant-sized array length should be compile-time, got asm: {asm}");
     assert!(asm.contains("Op5 Op5 OpNumEqual OpVerify"), "expected compile-time length comparison, got asm: {asm}");
 }
@@ -13427,12 +13566,12 @@ fn bool_as_int_normalizes_vm_truthiness() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("bool as int compiles");
-    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    let opcodes = script_to_str(&bytecode(&compiled)).expect("compiled bytecode stringifies");
     assert_eq!(opcodes.matches("Op0NotEqual").count(), 1, "bool as int must normalize VM truthiness exactly once: {opcodes}");
 
     let raw_truthy_arg =
         script_builder().add_data_with_push_opcode(&[2]).unwrap().add_data(&dispatch_tag_for(&compiled, "main")).unwrap().drain();
-    let result = run_bytecode_with_sigscript(compiled.bytecode, raw_truthy_arg);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), raw_truthy_arg);
     assert!(result.is_ok(), "truthy 0x02 must normalize to integer 1: {result:?}");
 }
 
@@ -13472,9 +13611,9 @@ fn int_as_fixed_bytes_has_a_fixed_result_type_and_uses_num2bin() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("fixed-size integer conversions compile");
-    assert_eq!(compiled.bytecode.iter().filter(|&&op| op == OpNum2Bin).count(), 4);
+    assert_eq!(bytecode(&compiled).iter().filter(|&&op| op == OpNum2Bin).count(), 4);
     let sigscript = script_builder().add_i64(42).unwrap().add_data(&dispatch_tag_for(&compiled, "test")).unwrap().drain();
-    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript).is_ok(), "fixed-size integer conversions should execute");
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled), sigscript).is_ok(), "fixed-size integer conversions should execute");
 }
 
 #[test]
@@ -13489,11 +13628,11 @@ fn int_as_byte_uses_num2bin_and_executes() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("int as byte compiles");
-    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    let opcodes = script_to_str(&bytecode(&compiled)).expect("compiled bytecode stringifies");
     assert_eq!(opcodes.matches("OpNum2Bin").count(), 1, "int as byte must emit one OpNum2Bin: {opcodes}");
 
-    let sigscript = compiled.build_sig_script("test", vec![Expr::int(42)]).expect("int argument encodes");
-    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript).is_ok(), "one-byte numeric conversion should execute");
+    let sigscript = encode_entry_sig_script(&compiled, "test", &[ArtifactValue::Int(42)]).expect("int argument encodes");
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled), sigscript).is_ok(), "one-byte numeric conversion should execute");
 }
 
 #[test]
@@ -13508,8 +13647,8 @@ fn int_as_byte_fails_at_runtime_when_value_does_not_fit() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("int as byte compiles");
-    let sigscript = compiled.build_sig_script("test", vec![Expr::int(128)]).expect("int argument encodes");
-    let err = run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect_err("128 needs two script-number bytes");
+    let sigscript = encode_entry_sig_script(&compiled, "test", &[ArtifactValue::Int(128)]).expect("int argument encodes");
+    let err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript).expect_err("128 needs two script-number bytes");
     assert_eq!(
         err,
         kaspa_txscript_errors::TxScriptError::Serialization(kaspa_txscript_errors::SerializationError::NumberTooLong(128, 1))
@@ -13580,7 +13719,7 @@ fn blake2b_builtins_require_dynamic_byte_array_arguments() {
         }
     "#;
     let compiled = compile_contract(valid_source, &[], CompileOptions::default()).expect("byte[] arguments should compile");
-    let asm = script_to_str(&compiled.bytecode).expect("Blake2b script should stringify");
+    let asm = script_to_str(&bytecode(&compiled)).expect("Blake2b script should stringify");
     assert!(asm.contains("OpBlake2b"), "expected OpBlake2b in generated script: {asm}");
     assert!(asm.contains("OpBlake2bWithKey"), "expected OpBlake2bWithKey in generated script: {asm}");
 }
@@ -13638,10 +13777,10 @@ fn fixed_byte_array_up_to_eight_bytes_casts_to_int_without_extra_opcodes() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("byte[2] to int cast compiles");
-    assert!(!compiled.bytecode.contains(&OpBin2Num), "int(data) must not emit OpBin2Num");
+    assert!(!bytecode(&compiled).contains(&OpBin2Num), "int(data) must not emit OpBin2Num");
 
-    let sigscript = compiled.build_sig_script("test", vec![vec![42u8, 0].into()]).expect("sigscript builds");
-    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript).is_ok(), "int(byte[2]) should produce a usable integer value");
+    let sigscript = encode_entry_sig_script(&compiled, "test", &[vec![42u8, 0].into()]).expect("sigscript builds");
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled), sigscript).is_ok(), "int(byte[2]) should produce a usable integer value");
 }
 
 #[test]
@@ -13729,7 +13868,7 @@ fn scalar_byte_cast_cannot_escape_validate_output_state_push() {
         }
     "#;
 
-    compile_contract(source, &[Expr::byte(0)], CompileOptions::default())
+    compile_contract(source, &[ArtifactValue::Byte(0)], CompileOptions::default())
         .expect_err("a string must not cast to a scalar byte and escape the generated one-byte state push");
 }
 
@@ -13770,12 +13909,12 @@ fn signed_byte_cast_is_a_passthrough_with_signed_numeric_semantics() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("signed(byte) compiles");
-    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    let opcodes = script_to_str(&bytecode(&compiled)).expect("compiled bytecode stringifies");
     assert!(!opcodes.contains("OpCat"), "signed(byte) must be a passthrough: {opcodes}");
     assert!(!opcodes.contains("OpBin2Num"), "signed(byte) must not normalize its operand: {opcodes}");
 
-    let sigscript = compiled.build_sig_script("test", vec![Expr::byte(255)]).expect("byte argument encodes");
-    assert!(run_bytecode_with_sigscript(compiled.bytecode, sigscript).is_ok(), "0xff must have signed value -127");
+    let sigscript = encode_entry_sig_script(&compiled, "test", &[ArtifactValue::Byte(255)]).expect("byte argument encodes");
+    assert!(run_bytecode_with_sigscript(bytecode(&compiled), sigscript).is_ok(), "0xff must have signed value -127");
 }
 
 #[test]
@@ -13791,11 +13930,11 @@ fn unsigned_byte_cast_appends_zero_and_preserves_255() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("unsigned(byte) compiles");
-    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode stringifies");
+    let opcodes = script_to_str(&bytecode(&compiled)).expect("compiled bytecode stringifies");
     assert_eq!(opcodes.matches("OpCat").count(), 1, "unsigned(byte) must append one zero byte: {opcodes}");
     assert!(!opcodes.contains("OpBin2Num"), "unsigned(byte) must use concatenation rather than normalization: {opcodes}");
     let dispatch_tag = dispatch_tag_for(&compiled, "test");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok(), "unsigned(0xff) must equal 255");
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok(), "unsigned(0xff) must equal 255");
 }
 
 #[test]
@@ -13824,7 +13963,7 @@ fn empty_array_statement_expr_evaluation_compiles_to_empty_array_data() {
         .drain();
 
     let expected = wrap_with_single_dispatch(&compiled, body);
-    assert_eq!(compiled.bytecode, expected);
+    assert_eq!(bytecode(&compiled), expected);
 }
 
 #[test]
@@ -13842,14 +13981,14 @@ fn function_param_shadows_constructor_constant_with_same_name() {
     "#;
 
     // Constructor fee=2, param fee=3 => local = 3+1 = 4 => pass
-    let compiled = compile_contract(source, &[Expr::int(2)], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::int(3)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
+    let compiled = compile_contract(source, &[ArtifactValue::Int(2)], CompileOptions::default()).expect("compile succeeds");
+    let sigscript = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(3)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript);
     assert!(result.is_ok(), "function param should shadow constructor constant: {}", result.unwrap_err());
 
     // Constructor fee=2, param fee=2 => local = 2+1 = 3 != 4 => fail (proves it's not always the constant)
-    let sigscript_wrong = compiled.build_sig_script("main", vec![Expr::int(2)]).expect("sigscript builds");
-    let result_wrong = run_bytecode_with_sigscript(compiled.bytecode, sigscript_wrong);
+    let sigscript_wrong = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(2)]).expect("sigscript builds");
+    let result_wrong = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_wrong);
     assert!(result_wrong.is_err(), "require(3==4) should fail, proving the param value matters");
 }
 
@@ -13877,7 +14016,7 @@ fn allows_same_variable_name_in_different_functions() {
     let compiled = compile_contract(source, &[], CompileOptions::default())
         .expect("separate functions should have independent variable namespaces");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -13915,7 +14054,7 @@ fn allows_same_variable_name_in_non_overlapping_sibling_scopes() {
     let compiled = compile_contract(source, &[], CompileOptions::default())
         .expect("non-overlapping sibling scopes should have independent variable namespaces");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    assert!(run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).is_ok());
+    assert!(run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).is_ok());
 }
 
 #[test]
@@ -13954,7 +14093,7 @@ fn rejects_contract_constant_that_shadows_constructor_parameter_used_as_array_si
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(4)], CompileOptions::default())
+    let err = compile_contract(source, &[ArtifactValue::Int(4)], CompileOptions::default())
         .expect_err("a contract constant must not shadow a constructor parameter");
     assert!(err.to_string().contains("variable 'A' is already defined"), "unexpected error: {err}");
     let span = err.span().expect("the conflicting constant should be identified");
@@ -14168,16 +14307,19 @@ fn ternary_expression_executes_selected_branch() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("ternary contract should compile");
 
-    let sigscript_then = compiled.build_sig_script("main", vec![Expr::int(1), Expr::int(7)]).expect("sigscript builds");
-    let result_then = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_then);
+    let sigscript_then =
+        encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Int(1), ArtifactValue::Int(7)]).expect("sigscript builds");
+    let result_then = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_then);
     assert!(result_then.is_ok(), "then branch should execute successfully: {}", result_then.unwrap_err());
 
-    let sigscript_else = compiled.build_sig_script("main", vec![Expr::int(0), Expr::int(11)]).expect("sigscript builds");
-    let result_else = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_else);
+    let sigscript_else =
+        encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Int(0), ArtifactValue::Int(11)]).expect("sigscript builds");
+    let result_else = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_else);
     assert!(result_else.is_ok(), "else branch should execute successfully: {}", result_else.unwrap_err());
 
-    let sigscript_wrong = compiled.build_sig_script("main", vec![Expr::int(0), Expr::int(7)]).expect("sigscript builds");
-    let result_wrong = run_bytecode_with_sigscript(compiled.bytecode, sigscript_wrong);
+    let sigscript_wrong =
+        encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Int(0), ArtifactValue::Int(7)]).expect("sigscript builds");
+    let result_wrong = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_wrong);
     assert!(result_wrong.is_err(), "else branch should not produce the then value");
 }
 
@@ -14200,7 +14342,7 @@ fn ternary_expression_does_not_execute_unselected_branch() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("ternary contract should compile");
-    let asm = script_to_str(&compiled.bytecode).expect("ternary script should stringify");
+    let asm = script_to_str(&bytecode(&compiled)).expect("ternary script should stringify");
     let if_index = asm.find("OpIf").expect("ternary should emit OpIf");
     let else_index = asm.find("OpElse").expect("ternary should emit OpElse");
     let end_if_index = asm.find("OpEndIf").expect("ternary should emit OpEndIf");
@@ -14211,31 +14353,71 @@ fn ternary_expression_does_not_execute_unselected_branch() {
         "divisions should remain inside their respective conditional branches: {asm}"
     );
 
-    let select_then = compiled
-        .build_sig_script("main", vec![Expr::bool(true), Expr::int(10), Expr::int(2), Expr::int(20), Expr::int(0), Expr::int(5)])
-        .expect("then-branch sigscript builds");
-    let then_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_then);
+    let select_then = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[
+            ArtifactValue::Bool(true),
+            ArtifactValue::Int(10),
+            ArtifactValue::Int(2),
+            ArtifactValue::Int(20),
+            ArtifactValue::Int(0),
+            ArtifactValue::Int(5),
+        ],
+    )
+    .expect("then-branch sigscript builds");
+    let then_result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), select_then);
     assert!(then_result.is_ok(), "zero divisor in the unselected else branch must not execute: {}", then_result.unwrap_err());
 
-    let select_else = compiled
-        .build_sig_script("main", vec![Expr::bool(false), Expr::int(10), Expr::int(0), Expr::int(20), Expr::int(4), Expr::int(5)])
-        .expect("else-branch sigscript builds");
-    let else_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_else);
+    let select_else = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[
+            ArtifactValue::Bool(false),
+            ArtifactValue::Int(10),
+            ArtifactValue::Int(0),
+            ArtifactValue::Int(20),
+            ArtifactValue::Int(4),
+            ArtifactValue::Int(5),
+        ],
+    )
+    .expect("else-branch sigscript builds");
+    let else_result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), select_else);
     assert!(else_result.is_ok(), "zero divisor in the unselected then branch must not execute: {}", else_result.unwrap_err());
 
-    let failing_then = compiled
-        .build_sig_script("main", vec![Expr::bool(true), Expr::int(10), Expr::int(0), Expr::int(20), Expr::int(4), Expr::int(5)])
-        .expect("failing then-branch sigscript builds");
+    let failing_then = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[
+            ArtifactValue::Bool(true),
+            ArtifactValue::Int(10),
+            ArtifactValue::Int(0),
+            ArtifactValue::Int(20),
+            ArtifactValue::Int(4),
+            ArtifactValue::Int(5),
+        ],
+    )
+    .expect("failing then-branch sigscript builds");
     assert!(
-        run_bytecode_with_sigscript(compiled.bytecode.clone(), failing_then).is_err(),
+        run_bytecode_with_sigscript(bytecode(&compiled).clone(), failing_then).is_err(),
         "zero divisor in the selected then branch should execute and fail"
     );
 
-    let failing_else = compiled
-        .build_sig_script("main", vec![Expr::bool(false), Expr::int(10), Expr::int(2), Expr::int(20), Expr::int(0), Expr::int(5)])
-        .expect("failing else-branch sigscript builds");
+    let failing_else = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[
+            ArtifactValue::Bool(false),
+            ArtifactValue::Int(10),
+            ArtifactValue::Int(2),
+            ArtifactValue::Int(20),
+            ArtifactValue::Int(0),
+            ArtifactValue::Int(5),
+        ],
+    )
+    .expect("failing else-branch sigscript builds");
     assert!(
-        run_bytecode_with_sigscript(compiled.bytecode, failing_else).is_err(),
+        run_bytecode_with_sigscript(bytecode(&compiled), failing_else).is_err(),
         "zero divisor in the selected else branch should execute and fail"
     );
 }
@@ -14258,8 +14440,9 @@ fn ternary_does_not_read_input_state_in_unselected_then_branch() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[Expr::int(7)], CompileOptions::default()).expect("ternary contract should compile");
-    let asm = script_to_str(&compiled.bytecode).expect("ternary script should stringify");
+    let compiled =
+        compile_contract(source, &[ArtifactValue::Int(7)], CompileOptions::default()).expect("ternary contract should compile");
+    let asm = script_to_str(&bytecode(&compiled)).expect("ternary script should stringify");
     let if_index = asm.find("OpIf").expect("ternary should emit OpIf");
     let read_index = asm.find("OpTxInputScriptSigLen").expect("selected branch should contain the input-state read");
     let else_index = asm.find("OpElse").expect("ternary should emit OpElse");
@@ -14268,13 +14451,13 @@ fn ternary_does_not_read_input_state_in_unselected_then_branch() {
         "input-state access should remain inside the ternary's then branch: {asm}"
     );
 
-    let select_local = compiled.build_sig_script("main", vec![Expr::bool(false)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_local);
+    let select_local = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Bool(false)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), select_local);
     assert!(result.is_ok(), "input 9 in the unselected branch must not be read: {}", result.unwrap_err());
 
-    let select_remote = compiled.build_sig_script("main", vec![Expr::bool(true)]).expect("sigscript builds");
+    let select_remote = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Bool(true)]).expect("sigscript builds");
     assert!(
-        run_bytecode_with_sigscript(compiled.bytecode, select_remote).is_err(),
+        run_bytecode_with_sigscript(bytecode(&compiled), select_remote).is_err(),
         "input 9 in the selected branch should be read and fail"
     );
 }
@@ -14296,7 +14479,7 @@ fn ternary_expression_does_not_execute_function_call_in_unselected_else_branch()
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("ternary contract should compile");
-    let asm = script_to_str(&compiled.bytecode).expect("ternary script should stringify");
+    let asm = script_to_str(&bytecode(&compiled)).expect("ternary script should stringify");
     let if_index = asm.find("OpIf").expect("ternary should emit OpIf");
     let else_index = asm.find("OpElse").expect("ternary should emit OpElse");
     let fail_index = asm.find("OpFalse OpVerify").expect("else-branch helper should emit require(false)");
@@ -14306,17 +14489,23 @@ fn ternary_expression_does_not_execute_function_call_in_unselected_else_branch()
         "require(false) should remain inside the ternary's else branch: {asm}"
     );
 
-    let select_then = compiled
-        .build_sig_script("main", vec![Expr::bool(true), Expr::int(7), Expr::int(11), Expr::int(7)])
-        .expect("then-branch sigscript builds");
-    let then_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_then);
+    let select_then = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Bool(true), ArtifactValue::Int(7), ArtifactValue::Int(11), ArtifactValue::Int(7)],
+    )
+    .expect("then-branch sigscript builds");
+    let then_result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), select_then);
     assert!(then_result.is_ok(), "require(false) in the unselected else-branch call must not execute: {}", then_result.unwrap_err());
 
-    let select_else = compiled
-        .build_sig_script("main", vec![Expr::bool(false), Expr::int(7), Expr::int(11), Expr::int(11)])
-        .expect("else-branch sigscript builds");
+    let select_else = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Bool(false), ArtifactValue::Int(7), ArtifactValue::Int(11), ArtifactValue::Int(11)],
+    )
+    .expect("else-branch sigscript builds");
     assert!(
-        run_bytecode_with_sigscript(compiled.bytecode, select_else).is_err(),
+        run_bytecode_with_sigscript(bytecode(&compiled), select_else).is_err(),
         "require(false) in the selected else-branch call should execute and fail"
     );
 }
@@ -14338,7 +14527,7 @@ fn ternary_expression_does_not_execute_function_call_in_unselected_then_branch()
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("ternary contract should compile");
-    let asm = script_to_str(&compiled.bytecode).expect("ternary script should stringify");
+    let asm = script_to_str(&bytecode(&compiled)).expect("ternary script should stringify");
     let if_index = asm.find("OpIf").expect("ternary should emit OpIf");
     let fail_index = asm.find("OpFalse OpVerify").expect("then-branch helper should emit require(false)");
     let else_index = asm.find("OpElse").expect("ternary should emit OpElse");
@@ -14348,17 +14537,23 @@ fn ternary_expression_does_not_execute_function_call_in_unselected_then_branch()
         "require(false) should remain inside the ternary's then branch: {asm}"
     );
 
-    let select_else = compiled
-        .build_sig_script("main", vec![Expr::bool(false), Expr::int(7), Expr::int(11), Expr::int(11)])
-        .expect("else-branch sigscript builds");
-    let else_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_else);
+    let select_else = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Bool(false), ArtifactValue::Int(7), ArtifactValue::Int(11), ArtifactValue::Int(11)],
+    )
+    .expect("else-branch sigscript builds");
+    let else_result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), select_else);
     assert!(else_result.is_ok(), "require(false) in the unselected then-branch call must not execute: {}", else_result.unwrap_err());
 
-    let select_then = compiled
-        .build_sig_script("main", vec![Expr::bool(true), Expr::int(7), Expr::int(11), Expr::int(7)])
-        .expect("then-branch sigscript builds");
+    let select_then = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Bool(true), ArtifactValue::Int(7), ArtifactValue::Int(11), ArtifactValue::Int(7)],
+    )
+    .expect("then-branch sigscript builds");
     assert!(
-        run_bytecode_with_sigscript(compiled.bytecode, select_then).is_err(),
+        run_bytecode_with_sigscript(bytecode(&compiled), select_then).is_err(),
         "require(false) in the selected then-branch call should execute and fail"
     );
 }
@@ -14381,21 +14576,27 @@ fn nested_ternary_function_call_remains_in_selected_branch() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("nested ternary contract should compile");
 
-    let select_then = compiled
-        .build_sig_script("main", vec![Expr::bool(true), Expr::int(7), Expr::int(11), Expr::int(8)])
-        .expect("then-branch sigscript builds");
-    let then_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_then);
+    let select_then = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Bool(true), ArtifactValue::Int(7), ArtifactValue::Int(11), ArtifactValue::Int(8)],
+    )
+    .expect("then-branch sigscript builds");
+    let then_result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), select_then);
     assert!(
         then_result.is_ok(),
         "require(false) in a nested unselected else-branch call must not execute: {}",
         then_result.unwrap_err()
     );
 
-    let select_else = compiled
-        .build_sig_script("main", vec![Expr::bool(false), Expr::int(7), Expr::int(11), Expr::int(12)])
-        .expect("else-branch sigscript builds");
+    let select_else = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Bool(false), ArtifactValue::Int(7), ArtifactValue::Int(11), ArtifactValue::Int(12)],
+    )
+    .expect("else-branch sigscript builds");
     assert!(
-        run_bytecode_with_sigscript(compiled.bytecode, select_else).is_err(),
+        run_bytecode_with_sigscript(bytecode(&compiled), select_else).is_err(),
         "require(false) in a nested selected else-branch call should execute and fail"
     );
 }
@@ -14438,7 +14639,13 @@ fn ternary_lowering_initializes_generated_results_for_supported_types() {
 
     compile_contract(
         source,
-        &[Expr::int(2), Expr::bytes(vec![1, 2]), Expr::bytes(vec![3; 32]), Expr::bytes(vec![4; 65]), Expr::bytes(vec![5; 64])],
+        &[
+            ArtifactValue::Int(2),
+            ArtifactValue::Bytes(vec![1, 2]),
+            ArtifactValue::Bytes(vec![3; 32]),
+            ArtifactValue::Bytes(vec![4; 65]),
+            ArtifactValue::Bytes(vec![5; 64]),
+        ],
         CompileOptions::default(),
     )
     .expect("ternary defaults should compile for every supported value type");
@@ -14466,7 +14673,7 @@ fn if_else_does_not_execute_function_call_in_unselected_else_branch() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("if/else contract should compile");
-    let asm = script_to_str(&compiled.bytecode).expect("if/else script should stringify");
+    let asm = script_to_str(&bytecode(&compiled)).expect("if/else script should stringify");
     let if_index = asm.find("OpIf").expect("if/else should emit OpIf");
     let else_index = asm.find("OpElse").expect("if/else should emit OpElse");
     let fail_index = asm.find("OpFalse OpVerify").expect("else-branch helper should emit require(false)");
@@ -14476,17 +14683,23 @@ fn if_else_does_not_execute_function_call_in_unselected_else_branch() {
         "require(false) should remain inside the else branch: {asm}"
     );
 
-    let select_then = compiled
-        .build_sig_script("main", vec![Expr::bool(true), Expr::int(7), Expr::int(11), Expr::int(7)])
-        .expect("then-branch sigscript builds");
-    let then_result = run_bytecode_with_sigscript(compiled.bytecode.clone(), select_then);
+    let select_then = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Bool(true), ArtifactValue::Int(7), ArtifactValue::Int(11), ArtifactValue::Int(7)],
+    )
+    .expect("then-branch sigscript builds");
+    let then_result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), select_then);
     assert!(then_result.is_ok(), "require(false) in the unselected else-branch call must not execute: {}", then_result.unwrap_err());
 
-    let select_else = compiled
-        .build_sig_script("main", vec![Expr::bool(false), Expr::int(7), Expr::int(11), Expr::int(11)])
-        .expect("else-branch sigscript builds");
+    let select_else = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Bool(false), ArtifactValue::Int(7), ArtifactValue::Int(11), ArtifactValue::Int(11)],
+    )
+    .expect("else-branch sigscript builds");
     assert!(
-        run_bytecode_with_sigscript(compiled.bytecode, select_else).is_err(),
+        run_bytecode_with_sigscript(bytecode(&compiled), select_else).is_err(),
         "require(false) in the selected else-branch call should execute and fail"
     );
 }
@@ -14569,8 +14782,8 @@ fn nested_inline_calls_with_args_compile_and_execute() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("nested inline calls should compile");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(5)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "nested inline calls should execute correctly: {}", result.unwrap_err());
 }
 
@@ -14593,17 +14806,17 @@ fn inline_local_binding_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("inline helper should compile");
 
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpAdd).count(),
         1,
         "x + 1 should be computed once and stored for both require statements"
     );
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(5)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored inline local should execute successfully: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(10)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "stored inline local should still enforce the second require");
 }
 
@@ -14625,17 +14838,17 @@ fn inline_function_argument_expression_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("inline call should compile");
 
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpAdd).count(),
         1,
         "x + 1 should be computed once and reused for both require statements in the inline callee"
     );
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(5)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored inline argument should execute successfully: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(10)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "stored inline argument should still enforce the second require");
 }
 
@@ -14695,18 +14908,18 @@ fn inline_argument_alias_reuses_existing_local_without_extra_snapshot() {
 
     let expected = wrap_with_single_dispatch(&compiled, body);
 
-    assert_eq!(compiled.bytecode, expected);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpDup).count(), 3);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpOver).count(), 1);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpPick).count(), 0);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(), 1);
+    assert_eq!(bytecode(&compiled), expected);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpDup).count(), 3);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpOver).count(), 1);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpPick).count(), 0);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpMul).count(), 1);
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(2)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(2)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "reused local should satisfy both inline requires: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(4)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(4)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "reused local should still fail the second inline require");
 }
 
@@ -14757,18 +14970,18 @@ fn inline_argument_alias_snapshots_entrypoint_param_once_per_inlined_call() {
 
     let expected = wrap_with_single_dispatch(&compiled, body);
 
-    assert_eq!(compiled.bytecode, expected);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpDup).count(), 2);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpOver).count(), 0);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpPick).count(), 0);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpDrop).count(), 1);
+    assert_eq!(bytecode(&compiled), expected);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpDup).count(), 2);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpOver).count(), 0);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpPick).count(), 0);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpDrop).count(), 1);
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(2)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(2)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "entrypoint param alias should satisfy both inline requires: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(10)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "entrypoint param alias should still fail the second inline require");
 }
 
@@ -14821,18 +15034,18 @@ fn local_alias_snapshots_existing_stack_value_once() {
 
     let expected = wrap_with_single_dispatch(&compiled, body);
 
-    assert_eq!(compiled.bytecode, expected);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(), 1);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpDup).count(), 3);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpOver).count(), 1);
-    assert_eq!(compiled.bytecode.iter().copied().filter(|op| *op == OpPick).count(), 0);
+    assert_eq!(bytecode(&compiled), expected);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpMul).count(), 1);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpDup).count(), 3);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpOver).count(), 1);
+    assert_eq!(bytecode(&compiled).iter().copied().filter(|op| *op == OpPick).count(), 0);
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(2)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(2)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "local alias should execute successfully: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(1)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(1)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "local alias should still enforce the requires");
 }
 
@@ -14852,12 +15065,12 @@ fn local_alias_reassignment_from_alias_passes_for_x_5() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("local alias reassignment should compile");
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(5)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "x=5 should pass after z is incremented past y: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(1)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(1)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "x=1 should still fail the initial require(y > 1)");
 }
 
@@ -14876,17 +15089,17 @@ fn local_bool_expression_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("bool local should compile");
 
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpAdd).count(),
         1,
         "x + 1 should be computed once for the stored bool expression"
     );
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(5)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored bool local should execute successfully: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(0)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(0)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "stored bool local should still enforce the false branch");
 }
 
@@ -14905,22 +15118,22 @@ fn local_nested_expression_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("nested local should compile");
 
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpAdd).count(),
         2,
         "the nested local expression should compute each addition once before storing the result"
     );
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpMul).count(),
         1,
         "the nested local expression should multiply once before storing the result"
     );
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(5)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored nested local should execute successfully: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(10)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "stored nested local should still enforce the second require");
 }
 
@@ -14967,8 +15180,8 @@ fn runs_branch_local_shadowing_and_preserves_outer_scope() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("branch-local shadowing should compile");
 
     for cond in [true, false] {
-        let sigscript = compiled.build_sig_script("main", vec![Expr::bool(cond)]).expect("sigscript builds");
-        let result = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript);
+        let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Bool(cond)]).expect("sigscript builds");
+        let result = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript);
         assert!(result.is_ok(), "branch-local shadowing should execute successfully for cond={cond}: {}", result.unwrap_err());
     }
 }
@@ -14991,7 +15204,7 @@ fn runs_for_loop_local_shadowing_and_preserves_outer_scope() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("loop-local shadowing should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "loop-local shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15013,7 +15226,7 @@ fn runs_standalone_block_local_shadowing_and_preserves_outer_scope() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("block-local shadowing should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "block-local shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15030,8 +15243,8 @@ fn runs_function_parameter_shadowing() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("parameter shadowing should compile");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::int(9)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(9)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "parameter shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15054,7 +15267,7 @@ fn runs_inlined_function_parameter_shadowing() {
     let compiled =
         compile_contract(source, &[], CompileOptions::default()).expect("inlined function parameter shadowing should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "inlined function parameter shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15078,7 +15291,7 @@ fn runs_standalone_block_tuple_binding_shadowing() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("tuple binding shadowing should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "tuple binding shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15101,7 +15314,7 @@ fn runs_split_on_non_byte_array() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("split on int[] should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "split on int[] should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15122,8 +15335,9 @@ fn runtime_split_index_produces_dynamic_array_parts() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("runtime split index should produce dynamic parts");
-    let sigscript = compiled.build_sig_script("main", vec![vec![10i64, 20, 30, 40].into(), Expr::int(2)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[vec![10i64, 20, 30, 40].into(), ArtifactValue::Int(2)])
+        .expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "runtime-index split should execute successfully: {result:?}");
 }
 
@@ -15147,8 +15361,8 @@ fn constant_split_index_produces_dynamic_parts_for_dynamic_source() {
 
     let compiled =
         compile_contract(source, &[], CompileOptions::default()).expect("constant split index should preserve dynamic parts");
-    let sigscript = compiled.build_sig_script("main", vec![vec![10i64, 20, 30, 40].into()]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[vec![10i64, 20, 30, 40].into()]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "constant-index split of a dynamic source should execute successfully: {result:?}");
 }
 
@@ -15174,7 +15388,7 @@ fn constant_split_index_produces_dynamic_parts_for_fixed_source() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("fixed source split should return dynamic parts");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "constant-index split of a fixed source should execute successfully: {result:?}");
 }
 
@@ -15286,7 +15500,7 @@ fn runs_slice_on_non_byte_array() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("slice on int[] should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "slice on int[] should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15328,7 +15542,7 @@ fn runs_split_and_slice_on_struct_array() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("struct array sequence operations should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "struct array sequence operations should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15401,7 +15615,7 @@ fn scalar_struct_values_can_be_compared_directly() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("scalar struct comparisons should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "scalar struct comparisons should execute successfully: {result:?}");
 }
 
@@ -15526,7 +15740,7 @@ fn runs_standalone_block_function_result_binding_shadowing() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("function result binding shadowing should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "function result binding shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15549,11 +15763,11 @@ fn runs_standalone_block_state_binding_shadowing() {
     "#;
 
     let input_compiled =
-        compile_contract(source, &[Expr::int(7)], CompileOptions::default()).expect("state binding shadowing should compile");
-    let sigscript = input_compiled.build_sig_script("main", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+        compile_contract(source, &[ArtifactValue::Int(7)], CompileOptions::default()).expect("state binding shadowing should compile");
+    let sigscript = encode_single_entry_sig_script(&input_compiled, &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: input_spk.clone(), covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -15586,7 +15800,7 @@ fn runs_standalone_block_struct_destructure_binding_shadowing() {
     let compiled =
         compile_contract(source, &[], CompileOptions::default()).expect("struct destructure binding shadowing should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "struct destructure binding shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15608,8 +15822,8 @@ fn branch_shadowing_initializer_reads_outer_binding() {
 
     let compiled =
         compile_contract(source, &[], CompileOptions::default()).expect("branch shadowing initializer should read the outer binding");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::bool(true)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Bool(true)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "branch shadowing initializer should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15632,8 +15846,8 @@ fn branch_reference_before_shadowing_declaration_reads_outer_binding() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default())
         .expect("a branch reference before a shadowing declaration should read the outer binding");
-    let sigscript = compiled.build_sig_script("main", vec![Expr::bool(true)]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Bool(true)]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "branch reference before shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15656,7 +15870,7 @@ fn for_loop_shadowing_initializer_reads_outer_binding() {
     let compiled =
         compile_contract(source, &[], CompileOptions::default()).expect("loop shadowing initializer should read the outer binding");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "loop shadowing initializer should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15680,7 +15894,7 @@ fn for_loop_reference_before_shadowing_declaration_reads_outer_binding() {
     let compiled = compile_contract(source, &[], CompileOptions::default())
         .expect("a loop reference before a shadowing declaration should read the outer binding");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "loop reference before shadowing should execute successfully: {}", result.unwrap_err());
 }
 
@@ -15720,12 +15934,12 @@ fn runs_standalone_block_and_preserves_outer_scope() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(5)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "standalone block should execute successfully: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(8)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(8)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_ok(), "outer scope should remain valid after the block: {}", result_err.unwrap_err());
 }
 
@@ -15747,22 +15961,22 @@ fn inline_nested_argument_expression_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("inline nested arg should compile");
 
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpAdd).count(),
         2,
         "the inline nested argument should compute each addition once and reuse the stored result"
     );
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpMul).count(),
         1,
         "the inline nested argument should multiply once and reuse the stored result"
     );
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(5)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(5)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored inline nested argument should execute successfully: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(10)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "stored inline nested argument should still enforce the second require");
 }
 
@@ -15793,22 +16007,22 @@ fn function_call_assignment_result_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("function-call assignment should compile");
 
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpSub).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpSub).count(),
         1,
         "the nested g(x) return calculation should be computed once and the assigned local reused"
     );
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpMul).count(),
         1,
         "the extra arithmetic in f(x) should be computed once and the assigned local reused"
     );
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(19)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(19)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored function-call assignment result should execute successfully: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(29)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(29)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "stored function-call assignment result should still enforce the second require");
 }
 
@@ -15841,22 +16055,22 @@ fn struct_return_field_is_stored_once_and_reused() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("struct-return local should compile");
 
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpAdd).count(),
         1,
         "s.a should be computed once and reused across both require statements"
     );
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpMul).count(),
         1,
         "s.b should be computed once and reused across both require statements"
     );
 
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(3)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(3)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "stored struct fields should execute successfully: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(10)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(10)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "stored struct fields should still enforce the require conditions");
 }
 
@@ -15959,7 +16173,7 @@ fn struct_reassignment_snapshots_all_fields_before_rebinding() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("struct field swap should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "struct field swap should execute atomically: {result:?}");
 }
 
@@ -15982,7 +16196,7 @@ fn nested_struct_reassignment_snapshots_all_leaves_before_rebinding() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("nested struct rotation should compile");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "nested struct rotation should execute atomically: {result:?}");
 }
 
@@ -16002,12 +16216,9 @@ fn struct_array_self_append_snapshots_all_leaf_expressions_before_rebinding() {
     "#;
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("struct array append should compile");
-    let argument = Expr::array(
-        parse_type_ref("S[]").expect("array type parses"),
-        vec![struct_object("S", vec![("a", Expr::int(7)), ("b", Expr::int(8))])],
-    );
-    let sigscript = compiled.build_sig_script("main", vec![argument]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let argument = ArtifactValue::Array(vec![artifact_object([("a", 7.into()), ("b", 8.into())])]);
+    let sigscript = encode_single_entry_sig_script(&compiled, &[argument]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "struct array leaf expressions should observe the pre-append value: {result:?}");
 }
 
@@ -16031,21 +16242,21 @@ fn partially_reassigned_struct_field_does_not_recompute_unchanged_fields() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("partial struct reassignment should compile");
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpMul).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpMul).count(),
         1,
         "the unchanged field should keep using its original expression instead of being copied into a new stack slot"
     );
     assert_eq!(
-        compiled.bytecode.iter().copied().filter(|op| *op == OpAdd).count(),
+        bytecode(&compiled).iter().copied().filter(|op| *op == OpAdd).count(),
         2,
         "only the initial `s.a = x + 1` and the reassigned `s.a = s.a + 1` should emit additions"
     );
-    let sigscript_ok = compiled.build_sig_script("main", vec![Expr::int(2)]).expect("sigscript builds");
-    let result_ok = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_ok);
+    let sigscript_ok = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(2)]).expect("sigscript builds");
+    let result_ok = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_ok);
     assert!(result_ok.is_ok(), "partial struct reassignment should execute successfully: {}", result_ok.unwrap_err());
 
-    let sigscript_err = compiled.build_sig_script("main", vec![Expr::int(0)]).expect("sigscript builds");
-    let result_err = run_bytecode_with_sigscript(compiled.bytecode, sigscript_err);
+    let sigscript_err = encode_single_entry_sig_script(&compiled, &[ArtifactValue::Int(0)]).expect("sigscript builds");
+    let result_err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_err);
     assert!(result_err.is_err(), "partial struct reassignment should still enforce the updated field checks");
 }
 
@@ -16069,14 +16280,22 @@ fn if_branch_reassignment_drops_hidden_shadow_bindings() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("if branch reassignment should compile");
 
-    let sigscript_then =
-        compiled.build_sig_script("main", vec![Expr::int(1), Expr::int(1), Expr::int(1), Expr::int(3)]).expect("sigscript builds");
-    let result_then = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_then);
+    let sigscript_then = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Int(1), ArtifactValue::Int(1), ArtifactValue::Int(1), ArtifactValue::Int(3)],
+    )
+    .expect("sigscript builds");
+    let result_then = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_then);
     assert!(result_then.is_ok(), "then-branch reassignment should leave a clean stack: {}", result_then.unwrap_err());
 
-    let sigscript_else =
-        compiled.build_sig_script("main", vec![Expr::int(0), Expr::int(1), Expr::int(1), Expr::int(2)]).expect("sigscript builds");
-    let result_else = run_bytecode_with_sigscript(compiled.bytecode, sigscript_else);
+    let sigscript_else = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Int(0), ArtifactValue::Int(1), ArtifactValue::Int(1), ArtifactValue::Int(2)],
+    )
+    .expect("sigscript builds");
+    let result_else = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_else);
     assert!(result_else.is_ok(), "else-branch reassignment should leave a clean stack: {}", result_else.unwrap_err());
 }
 
@@ -16107,7 +16326,8 @@ fn struct_if_reassignment_preserves_types_after_merge() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("post-if struct type merge should compile");
+    let compiled =
+        compile_internal_contract(source, &[], CompileOptions::default()).expect("post-if struct type merge should compile");
     let normalized = format_contract_ast(&compiled.ast);
     assert!(normalized.contains("S t = s;"), "merged struct type should still allow assignment after the if: {normalized}");
 }
@@ -16139,7 +16359,8 @@ fn partial_struct_if_reassignment_preserves_types_after_merge() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("post-if partial struct type merge should compile");
+    let compiled =
+        compile_internal_contract(source, &[], CompileOptions::default()).expect("post-if partial struct type merge should compile");
     let normalized = format_contract_ast(&compiled.ast);
     assert!(normalized.contains("S t = s;"), "merged struct type should still allow assignment after the if: {normalized}");
 }
@@ -16170,16 +16391,22 @@ fn struct_if_branch_reassignment_drops_hidden_shadow_bindings() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("struct branch cleanup should compile");
 
-    let sigscript_then = compiled
-        .build_sig_script("main", vec![Expr::int(1), Expr::int(2), Expr::int(3), Expr::int(6), Expr::int(7)])
-        .expect("sigscript builds");
-    let result_then = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_then);
+    let sigscript_then = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Int(1), ArtifactValue::Int(2), ArtifactValue::Int(3), ArtifactValue::Int(6), ArtifactValue::Int(7)],
+    )
+    .expect("sigscript builds");
+    let result_then = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_then);
     assert!(result_then.is_ok(), "then-branch struct cleanup should leave a clean stack: {}", result_then.unwrap_err());
 
-    let sigscript_else = compiled
-        .build_sig_script("main", vec![Expr::int(0), Expr::int(2), Expr::int(3), Expr::int(5), Expr::int(7)])
-        .expect("sigscript builds");
-    let result_else = run_bytecode_with_sigscript(compiled.bytecode, sigscript_else);
+    let sigscript_else = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Int(0), ArtifactValue::Int(2), ArtifactValue::Int(3), ArtifactValue::Int(5), ArtifactValue::Int(7)],
+    )
+    .expect("sigscript builds");
+    let result_else = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_else);
     assert!(result_else.is_ok(), "else-branch struct cleanup should leave a clean stack: {}", result_else.unwrap_err());
 }
 
@@ -16209,16 +16436,22 @@ fn partial_struct_if_branch_reassignment_drops_hidden_shadow_bindings() {
 
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("partial struct branch cleanup should compile");
 
-    let sigscript_then = compiled
-        .build_sig_script("main", vec![Expr::int(1), Expr::int(2), Expr::int(3), Expr::int(6), Expr::int(3)])
-        .expect("sigscript builds");
-    let result_then = run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript_then);
+    let sigscript_then = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Int(1), ArtifactValue::Int(2), ArtifactValue::Int(3), ArtifactValue::Int(6), ArtifactValue::Int(3)],
+    )
+    .expect("sigscript builds");
+    let result_then = run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript_then);
     assert!(result_then.is_ok(), "then-branch partial struct cleanup should leave a clean stack: {}", result_then.unwrap_err());
 
-    let sigscript_else = compiled
-        .build_sig_script("main", vec![Expr::int(0), Expr::int(2), Expr::int(3), Expr::int(2), Expr::int(8)])
-        .expect("sigscript builds");
-    let result_else = run_bytecode_with_sigscript(compiled.bytecode, sigscript_else);
+    let sigscript_else = encode_entry_sig_script(
+        &compiled,
+        "main",
+        &[ArtifactValue::Int(0), ArtifactValue::Int(2), ArtifactValue::Int(3), ArtifactValue::Int(2), ArtifactValue::Int(8)],
+    )
+    .expect("sigscript builds");
+    let result_else = run_bytecode_with_sigscript(bytecode(&compiled), sigscript_else);
     assert!(result_else.is_ok(), "else-branch partial struct cleanup should leave a clean stack: {}", result_else.unwrap_err());
 }
 
@@ -16243,9 +16476,9 @@ contract CounterLoop(int BOUND) {
     let bounds = [4i64, 8i64, 12i64];
     let mut lens = Vec::new();
     for b in bounds {
-        let args = [Expr::int(b)];
+        let args = [b.into()];
         let compiled = compile_contract(SOURCE, &args, CompileOptions::default()).expect("compile succeeds");
-        lens.push(compiled.bytecode.len());
+        lens.push(bytecode(&compiled).len());
     }
 
     assert!(lens[0] < lens[1] && lens[1] < lens[2], "expected monotonic growth, got {lens:?}");
@@ -16283,9 +16516,9 @@ contract StructCounterLoop(int BOUND) {
     let bounds = [4i64, 8i64, 12i64];
     let mut lens = Vec::new();
     for b in bounds {
-        let args = [Expr::int(b)];
+        let args = [b.into()];
         let compiled = compile_contract(SOURCE, &args, CompileOptions::default()).expect("compile succeeds");
-        lens.push(compiled.bytecode.len());
+        lens.push(bytecode(&compiled).len());
     }
 
     assert!(lens[0] < lens[1] && lens[1] < lens[2], "expected monotonic growth, got {lens:?}");
@@ -16323,11 +16556,11 @@ fn validate_output_state_preserves_nested_struct_field_paths() {
 
     let input_compiled = compile_contract(source, &[1.into(), 2.into()], CompileOptions::default()).expect("compile succeeds");
     let output_compiled = compile_contract(source, &[3.into(), 4.into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = input_compiled.build_sig_script("route", vec![]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&input_compiled, "route", &[]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&output_compiled.bytecode);
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
@@ -16422,17 +16655,17 @@ fn validate_output_state_with_template_preserves_nested_struct_field_paths() {
     );
 
     let input_compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile router succeeds");
-    let sigscript = input_compiled.build_sig_script("route", vec![target_hash.into()]).expect("sigscript builds");
-    let sigscript = pay_to_script_hash_signature_script(input_compiled.bytecode.clone(), sigscript).unwrap();
+    let sigscript = encode_entry_sig_script(&input_compiled, "route", &[target_hash.into()]).expect("sigscript builds");
+    let sigscript = pay_to_script_hash_signature_script(bytecode(&input_compiled).clone(), sigscript).unwrap();
     let input = test_input(0, sigscript);
-    let template_input = test_input(1, sigscript_push_bytecode(&target_template_compiled.bytecode));
-    let input_spk = pay_to_script_hash_script(&input_compiled.bytecode);
-    let output_spk = pay_to_script_hash_script(&target_output_compiled.bytecode);
+    let template_input = test_input(1, sigscript_push_bytecode(&bytecode(&target_template_compiled)));
+    let input_spk = pay_to_script_hash_script(&bytecode(&input_compiled));
+    let output_spk = pay_to_script_hash_script(&bytecode(&target_output_compiled));
     let output = TransactionOutput { value: 1000, script_public_key: output_spk, covenant: None };
     let tx = Transaction::new(1, vec![input, template_input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry = UtxoEntry::new(output.value, input_spk, 0, tx.is_coinbase(), None);
     let template_utxo =
-        UtxoEntry::new(output.value, pay_to_script_hash_script(&target_template_compiled.bytecode), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, pay_to_script_hash_script(&bytecode(&target_template_compiled)), 0, tx.is_coinbase(), None);
 
     let result = execute_input(tx, vec![utxo_entry, template_utxo], 0);
     assert!(result.is_ok(), "nested struct fields with the same leaf name should remain distinct by path: {result:?}");
@@ -16458,10 +16691,10 @@ fn blake2b_builtins_lower_and_execute_correctly() {
     );
 
     let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("Blake2b builtins compile");
-    assert!(compiled.bytecode.contains(&OpBlake2b));
-    assert!(compiled.bytecode.contains(&OpBlake2bWithKey));
+    assert!(bytecode(&compiled).contains(&OpBlake2b));
+    assert!(bytecode(&compiled).contains(&OpBlake2bWithKey));
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "Blake2b builtins should execute correctly: {result:?}");
 }
 
@@ -16486,10 +16719,10 @@ fn blake3_builtins_lower_and_execute_correctly() {
     );
 
     let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("Blake3 builtins compile");
-    assert!(compiled.bytecode.contains(&OpBlake3));
-    assert!(compiled.bytecode.contains(&OpBlake3WithKey));
+    assert!(bytecode(&compiled).contains(&OpBlake3));
+    assert!(bytecode(&compiled).contains(&OpBlake3WithKey));
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "Blake3 builtins should call the engine correctly: {result:?}");
 }
 
@@ -16535,14 +16768,14 @@ fn rejects_misaligned_dynamic_array_entrypoint_payload() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("dynamic int array should compile");
-    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode should stringify");
+    let opcodes = script_to_str(&bytecode(&compiled)).expect("compiled bytecode should stringify");
     assert!(opcodes.contains("OpMod"), "dynamic array validation should check payload alignment: {opcodes}");
 
     // Bypass build_sig_script to model an untrusted spender pushing one byte for
     // an int[] whose elements require eight bytes each.
     let sigscript =
         script_builder().add_data_with_push_opcode(&[1]).unwrap().add_data(&dispatch_tag_for(&compiled, "main")).unwrap().drain();
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_err(), "a dynamic int array payload must contain a whole number of elements");
 }
 
@@ -16556,8 +16789,8 @@ fn derived_dynamic_array_length_counts_elements() {
         }
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("dynamic int array slice should compile");
-    let sigscript = compiled.build_sig_script("main", vec![vec![10i64, 20i64].into()]).expect("sigscript builds");
-    let result = run_bytecode_with_sigscript(compiled.bytecode, sigscript);
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[vec![10i64, 20i64].into()]).expect("sigscript builds");
+    let result = run_bytecode_with_sigscript(bytecode(&compiled), sigscript);
     assert!(result.is_ok(), "slice length should be measured in int elements, not encoded bytes: {result:?}");
 }
 
@@ -16589,10 +16822,10 @@ fn allows_fixed_array_cast_with_compatible_encoded_size() {
     "#;
     let compiled = compile_contract(source, &[], CompileOptions::default())
         .expect("fixed arrays with equal encoded sizes should be cast-compatible");
-    let opcodes = script_to_str(&compiled.bytecode).expect("compiled bytecode should stringify");
+    let opcodes = script_to_str(&bytecode(&compiled)).expect("compiled bytecode should stringify");
     assert!(!opcodes.contains("OpNum2Bin"), "an equal-size array cast should remain a passthrough: {opcodes}");
     let dispatch_tag = dispatch_tag_for(&compiled, "main");
-    let result = run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag);
+    let result = run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag);
     assert!(result.is_ok(), "the reinterpreted byte array should preserve the int payload bytes: {result:?}");
 }
 
@@ -16718,7 +16951,7 @@ fn rejects_user_function_with_builtin_name() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(0)], CompileOptions::default())
+    let err = compile_contract(source, &[ArtifactValue::Int(0)], CompileOptions::default())
         .expect_err("user-defined functions must not use builtin names");
     assert!(err.to_string().contains("function name 'validateOutputState' is reserved for a builtin"), "unexpected error: {err}");
     let span = err.span().expect("the reserved function name should be identified");
@@ -16737,7 +16970,7 @@ fn rejects_builtin_names_for_variables() {
     ];
 
     for source in cases {
-        let constructor_args = if source.contains("int sha256") { vec![Expr::int(0)] } else { vec![] };
+        let constructor_args = if source.contains("int sha256") { vec![0.into()] } else { vec![] };
         let err =
             compile_contract(source, &constructor_args, CompileOptions::default()).expect_err("variables must not use builtin names");
         assert!(err.to_string().contains("is reserved for a builtin"), "unexpected error for `{source}`: {err}");
@@ -16749,6 +16982,7 @@ fn rejects_duplicate_declaration_names() {
     let cases = [
         (
             "contract DuplicateCtor(int value, int value) { entry spend() { require(true); } }",
+            vec![1.into(), 2.into()],
             vec![Expr::int(1), Expr::int(2)],
             "value",
             "duplicate contract parameter name 'value'",
@@ -16756,11 +16990,13 @@ fn rejects_duplicate_declaration_names() {
         (
             "contract DuplicateEntry() { entry spend(int value, int value) { require(value == value); } }",
             vec![],
+            vec![],
             "value",
             "duplicate parameter name 'value' in function 'spend'",
         ),
         (
             "contract DuplicateHelper() { function helper(int value, int value) { require(true); } entry spend() { require(true); } }",
+            vec![],
             vec![],
             "value",
             "duplicate parameter name 'value' in function 'helper'",
@@ -16768,12 +17004,13 @@ fn rejects_duplicate_declaration_names() {
         (
             "contract DuplicateConstant() { int constant VALUE = 1; int constant VALUE = 2; entry spend() { require(true); } }",
             vec![],
+            vec![],
             "VALUE",
             "duplicate constant name 'VALUE'",
         ),
     ];
 
-    for (source, constructor_args, duplicate_name, expected_error) in cases {
+    for (source, constructor_args, ast_constructor_args, duplicate_name, expected_error) in cases {
         let source_error = compile_contract(source, &constructor_args, CompileOptions::default())
             .expect_err("source compilation must reject duplicate declarations");
         assert_eq!(source_error.root().to_string(), format!("unsupported feature: {expected_error}"));
@@ -16781,7 +17018,7 @@ fn rejects_duplicate_declaration_names() {
         assert_eq!(&source[span.start..span.end], duplicate_name);
 
         let ast = parse_contract_ast(source).expect("duplicate declarations remain representable in the public AST");
-        let ast_error = compile_contract_ast(&ast, &constructor_args, CompileOptions::default())
+        let ast_error = compile_contract_ast(&ast, &ast_constructor_args, CompileOptions::default())
             .expect_err("public AST compilation must reject duplicate declarations");
         assert_eq!(ast_error.root().to_string(), source_error.root().to_string());
     }
@@ -16895,7 +17132,7 @@ fn compile_and_execute_conformance_assertion(assertion: &str) {
     let source = format!("contract Generated() {{ entry spend() {{ require({assertion}); }} }}");
     let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("generated well-typed program compiles");
     let dispatch_tag = dispatch_tag_for(&compiled, "spend");
-    run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).expect("reference result agrees with local VM");
+    run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).expect("reference result agrees with local VM");
 }
 
 #[test]
@@ -16922,7 +17159,7 @@ fn bounded_metamorphic_variants_preserve_behavior() {
         let source = format!("contract Meta() {{ {helper} entry spend() {{ {body} }} }}");
         let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("metamorphic variant compiles");
         let dispatch_tag = dispatch_tag_for(&compiled, "spend");
-        run_bytecode_with_dispatch_tag(compiled.bytecode, dispatch_tag).expect("metamorphic variant executes");
+        run_bytecode_with_dispatch_tag(bytecode(&compiled), dispatch_tag).expect("metamorphic variant executes");
     }
 }
 
@@ -16930,14 +17167,20 @@ fn bounded_metamorphic_variants_preserve_behavior() {
 fn formatting_and_ast_round_trip_preserve_artifact() {
     let source = "contract RoundTrip(int seed) { int state = seed; entry spend() { require(state == 4); } }";
     let args = [Expr::int(4)];
-    let original = compile_contract(source, &args, CompileOptions::default()).expect("source compiles");
+    let original = compile_contract(source, &[4.into()], CompileOptions::default()).expect("source compiles");
     let ast = parse_contract_ast(source).expect("source parses");
     let formatted = format_contract_ast(&ast);
     let reparsed = parse_contract_ast(&formatted).expect("formatted source parses");
     let from_ast = compile_contract_ast(&reparsed, &args, CompileOptions::default()).expect("public AST path compiles");
-    assert_eq!(original.bytecode, from_ast.bytecode);
-    assert_eq!(original.abi, from_ast.abi);
-    assert_eq!(original.state_layout, from_ast.state_layout);
+    assert_eq!(bytecode(&original), from_ast.bytecode);
+    let original_entries = &single_contract(&original).entries;
+    assert_eq!(original_entries.len(), from_ast.abi.len());
+    for (original_entry, ast_entry) in original_entries.iter().zip(&from_ast.abi) {
+        assert_eq!(original_entry.name, ast_entry.name);
+        assert_eq!(original_entry.dispatch_tag.into_bytes(), ast_entry.dispatch_tag);
+        assert_eq!(original_entry.params.len(), ast_entry.inputs.len());
+    }
+    assert_eq!(state_layout(&original), from_ast.state_layout);
 }
 
 #[test]
@@ -16946,14 +17189,18 @@ fn debug_recording_does_not_change_executable_artifact() {
     let plain = compile_contract(source, &[], CompileOptions::default()).expect("plain compile");
     let debug = compile_contract(source, &[], CompileOptions { record_debug_infos: true, ..CompileOptions::default() })
         .expect("debug compile");
-    assert_eq!(plain.abi, debug.abi);
-    assert_eq!(plain.state_layout, debug.state_layout);
-    assert!(plain.debug_info.is_none());
-    assert!(debug.debug_info.is_some());
+    assert_eq!(single_contract(&plain).entries, single_contract(&debug).entries);
+    assert_eq!(state_layout(&plain), state_layout(&debug));
+    let plain_internal = compile_internal_contract(source, &[], CompileOptions::default()).expect("plain internal compile");
+    let debug_internal =
+        compile_internal_contract(source, &[], CompileOptions { record_debug_infos: true, ..CompileOptions::default() })
+            .expect("debug internal compile");
+    assert!(plain_internal.debug_info.is_none());
+    assert!(debug_internal.debug_info.is_some());
     let dispatch_tag = dispatch_tag_for(&plain, "spend");
-    run_bytecode_with_dispatch_tag(plain.bytecode, dispatch_tag).expect("plain artifact executes");
+    run_bytecode_with_dispatch_tag(bytecode(&plain), dispatch_tag).expect("plain artifact executes");
     let dispatch_tag = dispatch_tag_for(&debug, "spend");
-    run_bytecode_with_dispatch_tag(debug.bytecode, dispatch_tag).expect("debug artifact executes with equivalent semantics");
+    run_bytecode_with_dispatch_tag(bytecode(&debug), dispatch_tag).expect("debug artifact executes with equivalent semantics");
 }
 
 #[test]
@@ -17054,7 +17301,7 @@ fn dynamic_array_abi_rejects_zero_width_elements() {
             }
         }
     "#;
-    let err = compile_contract(constructor_source, &[Expr::bytes(Vec::new())], CompileOptions::default())
+    let err = compile_contract(constructor_source, &[ArtifactValue::Bytes(Vec::new())], CompileOptions::default())
         .expect_err("constructor parameter dimensions must be greater than zero");
     assert!(err.to_string().contains("must be greater than zero"), "unexpected error: {err}");
 }
@@ -17087,7 +17334,7 @@ fn artifact_state_resolution_supports_constructor_sized_arrays() {
         }
     "#;
     let constructor_args = [Expr::int(2), Expr::bytes(vec![0xaa, 0xbb])];
-    let compiled = compile_contract(source, &constructor_args, CompileOptions::default()).expect("contract compiles");
+    let compiled = compile_internal_contract(source, &constructor_args, CompileOptions::default()).expect("contract compiles");
 
     let state = compiled
         .ast
@@ -17110,19 +17357,20 @@ fn artifact_sigscript_builder_supports_constructor_sized_struct_array_fields() {
             }
         }
     "#;
-    let compiled = compile_contract(source, &[Expr::int(3)], CompileOptions::default()).expect("contract compiles");
-    let input = &compiled.entry_by_name("main").expect("entrypoint exists").inputs[0];
-    assert_eq!(input.type_name, "Item[]");
-    assert_eq!(compiled.ast.structs[0].fields[0].type_ref, parse_type_ref("byte[3]").expect("resolved field type parses"));
+    let artifact = sil_abi_artifact(source, &[3.into()]).expect("contract compiles");
+    let input = &artifact.contract("C").and_then(|contract| contract.entry("main")).expect("entrypoint exists").params[0];
+    assert_eq!(input.ty, TypeArtifact::DynamicArray { item: Box::new(TypeArtifact::Struct { name: "Item".to_string() }) });
+    assert_eq!(artifact.states[0].fields[0].ty, TypeArtifact::FixedBytes { len: 3 });
 
-    let json = serde_json::to_string(&compiled).expect("compiled artifact serializes");
-    let compiled: CompiledContract<'_> = serde_json::from_str(&json).expect("compiled artifact deserializes");
-    assert_eq!(compiled.ast.structs[0].fields[0].type_ref, parse_type_ref("byte[3]").expect("resolved field type survives JSON"));
-    let item = struct_object("Item", vec![("data", Expr::bytes(vec![0xaa, 0xbb, 0xcc]))]);
-    let items = Expr::array(parse_type_ref("Item[]").expect("array type parses"), vec![item]);
-    let sigscript = compiled.build_sig_script("main", vec![items]).expect("resolved ABI encodes the valid argument");
+    let json = serde_json::to_string(&artifact).expect("portable artifact serializes");
+    let artifact: SilAbiArtifact = serde_json::from_str(&json).expect("portable artifact deserializes");
+    assert_eq!(artifact.states[0].fields[0].ty, TypeArtifact::FixedBytes { len: 3 });
+    let items =
+        ArtifactValue::Array(vec![ArtifactValue::Object(BTreeMap::from([("data".to_string(), vec![0xaau8, 0xbb, 0xcc].into())]))]);
+    let sigscript = encode_single_entry_sig_script(&artifact, &[items]).expect("resolved ABI encodes the valid argument");
+    let bytecode = artifact.contract("C").expect("contract exists").compiled.bytecode.clone();
 
-    run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect("artifact-built invocation executes");
+    run_bytecode_with_sigscript(bytecode, sigscript).expect("artifact-built invocation executes");
 }
 
 #[test]
@@ -17138,14 +17386,13 @@ fn artifact_sigscript_builder_rejects_wrong_constructor_sized_struct_fields() {
             }
         }
     "#;
-    let compiled = compile_contract(source, &[Expr::int(3)], CompileOptions::default()).expect("contract compiles");
-    let valid = struct_object("Item", vec![("data", Expr::bytes(vec![0xaa, 0xbb, 0xcc]))]);
-    compiled.build_sig_script("main", vec![valid]).expect("the valid constructor-sized struct argument encodes");
+    let artifact = sil_abi_artifact(source, &[3.into()]).expect("contract compiles");
+    let item = |data: Vec<u8>| ArtifactValue::Object(BTreeMap::from([("data".to_string(), ArtifactValue::from(data))]));
+    encode_single_entry_sig_script(&artifact, &[item(vec![0xaa, 0xbb, 0xcc])])
+        .expect("the valid constructor-sized struct argument encodes");
 
     for data in [vec![0xaa, 0xbb], vec![0xaa, 0xbb, 0xcc, 0xdd]] {
-        let malformed = struct_object("Item", vec![("data", Expr::bytes(data))]);
-        compiled
-            .build_sig_script("main", vec![malformed])
+        encode_single_entry_sig_script(&artifact, &[item(data)])
             .expect_err("the resolved ABI must reject an incorrectly sized nested field");
     }
 }
@@ -17199,11 +17446,11 @@ fn append_accepts_a_nested_array_element_as_its_array_source() {
 }
 
 fn execute_handcrafted_p2sh(
-    compiled: &CompiledContract<'_>,
+    compiled: &silverscript_abi::SilAbiArtifact,
     unlocking_prefix: Vec<u8>,
 ) -> Result<(), kaspa_txscript_errors::TxScriptError> {
     let flags = EngineFlags { covenants_enabled: true, ..Default::default() };
-    let signature_script = pay_to_script_hash_signature_script_with_flags(compiled.bytecode.clone(), unlocking_prefix, flags)
+    let signature_script = pay_to_script_hash_signature_script_with_flags(bytecode(compiled).clone(), unlocking_prefix, flags)
         .expect("redeem script push should build");
     let input = TransactionInput::new(
         TransactionOutpoint { transaction_id: TransactionId::from_bytes([1; 32]), index: 0 },
@@ -17212,7 +17459,7 @@ fn execute_handcrafted_p2sh(
         0,
     );
     let spent_output =
-        TransactionOutput { value: 1_000, script_public_key: pay_to_script_hash_script(&compiled.bytecode), covenant: None };
+        TransactionOutput { value: 1_000, script_public_key: pay_to_script_hash_script(&bytecode(compiled)), covenant: None };
     let tx = Transaction::new(1, vec![input.clone()], vec![spent_output.clone()], 0, SubnetworkId::default(), 0, vec![]);
     let utxo = UtxoEntry::new(spent_output.value, spent_output.script_public_key, 0, tx.is_coinbase(), None);
     let populated = PopulatedTransaction::new(&tx, vec![utxo.clone()]);
@@ -17229,7 +17476,7 @@ fn execute_handcrafted_p2sh(
     vm.execute()
 }
 
-fn compile_sigscript_boundary_contract() -> CompiledContract<'static> {
+fn compile_sigscript_boundary_contract() -> silverscript_abi::SilAbiArtifact {
     let source = r#"
         contract Boundary(int committed) {
             int stored = committed;
@@ -17241,10 +17488,10 @@ fn compile_sigscript_boundary_contract() -> CompiledContract<'static> {
             }
         }
     "#;
-    compile_contract(source, &[Expr::int(9)], CompileOptions::default()).expect("boundary contract compiles")
+    compile_contract(source, &[ArtifactValue::Int(9)], CompileOptions::default()).expect("boundary contract compiles")
 }
 
-fn valid_sigscript_boundary_prefix(compiled: &CompiledContract<'_>) -> Vec<u8> {
+fn valid_sigscript_boundary_prefix(compiled: &silverscript_abi::SilAbiArtifact) -> Vec<u8> {
     script_builder().add_i64(11).unwrap().add_i64(22).unwrap().add_data(&dispatch_tag_for(compiled, "main")).unwrap().drain()
 }
 
@@ -17363,10 +17610,10 @@ fn runtime_empty_loop_with_extreme_reversed_bounds_matches_constant_lowering() {
         }
     "#;
     let compiled = compile_contract(runtime_source, &[], CompileOptions::default()).expect("runtime-bound contract compiles");
-    let sigscript =
-        compiled.build_sig_script("main", vec![Expr::int(i64::MAX), Expr::int(-i64::MAX)]).expect("runtime sigscript builds");
-    let err =
-        run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect_err("the equivalent runtime range subtraction must overflow");
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Int(i64::MAX), ArtifactValue::Int(-i64::MAX)])
+        .expect("runtime sigscript builds");
+    let err = run_bytecode_with_sigscript(bytecode(&compiled), sigscript)
+        .expect_err("the equivalent runtime range subtraction must overflow");
     assert!(matches!(err, kaspa_txscript_errors::TxScriptError::NumberTooBig(_)), "unexpected runtime error: {err:?}");
 }
 
@@ -17463,21 +17710,20 @@ fn signature_script_builder_requires_explicit_byte_values() {
     let compiled = compile_contract(source, &[], CompileOptions::default()).expect("byte contract compiles");
 
     for value in [0, 0x80, 0xff] {
-        let err = compiled
-            .build_sig_script("main", vec![Expr::int(value)])
+        let err = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Int(value)])
             .expect_err("integer AST values must not be reinterpreted as ABI bytes");
-        assert!(err.to_string().contains("expects byte"), "unexpected error for {value:#04x}: {err}");
+        assert!(err.to_string().contains("expected byte"), "unexpected error for {value:#04x}: {err}");
     }
 
-    let sigscript = compiled.build_sig_script("main", vec![Expr::byte(0xff)]).expect("an explicit byte value builds");
-    run_bytecode_with_sigscript(compiled.bytecode.clone(), sigscript).expect("the explicit byte invocation executes");
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[ArtifactValue::Byte(0xff)]).expect("an explicit byte value builds");
+    run_bytecode_with_sigscript(bytecode(&compiled).clone(), sigscript).expect("the explicit byte invocation executes");
 
-    let contextual_array = Expr::array(parse_type_ref("byte[]").expect("byte array type parses"), vec![Expr::int(1)]);
-    let err = compiled
-        .build_sig_script("array", vec![contextual_array])
-        .expect_err("integer AST elements must not be reinterpreted as ABI bytes");
-    assert!(err.to_string().contains("expects byte[]"), "unexpected array error: {err}");
+    let contextual_array = ArtifactValue::Array(vec![1.into()]);
+    let err = encode_entry_sig_script(&compiled, "array", &[contextual_array])
+        .expect_err("integer artifact values must not be reinterpreted as ABI bytes");
+    assert!(err.to_string().contains("expected bytes"), "unexpected array error: {err}");
 
-    let sigscript = compiled.build_sig_script("array", vec![Expr::dynamic_bytes(vec![1])]).expect("explicit byte elements build");
-    run_bytecode_with_sigscript(compiled.bytecode, sigscript).expect("the explicit byte-array invocation executes");
+    let sigscript =
+        encode_entry_sig_script(&compiled, "array", &[ArtifactValue::Bytes(vec![1])]).expect("explicit byte elements build");
+    run_bytecode_with_sigscript(bytecode(&compiled), sigscript).expect("the explicit byte-array invocation executes");
 }

--- a/silverscript-lang/tests/consensus_time_tests.rs
+++ b/silverscript-lang/tests/consensus_time_tests.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use kaspa_consensus::config::ConfigBuilder;
 use kaspa_consensus::consensus::test_consensus::TestConsensus;
 use kaspa_consensus::params::{DEVNET_PARAMS, ForkActivation};
@@ -14,8 +16,10 @@ use kaspa_consensus_core::tx::{
     UtxoEntry,
 };
 use kaspa_muhash::MuHash;
-use silverscript_lang::ast::Expr;
-use silverscript_lang::compiler::{CompileOptions, compile_contract};
+use silverscript_abi::ArtifactValue;
+use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
+
+use common::{bytecode, encode_entry_sig_script, encode_single_entry_sig_script};
 
 const FUNDING_AMOUNT: u64 = 10_000_000_000;
 const AGE_OUTPUT_AMOUNT: u64 = 1_900_000_000;
@@ -57,11 +61,11 @@ async fn compiled_lock_domains_are_enforced_in_actual_consensus_blocks() {
     // Compile one contract for each lock domain. The tests below spend their
     // outputs in real consensus blocks rather than inspecting emitted opcodes.
     let age_source = "contract Age() { entry main(int age) { require(this.ageDaa >= age); } }";
-    let age = compile_contract(age_source, &[], CompileOptions::default()).expect("age contract compiles");
+    let age = sil_abi_artifact_with_options(age_source, &[], CompileOptions::default()).expect("age contract compiles");
     let time_source = "contract TimeLock() { entry main(temporal timestamp) { require(tx.time >= timestamp); } }";
-    let time = compile_contract(time_source, &[], CompileOptions::default()).expect("time contract compiles");
+    let time = sil_abi_artifact_with_options(time_source, &[], CompileOptions::default()).expect("time contract compiles");
     let daa_source = "contract DaaLock() { entry main(int daa) { require(tx.daa >= daa); } }";
-    let daa = compile_contract(daa_source, &[], CompileOptions::default()).expect("DAA contract compiles");
+    let daa = sil_abi_artifact_with_options(daa_source, &[], CompileOptions::default()).expect("DAA contract compiles");
 
     let funding_outpoint = TransactionOutpoint::new(TransactionId::from_bytes([1; 32]), 0);
     let age_overflow_outpoint = TransactionOutpoint::new(TransactionId::from_bytes([2; 32]), 0);
@@ -72,13 +76,16 @@ async fn compiled_lock_domains_are_enforced_in_actual_consensus_blocks() {
     // invalid candidate could make a later assertion depend on that candidate.
     let mut initial_utxos = vec![
         (funding_outpoint, UtxoEntry::new(FUNDING_AMOUNT, ScriptPublicKey::from_vec(0, vec![0x51]), 0, false, None)),
-        (age_overflow_outpoint, UtxoEntry::new(FUNDING_AMOUNT, ScriptPublicKey::new(0, age.bytecode.clone().into()), 0, false, None)),
+        (
+            age_overflow_outpoint,
+            UtxoEntry::new(FUNDING_AMOUNT, ScriptPublicKey::new(0, bytecode(&age).clone().into()), 0, false, None),
+        ),
     ];
     initial_utxos.extend(daa_outpoints.iter().copied().map(|outpoint| {
-        (outpoint, UtxoEntry::new(FUNDING_AMOUNT, ScriptPublicKey::new(0, daa.bytecode.clone().into()), 0, false, None))
+        (outpoint, UtxoEntry::new(FUNDING_AMOUNT, ScriptPublicKey::new(0, bytecode(&daa).clone().into()), 0, false, None))
     }));
     initial_utxos.extend(time_outpoints.iter().copied().map(|outpoint| {
-        (outpoint, UtxoEntry::new(FUNDING_AMOUNT, ScriptPublicKey::new(0, time.bytecode.clone().into()), 0, false, None))
+        (outpoint, UtxoEntry::new(FUNDING_AMOUNT, ScriptPublicKey::new(0, bytecode(&time).clone().into()), 0, false, None))
     }));
 
     let config = ConfigBuilder::new(DEVNET_PARAMS)
@@ -112,7 +119,7 @@ async fn compiled_lock_domains_are_enforced_in_actual_consensus_blocks() {
     let mut funding_tx = Transaction::new(
         0,
         vec![TransactionInput::new(funding_outpoint, vec![], 0, 0)],
-        (0..5).map(|_| TransactionOutput::new(AGE_OUTPUT_AMOUNT, ScriptPublicKey::new(0, age.bytecode.clone().into()))).collect(),
+        (0..5).map(|_| TransactionOutput::new(AGE_OUTPUT_AMOUNT, ScriptPublicKey::new(0, bytecode(&age).clone().into()))).collect(),
         0,
         SUBNETWORK_ID_NATIVE,
         0,
@@ -129,7 +136,7 @@ async fn compiled_lock_domains_are_enforced_in_actual_consensus_blocks() {
     let funding_daa_score = consensus.get_header(funding_block_hash).unwrap().daa_score;
     assert_eq!(funding_daa_score, config.genesis.daa_score + 4, "the funding transaction must be in the fifth post-genesis block");
 
-    let age_sigscript = age.build_sig_script("main", vec![Expr::int(4)]).expect("age sigscript builds");
+    let age_sigscript = encode_single_entry_sig_script(&age, &[ArtifactValue::Int(4)]).expect("age sigscript builds");
     let miner_data = MinerData::new(ScriptPublicKey::from_vec(0, vec![]), vec![]);
 
     // At ages 0, 1, 2, and 3, append the spend to an otherwise valid candidate
@@ -189,7 +196,7 @@ async fn compiled_lock_domains_are_enforced_in_actual_consensus_blocks() {
     let daa_start = consensus.get_header(tip).unwrap().daa_score;
     let daa_target = daa_start + 4;
     assert!(daa_target < kaspa_txscript::LOCK_TIME_THRESHOLD);
-    let daa_sigscript = daa.build_sig_script("main", vec![Expr::int(daa_target as i64)]).expect("DAA sigscript builds");
+    let daa_sigscript = encode_entry_sig_script(&daa, "main", &[ArtifactValue::Int(daa_target as i64)]).expect("DAA sigscript builds");
 
     // Candidate blocks at target - 4 through target - 1 must all fail. Add one
     // valid empty block after each attempt to advance the chain one DAA step.
@@ -224,8 +231,8 @@ async fn compiled_lock_domains_are_enforced_in_actual_consensus_blocks() {
     // Equality remains locked because finality requires lock_time < median time.
     let locked_time_millis = consensus.get_virtual_past_median_time();
     assert!(locked_time_millis >= kaspa_txscript::LOCK_TIME_THRESHOLD);
-    let locked_time_sigscript =
-        time.build_sig_script("main", vec![Expr::temporal(locked_time_millis as i64)]).expect("locked time sigscript builds");
+    let locked_time_sigscript = encode_entry_sig_script(&time, "main", &[ArtifactValue::Int(locked_time_millis as i64)])
+        .expect("locked time sigscript builds");
     let premature_time_tx = spending_transaction(time_outpoints[0], locked_time_sigscript, 0, locked_time_millis);
     let mut premature_time_block = consensus.build_utxo_valid_block_with_parents(300.into(), vec![tip], miner_data.clone(), vec![]);
     premature_time_block.transactions.push(premature_time_tx);
@@ -238,8 +245,8 @@ async fn compiled_lock_domains_are_enforced_in_actual_consensus_blocks() {
     // millisecond—not second—granularity end to end.
     let unlocked_time_millis = locked_time_millis - 1;
     assert_eq!(locked_time_millis - unlocked_time_millis, 1, "the acceptance boundary must be one millisecond wide");
-    let unlocked_time_sigscript =
-        time.build_sig_script("main", vec![Expr::temporal(unlocked_time_millis as i64)]).expect("unlocked time sigscript builds");
+    let unlocked_time_sigscript = encode_entry_sig_script(&time, "main", &[ArtifactValue::Int(unlocked_time_millis as i64)])
+        .expect("unlocked time sigscript builds");
     let time_tx = spending_transaction(time_outpoints[1], unlocked_time_sigscript, 0, unlocked_time_millis);
     let mut time_tx = MutableTransaction::from_tx(time_tx);
     consensus.validate_mempool_transaction(&mut time_tx, &TransactionValidationArgs::default()).unwrap();
@@ -250,7 +257,7 @@ async fn compiled_lock_domains_are_enforced_in_actual_consensus_blocks() {
 
     // Finally, prove the compiled this.ageDaa runtime guard also survives the
     // full consensus path: 2^32 is rejected even when supplied dynamically.
-    let overflow_sigscript = age.build_sig_script("main", vec![Expr::int(1_i64 << 32)]).expect("age sigscript builds");
+    let overflow_sigscript = encode_entry_sig_script(&age, "main", &[ArtifactValue::Int(1_i64 << 32)]).expect("age sigscript builds");
     let mut overflow_tx = MutableTransaction::from_tx(spending_transaction(age_overflow_outpoint, overflow_sigscript, 0, 0));
     let _ = consensus.validate_mempool_transaction(&mut overflow_tx, &TransactionValidationArgs::default());
     let overflow_tx = (*overflow_tx.tx).clone();

--- a/silverscript-lang/tests/consensus_time_tests.rs
+++ b/silverscript-lang/tests/consensus_time_tests.rs
@@ -17,7 +17,7 @@ use kaspa_consensus_core::tx::{
 };
 use kaspa_muhash::MuHash;
 use silverscript_abi::ArtifactValue;
-use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
+use silverscript_lang::compiler::{CompileOptions, compile_to_sil_abi_artifact_with_options};
 
 use common::{bytecode, encode_entry_sig_script, encode_single_entry_sig_script};
 
@@ -61,11 +61,11 @@ async fn compiled_lock_domains_are_enforced_in_actual_consensus_blocks() {
     // Compile one contract for each lock domain. The tests below spend their
     // outputs in real consensus blocks rather than inspecting emitted opcodes.
     let age_source = "contract Age() { entry main(int age) { require(this.ageDaa >= age); } }";
-    let age = sil_abi_artifact_with_options(age_source, &[], CompileOptions::default()).expect("age contract compiles");
+    let age = compile_to_sil_abi_artifact_with_options(age_source, &[], CompileOptions::default()).expect("age contract compiles");
     let time_source = "contract TimeLock() { entry main(temporal timestamp) { require(tx.time >= timestamp); } }";
-    let time = sil_abi_artifact_with_options(time_source, &[], CompileOptions::default()).expect("time contract compiles");
+    let time = compile_to_sil_abi_artifact_with_options(time_source, &[], CompileOptions::default()).expect("time contract compiles");
     let daa_source = "contract DaaLock() { entry main(int daa) { require(tx.daa >= daa); } }";
-    let daa = sil_abi_artifact_with_options(daa_source, &[], CompileOptions::default()).expect("DAA contract compiles");
+    let daa = compile_to_sil_abi_artifact_with_options(daa_source, &[], CompileOptions::default()).expect("DAA contract compiles");
 
     let funding_outpoint = TransactionOutpoint::new(TransactionId::from_bytes([1; 32]), 0);
     let age_overflow_outpoint = TransactionOutpoint::new(TransactionId::from_bytes([2; 32]), 0);

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -4,7 +4,8 @@ use kaspa_txscript::opcodes::codes::{OpAuthOutputCount, OpCovInputCount, OpCovIn
 use silverscript_abi::{ArtifactValue, SilAbiArtifact, TypeArtifact};
 use silverscript_lang::ast::Expr;
 use silverscript_lang::compiler::{
-    CompileOptions, compile_contract, generated_covenant_auth_entrypoint_name, compile_to_sil_abi_artifact, compile_to_sil_abi_artifact_with_options,
+    CompileOptions, compile_contract, compile_to_sil_abi_artifact, compile_to_sil_abi_artifact_with_options,
+    generated_covenant_auth_entrypoint_name,
 };
 
 use common::{build_sig_script_for_covenant_decl, bytecode, encode_entry_sig_script, single_contract};
@@ -62,8 +63,7 @@ fn lowers_cov_covenant_to_leader_and_delegate_entrypoints() {
         }
     "#;
 
-    let compiled =
-        compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
     let abi = compile_to_sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
     let abi_names: Vec<&str> = artifact.entries.iter().map(|entry| entry.name.as_str()).collect();
@@ -85,8 +85,7 @@ fn infers_cov_binding_from_from_greater_than_one_when_binding_omitted() {
         }
     "#;
 
-    let compiled =
-        compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
     let abi = compile_to_sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
     let abi_names: Vec<&str> = artifact.entries.iter().map(|entry| entry.name.as_str()).collect();
@@ -268,8 +267,8 @@ fn lowers_fanout_sugar_to_auth_with_to_bound() {
         }
     "#;
 
-    let compiled =
-        compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default())
+        .expect("compile succeeds");
     let artifact = single_contract(&compiled);
     assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("split"));
     assert!(bytecode(&compiled).contains(&OpAuthOutputCount));
@@ -301,8 +300,8 @@ fn rejects_singleton_sugar_with_from_or_to_arguments() {
         }
     "#;
 
-    let err =
-        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("singleton sugar should reject from/to");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        .expect_err("singleton sugar should reject from/to");
     assert!(err.to_string().contains("covenant.singleton is sugar and does not accept 'from' or 'to' arguments"));
 }
 
@@ -317,7 +316,8 @@ fn rejects_auth_covenant_with_from_not_equal_one() {
         }
     "#;
 
-    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("auth binding must require from=1");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        .expect_err("auth binding must require from=1");
     assert!(err.to_string().contains("binding=auth requires from = 1"));
 }
 
@@ -332,8 +332,8 @@ fn rejects_cov_covenant_groups_multiple_for_now() {
         }
     "#;
 
-    let err =
-        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("cov groups=multiple should be rejected");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        .expect_err("cov groups=multiple should be rejected");
     assert!(err.to_string().contains("binding=cov with groups=multiple is not supported yet"));
 }
 
@@ -515,8 +515,9 @@ fn rejects_termination_allowed_for_non_singleton() {
         }
     "#;
 
-    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3), ArtifactValue::Int(10)], CompileOptions::default())
-        .expect_err("termination=allowed should be singleton-only");
+    let err =
+        compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3), ArtifactValue::Int(10)], CompileOptions::default())
+            .expect_err("termination=allowed should be singleton-only");
     assert!(err.to_string().contains("termination is only supported for singleton covenants"));
 }
 
@@ -533,8 +534,9 @@ fn rejects_termination_disallowed_for_non_singleton() {
         }
     "#;
 
-    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3), ArtifactValue::Int(10)], CompileOptions::default())
-        .expect_err("termination arg should be singleton-only regardless of value");
+    let err =
+        compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3), ArtifactValue::Int(10)], CompileOptions::default())
+            .expect_err("termination arg should be singleton-only regardless of value");
     assert!(err.to_string().contains("termination is only supported for singleton covenants"));
 }
 
@@ -566,7 +568,8 @@ fn rejects_transition_mode_without_return_values() {
         }
     "#;
 
-    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("transition policy must return values");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        .expect_err("transition policy must return values");
     assert!(err.to_string().contains("transition mode policy functions must declare return values"));
 }
 
@@ -581,8 +584,8 @@ fn rejects_verification_mode_with_return_values() {
         }
     "#;
 
-    let err =
-        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("verification policy must not return values");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        .expect_err("verification policy must not return values");
     assert!(err.to_string().contains("verification mode policy functions must not declare return values"));
 }
 
@@ -619,8 +622,9 @@ fn rejects_mixed_auth_and_cov_covenant_declarations() {
         }
     "#;
 
-    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
-        .expect_err("auth-bound declarations must not coexist with generated delegates");
+    let err =
+        compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
+            .expect_err("auth-bound declarations must not coexist with generated delegates");
     let message = err.to_string();
     assert!(message.contains("binding=cov"), "unexpected error: {message}");
     assert!(message.contains("merge"), "unexpected error: {message}");
@@ -644,8 +648,9 @@ fn rejects_mixed_inferred_auth_and_cov_covenant_declarations() {
         }
     "#;
 
-    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
-        .expect_err("inferred auth and cov declarations must not coexist");
+    let err =
+        compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
+            .expect_err("inferred auth and cov declarations must not coexist");
     assert!(err.to_string().contains("cannot use binding=auth"), "unexpected error: {err}");
 }
 
@@ -664,8 +669,9 @@ fn leader_contract_rejects_unacknowledged_manual_entrypoint() {
         }
     "#;
 
-    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
-        .expect_err("manual entrypoints in leader contracts require acknowledgment");
+    let err =
+        compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
+            .expect_err("manual entrypoints in leader contracts require acknowledgment");
     let message = err.to_string();
     assert!(message.contains("manual entrypoint 'recover'"), "unexpected error: {message}");
     assert!(message.contains("manual_entrypoint_in_leader_contract"), "unexpected error: {message}");
@@ -863,7 +869,8 @@ fn rejects_duplicate_delegate_bodies() {
         }
     "#;
 
-    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("duplicate delegate bodies must fail");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        .expect_err("duplicate delegate bodies must fail");
     assert!(err.to_string().contains("more than one #[covenant.delegate] body"), "unexpected error: {err}");
 }
 
@@ -876,7 +883,8 @@ fn rejects_delegate_body_without_cov_bound_declaration() {
         }
     "#;
 
-    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("unused delegate body must fail");
+    let err =
+        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("unused delegate body must fail");
     assert!(err.to_string().contains("requires at least one binding=cov"), "unexpected error: {err}");
 }
 
@@ -892,8 +900,7 @@ fn delegate_and_leader_internal_policy_names_use_disjoint_namespaces() {
         }
     "#;
 
-    let compiled =
-        compile_contract(source, &[], CompileOptions::default()).expect("internal policy names do not collide");
+    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("internal policy names do not collide");
     assert!(compiled.ast.functions.iter().any(|function| function.name == "__covenant_policy_delegate_authorize"));
     assert!(compiled.ast.functions.iter().any(|function| function.name == "__covenant_delegate_policy_authorize"));
 }
@@ -914,7 +921,8 @@ fn rejects_direct_calls_to_the_delegate_body() {
         }
     "#;
 
-    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("delegate bodies are compiler hooks");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        .expect_err("delegate bodies are compiler hooks");
     let message = err.to_string();
     assert!(message.contains("covenant-annotated function 'authorizeDelegate' cannot be called directly"));
     assert!(message.contains("extract shared logic into an unannotated helper function"));
@@ -936,7 +944,8 @@ fn rejects_direct_calls_to_a_covenant_policy() {
         }
     "#;
 
-    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("covenant policies are compiler hooks");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        .expect_err("covenant policies are compiler hooks");
     let message = err.to_string();
     assert!(message.contains("covenant-annotated function 'transferPolicy' cannot be called directly"));
     assert!(message.contains("extract shared logic into an unannotated helper function"));
@@ -988,8 +997,8 @@ fn rejects_invalid_delegate_body_signatures() {
     ];
 
     for source in cases {
-        let err =
-            compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("invalid delegate signature must fail");
+        let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+            .expect_err("invalid delegate signature must fail");
         assert!(err.to_string().contains("#[covenant.delegate]"), "unexpected error: {err}");
     }
 }
@@ -1009,8 +1018,8 @@ fn rejects_generated_public_name_collision() {
         }
     "#;
 
-    let err =
-        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("generated public name collision must fail");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        .expect_err("generated public name collision must fail");
     assert!(err.to_string().contains("duplicate function name 'transfer'"), "unexpected error: {err}");
 }
 
@@ -1056,7 +1065,7 @@ fn rejects_per_leader_delegate_policy_selection() {
         }
     "#;
 
-    let err =
-        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("leaders cannot select delegate policies");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        .expect_err("leaders cannot select delegate policies");
     assert!(err.to_string().contains("unknown covenant attribute argument 'delegate_policy'"), "unexpected error: {err}");
 }

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -25,7 +25,7 @@ fn lowers_auth_covenant_declaration_to_hidden_entrypoint_name() {
     let abi = compile_to_sil_abi_artifact(source, &[3.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
     assert_eq!(artifact.entries.len(), 1);
-    assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("spend"));
+    assert!(artifact.entries.contains_key(&generated_covenant_auth_entrypoint_name("spend")));
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_spend" && !f.entrypoint));
     assert!(compiled.ast.functions.iter().any(|f| f.name == generated_covenant_auth_entrypoint_name("spend") && f.entrypoint));
     assert!(compiled.bytecode.clone().contains(&OpAuthOutputCount));
@@ -46,7 +46,7 @@ fn infers_auth_binding_from_from_equal_one_when_binding_omitted() {
     let abi = compile_to_sil_abi_artifact(source, &[3.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
     assert_eq!(artifact.entries.len(), 1);
-    assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("spend"));
+    assert!(artifact.entries.contains_key(&generated_covenant_auth_entrypoint_name("spend")));
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_spend" && !f.entrypoint));
     assert!(compiled.ast.functions.iter().any(|f| f.name == generated_covenant_auth_entrypoint_name("spend") && f.entrypoint));
     assert!(compiled.bytecode.clone().contains(&OpAuthOutputCount));
@@ -66,8 +66,8 @@ fn lowers_cov_covenant_to_leader_and_delegate_entrypoints() {
     let compiled = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
     let abi = compile_to_sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
-    let abi_names: Vec<&str> = artifact.entries.iter().map(|entry| entry.name.as_str()).collect();
-    assert_eq!(abi_names, vec!["__leader_transition_ok", "__delegate"]);
+    let abi_names: Vec<&str> = artifact.entries.keys().map(String::as_str).collect();
+    assert_eq!(abi_names, vec!["__delegate", "__leader_transition_ok"]);
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_transition_ok" && !f.entrypoint));
     assert!(compiled.bytecode.clone().contains(&OpCovInputCount));
     assert!(compiled.bytecode.clone().contains(&OpCovOutputCount));
@@ -88,8 +88,8 @@ fn infers_cov_binding_from_from_greater_than_one_when_binding_omitted() {
     let compiled = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
     let abi = compile_to_sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
-    let abi_names: Vec<&str> = artifact.entries.iter().map(|entry| entry.name.as_str()).collect();
-    assert_eq!(abi_names, vec!["__leader_transition_ok", "__delegate"]);
+    let abi_names: Vec<&str> = artifact.entries.keys().map(String::as_str).collect();
+    assert_eq!(abi_names, vec!["__delegate", "__leader_transition_ok"]);
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_transition_ok" && !f.entrypoint));
     assert!(compiled.bytecode.clone().contains(&OpCovInputCount));
     assert!(compiled.bytecode.clone().contains(&OpCovOutputCount));
@@ -252,7 +252,7 @@ fn lowers_singleton_sugar_to_auth_one_to_one_defaults() {
 
     let compiled = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("compile succeeds");
     let artifact = single_contract(&compiled);
-    assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("spend"));
+    assert!(artifact.entries.contains_key(&generated_covenant_auth_entrypoint_name("spend")));
     assert!(bytecode(&compiled).contains(&OpAuthOutputCount));
 }
 
@@ -270,7 +270,7 @@ fn lowers_fanout_sugar_to_auth_with_to_bound() {
     let compiled = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default())
         .expect("compile succeeds");
     let artifact = single_contract(&compiled);
-    assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("split"));
+    assert!(artifact.entries.contains_key(&generated_covenant_auth_entrypoint_name("split")));
     assert!(bytecode(&compiled).contains(&OpAuthOutputCount));
 }
 
@@ -723,11 +723,11 @@ fn allows_multiple_cov_covenant_declarations() {
         .expect("multiple cov-bound declarations compile");
     let abi = compile_to_sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
-    let abi_names: Vec<&str> = artifact.entries.iter().map(|entry| entry.name.as_str()).collect();
-    assert_eq!(abi_names, vec!["__leader_merge", "__leader_rebalance", "__delegate"]);
+    let abi_names: Vec<&str> = artifact.entries.keys().map(String::as_str).collect();
+    assert_eq!(abi_names, vec!["__delegate", "__leader_merge", "__leader_rebalance"]);
     assert_eq!(artifact.cov_binding_leader_decl_entry("merge"), artifact.entry("__leader_merge"));
     assert_eq!(artifact.cov_binding_leader_decl_entry("rebalance"), artifact.entry("__leader_rebalance"));
-    assert_eq!(artifact.delegate_entry_abi.as_ref(), artifact.entry("__delegate"));
+    assert_eq!(artifact.delegate_entry_abi.as_deref(), Some("__delegate"));
 
     let merge_delegate = build_sig_script_for_covenant_decl(&compiled, "merge", vec![], Default::default())
         .expect("merge routes to the shared delegate");
@@ -759,11 +759,11 @@ fn portable_abi_preserves_covenant_declaration_and_delegate_entries() {
     let decoded: SilAbiArtifact = serde_json::from_str(&json).expect("portable covenant ABI deserializes");
     let contract = decoded.contract("Decls").expect("contract exists");
 
-    assert_eq!(contract.cov_decl_to_abi["merge"].name, "__leader_merge");
-    assert_eq!(contract.cov_decl_to_abi["rebalance"].name, "__leader_rebalance");
-    assert_eq!(contract.delegate_entry_abi.as_ref().expect("delegate entry exists").name, "__delegate");
-    assert_eq!(contract.cov_binding_leader_decl_entry("merge").expect("leader entry resolves").name, "__leader_merge");
-    assert_eq!(contract.delegate_entry_abi.as_ref().expect("delegate entry resolves").name, "__delegate");
+    assert_eq!(contract.cov_decl_to_abi["merge"], "__leader_merge");
+    assert_eq!(contract.cov_decl_to_abi["rebalance"], "__leader_rebalance");
+    assert_eq!(contract.delegate_entry_abi.as_deref(), Some("__delegate"));
+    assert_eq!(contract.cov_binding_leader_decl_entry("merge"), contract.entry("__leader_merge"));
+    assert_eq!(contract.covenant_decl_entry("merge", false), contract.entry("__delegate"));
 }
 
 #[test]
@@ -807,7 +807,7 @@ fn lowers_kcc20_shaped_public_names_and_shared_delegate_body() {
     let abi = artifact
         .entries
         .iter()
-        .map(|entry| (entry.name.as_str(), entry.params.iter().map(|input| &input.ty).collect::<Vec<_>>()))
+        .map(|(name, entry)| (name.as_str(), entry.params.iter().map(|input| &input.ty).collect::<Vec<_>>()))
         .collect::<Vec<_>>();
     assert_eq!(
         abi,
@@ -833,7 +833,7 @@ fn lowers_kcc20_shaped_public_names_and_shared_delegate_body() {
     let direct = encode_entry_sig_script(&compiled, "transfer_delegator", &delegate_args).expect("public delegate sigscript builds");
     assert_eq!(routed, direct);
     assert_eq!(artifact.cov_binding_leader_decl_entry("transferPolicy"), artifact.entry("transfer"));
-    assert_eq!(artifact.delegate_entry_abi.as_ref(), artifact.entry("transfer_delegator"));
+    assert_eq!(artifact.delegate_entry_abi.as_deref(), Some("transfer_delegator"));
 }
 
 #[test]
@@ -849,8 +849,8 @@ fn supports_public_name_override_for_auth_bound_declaration() {
 
     let artifact = compile_to_sil_abi_artifact(source, &[]).expect("portable auth ABI compiles");
     let contract = artifact.contract("Decls").expect("contract exists");
-    assert_eq!(contract.entries[0].name, "spend");
-    assert_eq!(contract.auth_decl_entry("spendPolicy").expect("auth entry resolves").name, "spend");
+    assert!(contract.entries.contains_key("spend"));
+    assert_eq!(contract.auth_decl_entry("spendPolicy"), contract.entry("spend"));
     assert_eq!(contract.delegate_entry_abi, None);
 }
 

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -1,6 +1,7 @@
 use kaspa_txscript::opcodes::codes::{OpAuthOutputCount, OpCovInputCount, OpCovInputIdx, OpCovOutputCount, OpInputCovenantId};
+use silverscript_abi::{ArtifactValue, SilAbiArtifact};
 use silverscript_lang::ast::Expr;
-use silverscript_lang::compiler::{CompileOptions, compile_contract, generated_covenant_auth_entrypoint_name};
+use silverscript_lang::compiler::{CompileOptions, compile_contract, generated_covenant_auth_entrypoint_name, sil_abi_artifact};
 
 #[test]
 fn lowers_auth_covenant_declaration_to_hidden_entrypoint_name() {
@@ -703,6 +704,34 @@ fn allows_multiple_cov_covenant_declarations() {
 }
 
 #[test]
+fn portable_abi_preserves_covenant_declaration_and_delegate_entries() {
+    let source = r#"
+        contract Decls(int max_ins, int max_outs) {
+            #[covenant(binding = cov, from = max_ins, to = max_outs)]
+            function merge(int nonce) {
+                require(nonce >= 0);
+            }
+
+            #[covenant(binding = cov, from = max_ins, to = max_outs)]
+            function rebalance(int nonce) {
+                require(nonce >= 0);
+            }
+        }
+    "#;
+
+    let artifact = sil_abi_artifact(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)]).expect("portable covenant ABI compiles");
+    let json = serde_json::to_string(&artifact).expect("portable covenant ABI serializes");
+    let decoded: SilAbiArtifact = serde_json::from_str(&json).expect("portable covenant ABI deserializes");
+    let contract = decoded.contract("Decls").expect("contract exists");
+
+    assert_eq!(contract.cov_decl_to_abi["merge"].name, "__leader_merge");
+    assert_eq!(contract.cov_decl_to_abi["rebalance"].name, "__leader_rebalance");
+    assert_eq!(contract.delegate_entry_abi.as_ref().expect("delegate entry exists").name, "__delegate");
+    assert_eq!(contract.cov_binding_leader_decl_entry("merge").expect("leader entry resolves").name, "__leader_merge");
+    assert_eq!(contract.delegate_entry_abi.as_ref().expect("delegate entry resolves").name, "__delegate");
+}
+
+#[test]
 fn lowers_kcc20_shaped_public_names_and_shared_delegate_body() {
     let source = r#"
         contract Token(byte[1] initial_owner, int initial_amount) {
@@ -777,6 +806,10 @@ fn supports_public_name_override_for_auth_bound_declaration() {
     assert_eq!(compiled.cov_decl_to_abi.get("spendPolicy"), compiled.entry_by_name("spend"));
     assert_eq!(compiled.delegate_entry_abi, None);
     assert_eq!(compiled.covenant_decl_entrypoint_name("spendPolicy", false), Some("spend"));
+
+    let artifact = sil_abi_artifact(source, &[]).expect("portable auth ABI compiles");
+    let contract = artifact.contract("Decls").expect("contract exists");
+    assert_eq!(contract.auth_decl_entry("spendPolicy").expect("auth entry resolves").name, "spend");
 }
 
 #[test]

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -4,7 +4,7 @@ use kaspa_txscript::opcodes::codes::{OpAuthOutputCount, OpCovInputCount, OpCovIn
 use silverscript_abi::{ArtifactValue, SilAbiArtifact, TypeArtifact};
 use silverscript_lang::ast::Expr;
 use silverscript_lang::compiler::{
-    CompileOptions, compile_contract, generated_covenant_auth_entrypoint_name, sil_abi_artifact, sil_abi_artifact_with_options,
+    CompileOptions, compile_contract, generated_covenant_auth_entrypoint_name, compile_to_sil_abi_artifact, compile_to_sil_abi_artifact_with_options,
 };
 
 use common::{build_sig_script_for_covenant_decl, bytecode, encode_entry_sig_script, single_contract};
@@ -21,7 +21,7 @@ fn lowers_auth_covenant_declaration_to_hidden_entrypoint_name() {
     "#;
 
     let compiled = compile_contract(source, &[Expr::int(3)], CompileOptions::default()).expect("compile succeeds");
-    let abi = sil_abi_artifact(source, &[3.into()]).expect("portable ABI compiles");
+    let abi = compile_to_sil_abi_artifact(source, &[3.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
     assert_eq!(artifact.entries.len(), 1);
     assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("spend"));
@@ -42,7 +42,7 @@ fn infers_auth_binding_from_from_equal_one_when_binding_omitted() {
     "#;
 
     let compiled = compile_contract(source, &[Expr::int(3)], CompileOptions::default()).expect("compile succeeds");
-    let abi = sil_abi_artifact(source, &[3.into()]).expect("portable ABI compiles");
+    let abi = compile_to_sil_abi_artifact(source, &[3.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
     assert_eq!(artifact.entries.len(), 1);
     assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("spend"));
@@ -64,7 +64,7 @@ fn lowers_cov_covenant_to_leader_and_delegate_entrypoints() {
 
     let compiled =
         compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
-    let abi = sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
+    let abi = compile_to_sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
     let abi_names: Vec<&str> = artifact.entries.iter().map(|entry| entry.name.as_str()).collect();
     assert_eq!(abi_names, vec!["__leader_transition_ok", "__delegate"]);
@@ -87,7 +87,7 @@ fn infers_cov_binding_from_from_greater_than_one_when_binding_omitted() {
 
     let compiled =
         compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
-    let abi = sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
+    let abi = compile_to_sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
     let abi_names: Vec<&str> = artifact.entries.iter().map(|entry| entry.name.as_str()).collect();
     assert_eq!(abi_names, vec!["__leader_transition_ok", "__delegate"]);
@@ -110,7 +110,7 @@ fn rejects_cov_verification_without_prev_new_field_arrays() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("cov verification with state fields should require prev/new field arrays");
     assert!(err.to_string().contains("expects parameters '(State[] prev_states, State[] new_states, ...)'"));
 }
@@ -128,7 +128,7 @@ fn rejects_cov_transition_without_prev_field_arrays() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("cov transition with state fields should require prev-state field arrays");
     assert!(err.to_string().contains("expects parameters '(State[] prev_states, ...)'"));
 }
@@ -146,7 +146,7 @@ fn rejects_auth_verification_without_prev_new_state_shape() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("auth verification with state fields should require prev/new state params");
     assert!(err.to_string().contains("mode=verification with binding=auth"));
 }
@@ -164,7 +164,7 @@ fn rejects_auth_transition_without_prev_state_shape() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("auth transition with state fields should require prev-state params");
     assert!(err.to_string().contains("mode=transition with binding=auth"));
 }
@@ -180,7 +180,7 @@ fn rejects_auth_transition_when_contract_state_is_empty() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("auth transition should be unsupported when contract state is empty");
     assert!(err.to_string().contains("mode=tranisition is not supported when contract state is empty"));
 }
@@ -196,7 +196,7 @@ fn rejects_cov_transition_when_contract_state_is_empty() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("cov transition should be unsupported when contract state is empty");
     assert!(err.to_string().contains("mode=tranisition is not supported when contract state is empty"));
 }
@@ -215,7 +215,7 @@ fn rejects_old_per_field_covenant_state_syntax() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("old per-field covenant syntax should be rejected for stateful contracts");
     assert!(err.to_string().contains("expects parameters '(State prev_state, State[] new_states, ...)'"));
 }
@@ -233,7 +233,7 @@ fn rejects_canonical_one_to_one_auth_verification_with_scalar_new_state() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(7)], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(7)], CompileOptions::default())
         .expect_err("canonical one-to-one auth verification should require State[] new_states");
     assert!(err.to_string().contains(
         "mode=verification with binding=auth on function 'step' expects parameters '(State prev_state, State[] new_states, ...)'"
@@ -251,7 +251,7 @@ fn lowers_singleton_sugar_to_auth_one_to_one_defaults() {
         }
     "#;
 
-    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("compile succeeds");
     let artifact = single_contract(&compiled);
     assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("spend"));
     assert!(bytecode(&compiled).contains(&OpAuthOutputCount));
@@ -269,7 +269,7 @@ fn lowers_fanout_sugar_to_auth_with_to_bound() {
     "#;
 
     let compiled =
-        sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default()).expect("compile succeeds");
+        compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default()).expect("compile succeeds");
     let artifact = single_contract(&compiled);
     assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("split"));
     assert!(bytecode(&compiled).contains(&OpAuthOutputCount));
@@ -286,7 +286,7 @@ fn rejects_fanout_sugar_without_to_argument() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("fanout sugar requires to");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("fanout sugar requires to");
     assert!(err.to_string().contains("missing covenant attribute argument 'to'"));
 }
 
@@ -302,7 +302,7 @@ fn rejects_singleton_sugar_with_from_or_to_arguments() {
     "#;
 
     let err =
-        sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("singleton sugar should reject from/to");
+        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("singleton sugar should reject from/to");
     assert!(err.to_string().contains("covenant.singleton is sugar and does not accept 'from' or 'to' arguments"));
 }
 
@@ -317,7 +317,7 @@ fn rejects_auth_covenant_with_from_not_equal_one() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("auth binding must require from=1");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("auth binding must require from=1");
     assert!(err.to_string().contains("binding=auth requires from = 1"));
 }
 
@@ -333,7 +333,7 @@ fn rejects_cov_covenant_groups_multiple_for_now() {
     "#;
 
     let err =
-        sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("cov groups=multiple should be rejected");
+        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("cov groups=multiple should be rejected");
     assert!(err.to_string().contains("binding=cov with groups=multiple is not supported yet"));
 }
 
@@ -386,7 +386,7 @@ fn rejects_auth_transition_single_state_return_when_to_is_not_literal_one() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(
+    let err = compile_to_sil_abi_artifact_with_options(
         source,
         &[ArtifactValue::Int(4), ArtifactValue::Int(10), ArtifactValue::Bytes(vec![7u8; 32])],
         CompileOptions::default(),
@@ -409,7 +409,7 @@ fn rejects_auth_transition_single_state_return_when_to_is_constant_one() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default())
         .expect_err("auth transition returning one State should require literal to=1");
     assert!(err.to_string().contains("may return a single State only when 'to' is the literal 1 or omitted"));
 }
@@ -462,7 +462,7 @@ fn rejects_omitted_to_for_auth_transition_array_state_return() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default())
         .expect_err("omitted to should only infer literal 1 for single State returns");
     assert!(err.to_string().contains("missing covenant attribute argument 'to'"));
 }
@@ -480,7 +480,7 @@ fn rejects_singleton_transition_array_returns_without_termination_allowed() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default())
         .expect_err("singleton transition arrays should require termination=allowed");
     assert!(err.to_string().contains("arrays are not allowed unless termination=allowed"));
 }
@@ -515,7 +515,7 @@ fn rejects_termination_allowed_for_non_singleton() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3), ArtifactValue::Int(10)], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3), ArtifactValue::Int(10)], CompileOptions::default())
         .expect_err("termination=allowed should be singleton-only");
     assert!(err.to_string().contains("termination is only supported for singleton covenants"));
 }
@@ -533,7 +533,7 @@ fn rejects_termination_disallowed_for_non_singleton() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3), ArtifactValue::Int(10)], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3), ArtifactValue::Int(10)], CompileOptions::default())
         .expect_err("termination arg should be singleton-only regardless of value");
     assert!(err.to_string().contains("termination is only supported for singleton covenants"));
 }
@@ -566,7 +566,7 @@ fn rejects_transition_mode_without_return_values() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("transition policy must return values");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("transition policy must return values");
     assert!(err.to_string().contains("transition mode policy functions must declare return values"));
 }
 
@@ -582,7 +582,7 @@ fn rejects_verification_mode_with_return_values() {
     "#;
 
     let err =
-        sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("verification policy must not return values");
+        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("verification policy must not return values");
     assert!(err.to_string().contains("verification mode policy functions must not declare return values"));
 }
 
@@ -597,7 +597,7 @@ fn auth_covenant_groups_single_injects_shared_count_check() {
         }
     "#;
 
-    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("compile succeeds");
     assert!(bytecode(&compiled).contains(&OpInputCovenantId));
     assert!(bytecode(&compiled).contains(&OpCovOutputCount));
     assert!(bytecode(&compiled).contains(&OpAuthOutputCount));
@@ -619,7 +619,7 @@ fn rejects_mixed_auth_and_cov_covenant_declarations() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
         .expect_err("auth-bound declarations must not coexist with generated delegates");
     let message = err.to_string();
     assert!(message.contains("binding=cov"), "unexpected error: {message}");
@@ -644,7 +644,7 @@ fn rejects_mixed_inferred_auth_and_cov_covenant_declarations() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
         .expect_err("inferred auth and cov declarations must not coexist");
     assert!(err.to_string().contains("cannot use binding=auth"), "unexpected error: {err}");
 }
@@ -664,7 +664,7 @@ fn leader_contract_rejects_unacknowledged_manual_entrypoint() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
         .expect_err("manual entrypoints in leader contracts require acknowledgment");
     let message = err.to_string();
     assert!(message.contains("manual entrypoint 'recover'"), "unexpected error: {message}");
@@ -690,7 +690,7 @@ fn leader_contract_allows_acknowledged_manual_entrypoint() {
 
     let compiled = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default())
         .expect("acknowledged manual entrypoint compiles");
-    let abi = sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
+    let abi = compile_to_sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
     assert!(artifact.entry("recover").is_some());
     let recover = compiled.ast.functions.iter().find(|function| function.name == "recover").expect("recover remains an entrypoint");
@@ -713,9 +713,9 @@ fn allows_multiple_cov_covenant_declarations() {
         }
     "#;
 
-    let compiled = sil_abi_artifact_with_options(source, &[2.into(), 4.into()], CompileOptions::default())
+    let compiled = compile_to_sil_abi_artifact_with_options(source, &[2.into(), 4.into()], CompileOptions::default())
         .expect("multiple cov-bound declarations compile");
-    let abi = sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
+    let abi = compile_to_sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi);
     let abi_names: Vec<&str> = artifact.entries.iter().map(|entry| entry.name.as_str()).collect();
     assert_eq!(abi_names, vec!["__leader_merge", "__leader_rebalance", "__delegate"]);
@@ -748,7 +748,7 @@ fn portable_abi_preserves_covenant_declaration_and_delegate_entries() {
         }
     "#;
 
-    let artifact = sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable covenant ABI compiles");
+    let artifact = compile_to_sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable covenant ABI compiles");
     let json = serde_json::to_string(&artifact).expect("portable covenant ABI serializes");
     let decoded: SilAbiArtifact = serde_json::from_str(&json).expect("portable covenant ABI deserializes");
     let contract = decoded.contract("Decls").expect("contract exists");
@@ -793,9 +793,9 @@ fn lowers_kcc20_shaped_public_names_and_shared_delegate_body() {
         }
     "#;
 
-    let compiled = sil_abi_artifact_with_options(source, &[vec![7u8].into(), 10.into()], CompileOptions::default())
+    let compiled = compile_to_sil_abi_artifact_with_options(source, &[vec![7u8].into(), 10.into()], CompileOptions::default())
         .expect("KCC20-shaped declaration compiles");
-    let abi_artifact = sil_abi_artifact(source, &[vec![7u8].into(), 10.into()]).expect("portable ABI compiles");
+    let abi_artifact = compile_to_sil_abi_artifact(source, &[vec![7u8].into(), 10.into()]).expect("portable ABI compiles");
     let artifact = single_contract(&abi_artifact);
 
     let abi = artifact
@@ -841,7 +841,7 @@ fn supports_public_name_override_for_auth_bound_declaration() {
         }
     "#;
 
-    let artifact = sil_abi_artifact(source, &[]).expect("portable auth ABI compiles");
+    let artifact = compile_to_sil_abi_artifact(source, &[]).expect("portable auth ABI compiles");
     let contract = artifact.contract("Decls").expect("contract exists");
     assert_eq!(contract.entries[0].name, "spend");
     assert_eq!(contract.auth_decl_entry("spendPolicy").expect("auth entry resolves").name, "spend");
@@ -863,7 +863,7 @@ fn rejects_duplicate_delegate_bodies() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("duplicate delegate bodies must fail");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("duplicate delegate bodies must fail");
     assert!(err.to_string().contains("more than one #[covenant.delegate] body"), "unexpected error: {err}");
 }
 
@@ -876,7 +876,7 @@ fn rejects_delegate_body_without_cov_bound_declaration() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("unused delegate body must fail");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("unused delegate body must fail");
     assert!(err.to_string().contains("requires at least one binding=cov"), "unexpected error: {err}");
 }
 
@@ -914,7 +914,7 @@ fn rejects_direct_calls_to_the_delegate_body() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("delegate bodies are compiler hooks");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("delegate bodies are compiler hooks");
     let message = err.to_string();
     assert!(message.contains("covenant-annotated function 'authorizeDelegate' cannot be called directly"));
     assert!(message.contains("extract shared logic into an unannotated helper function"));
@@ -936,7 +936,7 @@ fn rejects_direct_calls_to_a_covenant_policy() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("covenant policies are compiler hooks");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("covenant policies are compiler hooks");
     let message = err.to_string();
     assert!(message.contains("covenant-annotated function 'transferPolicy' cannot be called directly"));
     assert!(message.contains("extract shared logic into an unannotated helper function"));
@@ -954,7 +954,7 @@ fn rejects_conflicting_shared_delegate_names() {
         }
     "#;
 
-    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("delegate names must agree");
+    let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("delegate names must agree");
     assert!(err.to_string().contains("conflicting shared delegate entrypoint names"), "unexpected error: {err}");
 }
 
@@ -989,7 +989,7 @@ fn rejects_invalid_delegate_body_signatures() {
 
     for source in cases {
         let err =
-            sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("invalid delegate signature must fail");
+            compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("invalid delegate signature must fail");
         assert!(err.to_string().contains("#[covenant.delegate]"), "unexpected error: {err}");
     }
 }
@@ -1010,7 +1010,7 @@ fn rejects_generated_public_name_collision() {
     "#;
 
     let err =
-        sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("generated public name collision must fail");
+        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("generated public name collision must fail");
     assert!(err.to_string().contains("duplicate function name 'transfer'"), "unexpected error: {err}");
 }
 
@@ -1036,7 +1036,7 @@ fn rejects_generated_public_name_collisions_with_helpers() {
     ];
 
     for source in cases {
-        let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        let err = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
             .expect_err("generated public names must not collide with helper functions");
         assert!(err.to_string().contains("duplicate function name 'spend'"), "unexpected error: {err}");
     }
@@ -1057,6 +1057,6 @@ fn rejects_per_leader_delegate_policy_selection() {
     "#;
 
     let err =
-        sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("leaders cannot select delegate policies");
+        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("leaders cannot select delegate policies");
     assert!(err.to_string().contains("unknown covenant attribute argument 'delegate_policy'"), "unexpected error: {err}");
 }

--- a/silverscript-lang/tests/covenant_compiler_tests.rs
+++ b/silverscript-lang/tests/covenant_compiler_tests.rs
@@ -1,7 +1,13 @@
+mod common;
+
 use kaspa_txscript::opcodes::codes::{OpAuthOutputCount, OpCovInputCount, OpCovInputIdx, OpCovOutputCount, OpInputCovenantId};
-use silverscript_abi::{ArtifactValue, SilAbiArtifact};
+use silverscript_abi::{ArtifactValue, SilAbiArtifact, TypeArtifact};
 use silverscript_lang::ast::Expr;
-use silverscript_lang::compiler::{CompileOptions, compile_contract, generated_covenant_auth_entrypoint_name, sil_abi_artifact};
+use silverscript_lang::compiler::{
+    CompileOptions, compile_contract, generated_covenant_auth_entrypoint_name, sil_abi_artifact, sil_abi_artifact_with_options,
+};
+
+use common::{build_sig_script_for_covenant_decl, bytecode, encode_entry_sig_script, single_contract};
 
 #[test]
 fn lowers_auth_covenant_declaration_to_hidden_entrypoint_name() {
@@ -15,11 +21,13 @@ fn lowers_auth_covenant_declaration_to_hidden_entrypoint_name() {
     "#;
 
     let compiled = compile_contract(source, &[Expr::int(3)], CompileOptions::default()).expect("compile succeeds");
-    assert_eq!(compiled.abi.len(), 1);
-    assert_eq!(compiled.abi[0].name, generated_covenant_auth_entrypoint_name("spend"));
+    let abi = sil_abi_artifact(source, &[3.into()]).expect("portable ABI compiles");
+    let artifact = single_contract(&abi);
+    assert_eq!(artifact.entries.len(), 1);
+    assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("spend"));
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_spend" && !f.entrypoint));
     assert!(compiled.ast.functions.iter().any(|f| f.name == generated_covenant_auth_entrypoint_name("spend") && f.entrypoint));
-    assert!(compiled.bytecode.contains(&OpAuthOutputCount));
+    assert!(compiled.bytecode.clone().contains(&OpAuthOutputCount));
 }
 
 #[test]
@@ -34,11 +42,13 @@ fn infers_auth_binding_from_from_equal_one_when_binding_omitted() {
     "#;
 
     let compiled = compile_contract(source, &[Expr::int(3)], CompileOptions::default()).expect("compile succeeds");
-    assert_eq!(compiled.abi.len(), 1);
-    assert_eq!(compiled.abi[0].name, generated_covenant_auth_entrypoint_name("spend"));
+    let abi = sil_abi_artifact(source, &[3.into()]).expect("portable ABI compiles");
+    let artifact = single_contract(&abi);
+    assert_eq!(artifact.entries.len(), 1);
+    assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("spend"));
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_spend" && !f.entrypoint));
     assert!(compiled.ast.functions.iter().any(|f| f.name == generated_covenant_auth_entrypoint_name("spend") && f.entrypoint));
-    assert!(compiled.bytecode.contains(&OpAuthOutputCount));
+    assert!(compiled.bytecode.clone().contains(&OpAuthOutputCount));
 }
 
 #[test]
@@ -52,13 +62,16 @@ fn lowers_cov_covenant_to_leader_and_delegate_entrypoints() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
-    let abi_names: Vec<&str> = compiled.abi.iter().map(|entry| entry.name.as_str()).collect();
+    let compiled =
+        compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
+    let abi = sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
+    let artifact = single_contract(&abi);
+    let abi_names: Vec<&str> = artifact.entries.iter().map(|entry| entry.name.as_str()).collect();
     assert_eq!(abi_names, vec!["__leader_transition_ok", "__delegate"]);
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_transition_ok" && !f.entrypoint));
-    assert!(compiled.bytecode.contains(&OpCovInputCount));
-    assert!(compiled.bytecode.contains(&OpCovOutputCount));
-    assert!(compiled.bytecode.contains(&OpCovInputIdx));
+    assert!(compiled.bytecode.clone().contains(&OpCovInputCount));
+    assert!(compiled.bytecode.clone().contains(&OpCovOutputCount));
+    assert!(compiled.bytecode.clone().contains(&OpCovInputIdx));
 }
 
 #[test]
@@ -72,13 +85,16 @@ fn infers_cov_binding_from_from_greater_than_one_when_binding_omitted() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
-    let abi_names: Vec<&str> = compiled.abi.iter().map(|entry| entry.name.as_str()).collect();
+    let compiled =
+        compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default()).expect("compile succeeds");
+    let abi = sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
+    let artifact = single_contract(&abi);
+    let abi_names: Vec<&str> = artifact.entries.iter().map(|entry| entry.name.as_str()).collect();
     assert_eq!(abi_names, vec!["__leader_transition_ok", "__delegate"]);
     assert!(compiled.ast.functions.iter().any(|f| f.name == "__covenant_policy_transition_ok" && !f.entrypoint));
-    assert!(compiled.bytecode.contains(&OpCovInputCount));
-    assert!(compiled.bytecode.contains(&OpCovOutputCount));
-    assert!(compiled.bytecode.contains(&OpCovInputIdx));
+    assert!(compiled.bytecode.clone().contains(&OpCovInputCount));
+    assert!(compiled.bytecode.clone().contains(&OpCovOutputCount));
+    assert!(compiled.bytecode.clone().contains(&OpCovInputIdx));
 }
 
 #[test]
@@ -94,7 +110,7 @@ fn rejects_cov_verification_without_prev_new_field_arrays() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("cov verification with state fields should require prev/new field arrays");
     assert!(err.to_string().contains("expects parameters '(State[] prev_states, State[] new_states, ...)'"));
 }
@@ -112,7 +128,7 @@ fn rejects_cov_transition_without_prev_field_arrays() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("cov transition with state fields should require prev-state field arrays");
     assert!(err.to_string().contains("expects parameters '(State[] prev_states, ...)'"));
 }
@@ -130,7 +146,7 @@ fn rejects_auth_verification_without_prev_new_state_shape() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("auth verification with state fields should require prev/new state params");
     assert!(err.to_string().contains("mode=verification with binding=auth"));
 }
@@ -148,7 +164,7 @@ fn rejects_auth_transition_without_prev_state_shape() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("auth transition with state fields should require prev-state params");
     assert!(err.to_string().contains("mode=transition with binding=auth"));
 }
@@ -164,7 +180,7 @@ fn rejects_auth_transition_when_contract_state_is_empty() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("auth transition should be unsupported when contract state is empty");
     assert!(err.to_string().contains("mode=tranisition is not supported when contract state is empty"));
 }
@@ -180,7 +196,7 @@ fn rejects_cov_transition_when_contract_state_is_empty() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("cov transition should be unsupported when contract state is empty");
     assert!(err.to_string().contains("mode=tranisition is not supported when contract state is empty"));
 }
@@ -199,7 +215,7 @@ fn rejects_old_per_field_covenant_state_syntax() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
         .expect_err("old per-field covenant syntax should be rejected for stateful contracts");
     assert!(err.to_string().contains("expects parameters '(State prev_state, State[] new_states, ...)'"));
 }
@@ -217,7 +233,7 @@ fn rejects_canonical_one_to_one_auth_verification_with_scalar_new_state() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(7)], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(7)], CompileOptions::default())
         .expect_err("canonical one-to-one auth verification should require State[] new_states");
     assert!(err.to_string().contains(
         "mode=verification with binding=auth on function 'step' expects parameters '(State prev_state, State[] new_states, ...)'"
@@ -235,9 +251,10 @@ fn lowers_singleton_sugar_to_auth_one_to_one_defaults() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    assert_eq!(compiled.abi[0].name, generated_covenant_auth_entrypoint_name("spend"));
-    assert!(compiled.bytecode.contains(&OpAuthOutputCount));
+    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("compile succeeds");
+    let artifact = single_contract(&compiled);
+    assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("spend"));
+    assert!(bytecode(&compiled).contains(&OpAuthOutputCount));
 }
 
 #[test]
@@ -251,9 +268,11 @@ fn lowers_fanout_sugar_to_auth_with_to_bound() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[Expr::int(3)], CompileOptions::default()).expect("compile succeeds");
-    assert_eq!(compiled.abi[0].name, generated_covenant_auth_entrypoint_name("split"));
-    assert!(compiled.bytecode.contains(&OpAuthOutputCount));
+    let compiled =
+        sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default()).expect("compile succeeds");
+    let artifact = single_contract(&compiled);
+    assert_eq!(artifact.entries[0].name, generated_covenant_auth_entrypoint_name("split"));
+    assert!(bytecode(&compiled).contains(&OpAuthOutputCount));
 }
 
 #[test]
@@ -267,7 +286,7 @@ fn rejects_fanout_sugar_without_to_argument() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("fanout sugar requires to");
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("fanout sugar requires to");
     assert!(err.to_string().contains("missing covenant attribute argument 'to'"));
 }
 
@@ -282,7 +301,8 @@ fn rejects_singleton_sugar_with_from_or_to_arguments() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("singleton sugar should reject from/to");
+    let err =
+        sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("singleton sugar should reject from/to");
     assert!(err.to_string().contains("covenant.singleton is sugar and does not accept 'from' or 'to' arguments"));
 }
 
@@ -297,7 +317,7 @@ fn rejects_auth_covenant_with_from_not_equal_one() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("auth binding must require from=1");
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("auth binding must require from=1");
     assert!(err.to_string().contains("binding=auth requires from = 1"));
 }
 
@@ -312,7 +332,8 @@ fn rejects_cov_covenant_groups_multiple_for_now() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("cov groups=multiple should be rejected");
+    let err =
+        sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("cov groups=multiple should be rejected");
     assert!(err.to_string().contains("binding=cov with groups=multiple is not supported yet"));
 }
 
@@ -365,8 +386,12 @@ fn rejects_auth_transition_single_state_return_when_to_is_not_literal_one() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(4), Expr::int(10), Expr::bytes(vec![7u8; 32])], CompileOptions::default())
-        .expect_err("auth transition returning one State must not accept dynamic to bounds");
+    let err = sil_abi_artifact_with_options(
+        source,
+        &[ArtifactValue::Int(4), ArtifactValue::Int(10), ArtifactValue::Bytes(vec![7u8; 32])],
+        CompileOptions::default(),
+    )
+    .expect_err("auth transition returning one State must not accept dynamic to bounds");
     assert!(err.to_string().contains("may return a single State only when 'to' is the literal 1 or omitted"));
 }
 
@@ -384,7 +409,7 @@ fn rejects_auth_transition_single_state_return_when_to_is_constant_one() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(3)], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default())
         .expect_err("auth transition returning one State should require literal to=1");
     assert!(err.to_string().contains("may return a single State only when 'to' is the literal 1 or omitted"));
 }
@@ -437,7 +462,7 @@ fn rejects_omitted_to_for_auth_transition_array_state_return() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(3)], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default())
         .expect_err("omitted to should only infer literal 1 for single State returns");
     assert!(err.to_string().contains("missing covenant attribute argument 'to'"));
 }
@@ -455,7 +480,7 @@ fn rejects_singleton_transition_array_returns_without_termination_allowed() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(3)], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3)], CompileOptions::default())
         .expect_err("singleton transition arrays should require termination=allowed");
     assert!(err.to_string().contains("arrays are not allowed unless termination=allowed"));
 }
@@ -490,7 +515,7 @@ fn rejects_termination_allowed_for_non_singleton() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(3), Expr::int(10)], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3), ArtifactValue::Int(10)], CompileOptions::default())
         .expect_err("termination=allowed should be singleton-only");
     assert!(err.to_string().contains("termination is only supported for singleton covenants"));
 }
@@ -508,7 +533,7 @@ fn rejects_termination_disallowed_for_non_singleton() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(3), Expr::int(10)], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(3), ArtifactValue::Int(10)], CompileOptions::default())
         .expect_err("termination arg should be singleton-only regardless of value");
     assert!(err.to_string().contains("termination is only supported for singleton covenants"));
 }
@@ -541,7 +566,7 @@ fn rejects_transition_mode_without_return_values() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("transition policy must return values");
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("transition policy must return values");
     assert!(err.to_string().contains("transition mode policy functions must declare return values"));
 }
 
@@ -556,7 +581,8 @@ fn rejects_verification_mode_with_return_values() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("verification policy must not return values");
+    let err =
+        sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("verification policy must not return values");
     assert!(err.to_string().contains("verification mode policy functions must not declare return values"));
 }
 
@@ -571,10 +597,10 @@ fn auth_covenant_groups_single_injects_shared_count_check() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    assert!(compiled.bytecode.contains(&OpInputCovenantId));
-    assert!(compiled.bytecode.contains(&OpCovOutputCount));
-    assert!(compiled.bytecode.contains(&OpAuthOutputCount));
+    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("compile succeeds");
+    assert!(bytecode(&compiled).contains(&OpInputCovenantId));
+    assert!(bytecode(&compiled).contains(&OpCovOutputCount));
+    assert!(bytecode(&compiled).contains(&OpAuthOutputCount));
 }
 
 #[test]
@@ -593,7 +619,7 @@ fn rejects_mixed_auth_and_cov_covenant_declarations() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
         .expect_err("auth-bound declarations must not coexist with generated delegates");
     let message = err.to_string();
     assert!(message.contains("binding=cov"), "unexpected error: {message}");
@@ -618,7 +644,7 @@ fn rejects_mixed_inferred_auth_and_cov_covenant_declarations() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
         .expect_err("inferred auth and cov declarations must not coexist");
     assert!(err.to_string().contains("cannot use binding=auth"), "unexpected error: {err}");
 }
@@ -638,7 +664,7 @@ fn leader_contract_rejects_unacknowledged_manual_entrypoint() {
         }
     "#;
 
-    let err = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default())
+    let err = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)], CompileOptions::default())
         .expect_err("manual entrypoints in leader contracts require acknowledgment");
     let message = err.to_string();
     assert!(message.contains("manual entrypoint 'recover'"), "unexpected error: {message}");
@@ -664,7 +690,9 @@ fn leader_contract_allows_acknowledged_manual_entrypoint() {
 
     let compiled = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default())
         .expect("acknowledged manual entrypoint compiles");
-    assert!(compiled.entry_by_name("recover").is_some());
+    let abi = sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
+    let artifact = single_contract(&abi);
+    assert!(artifact.entry("recover").is_some());
     let recover = compiled.ast.functions.iter().find(|function| function.name == "recover").expect("recover remains an entrypoint");
     assert!(recover.attributes.is_empty(), "allow acknowledgment must not survive lowering");
 }
@@ -685,20 +713,21 @@ fn allows_multiple_cov_covenant_declarations() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[Expr::int(2), Expr::int(4)], CompileOptions::default())
+    let compiled = sil_abi_artifact_with_options(source, &[2.into(), 4.into()], CompileOptions::default())
         .expect("multiple cov-bound declarations compile");
-    let abi_names: Vec<&str> = compiled.abi.iter().map(|entry| entry.name.as_str()).collect();
+    let abi = sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable ABI compiles");
+    let artifact = single_contract(&abi);
+    let abi_names: Vec<&str> = artifact.entries.iter().map(|entry| entry.name.as_str()).collect();
     assert_eq!(abi_names, vec!["__leader_merge", "__leader_rebalance", "__delegate"]);
-    assert_eq!(compiled.cov_decl_to_abi.get("merge"), compiled.entry_by_name("__leader_merge"));
-    assert_eq!(compiled.cov_decl_to_abi.get("rebalance"), compiled.entry_by_name("__leader_rebalance"));
-    assert_eq!(compiled.delegate_entry_abi.as_ref(), compiled.entry_by_name("__delegate"));
+    assert_eq!(artifact.cov_binding_leader_decl_entry("merge"), artifact.entry("__leader_merge"));
+    assert_eq!(artifact.cov_binding_leader_decl_entry("rebalance"), artifact.entry("__leader_rebalance"));
+    assert_eq!(artifact.delegate_entry_abi.as_ref(), artifact.entry("__delegate"));
 
-    let merge_delegate =
-        compiled.build_sig_script_for_covenant_decl("merge", vec![], Default::default()).expect("merge routes to the shared delegate");
-    let rebalance_delegate = compiled
-        .build_sig_script_for_covenant_decl("rebalance", vec![], Default::default())
+    let merge_delegate = build_sig_script_for_covenant_decl(&compiled, "merge", vec![], Default::default())
+        .expect("merge routes to the shared delegate");
+    let rebalance_delegate = build_sig_script_for_covenant_decl(&compiled, "rebalance", vec![], Default::default())
         .expect("rebalance routes to the shared delegate");
-    let shared_delegate = compiled.build_sig_script("__delegate", vec![]).expect("shared delegate sigscript builds");
+    let shared_delegate = encode_entry_sig_script(&compiled, "__delegate", &[]).expect("shared delegate sigscript builds");
     assert_eq!(merge_delegate, shared_delegate);
     assert_eq!(rebalance_delegate, shared_delegate);
 }
@@ -719,7 +748,7 @@ fn portable_abi_preserves_covenant_declaration_and_delegate_entries() {
         }
     "#;
 
-    let artifact = sil_abi_artifact(source, &[ArtifactValue::Int(2), ArtifactValue::Int(4)]).expect("portable covenant ABI compiles");
+    let artifact = sil_abi_artifact(source, &[2.into(), 4.into()]).expect("portable covenant ABI compiles");
     let json = serde_json::to_string(&artifact).expect("portable covenant ABI serializes");
     let decoded: SilAbiArtifact = serde_json::from_str(&json).expect("portable covenant ABI deserializes");
     let contract = decoded.contract("Decls").expect("contract exists");
@@ -764,30 +793,41 @@ fn lowers_kcc20_shaped_public_names_and_shared_delegate_body() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[Expr::bytes(vec![7]), Expr::int(10)], CompileOptions::default())
+    let compiled = sil_abi_artifact_with_options(source, &[vec![7u8].into(), 10.into()], CompileOptions::default())
         .expect("KCC20-shaped declaration compiles");
+    let abi_artifact = sil_abi_artifact(source, &[vec![7u8].into(), 10.into()]).expect("portable ABI compiles");
+    let artifact = single_contract(&abi_artifact);
 
-    let abi = compiled
-        .abi
+    let abi = artifact
+        .entries
         .iter()
-        .map(|entry| (entry.name.as_str(), entry.inputs.iter().map(|input| input.type_name.as_str()).collect::<Vec<_>>()))
+        .map(|entry| (entry.name.as_str(), entry.params.iter().map(|input| &input.ty).collect::<Vec<_>>()))
         .collect::<Vec<_>>();
-    assert_eq!(abi, vec![("transfer", vec!["State[]", "byte[]"]), ("transfer_delegator", vec!["byte[]"]),]);
+    assert_eq!(
+        abi,
+        vec![
+            (
+                "transfer",
+                vec![
+                    &TypeArtifact::DynamicArray { item: Box::new(TypeArtifact::Struct { name: "State".to_string() }) },
+                    &TypeArtifact::Bytes,
+                ],
+            ),
+            ("transfer_delegator", vec![&TypeArtifact::Bytes]),
+        ]
+    );
 
-    let transfer = compiled.entry_by_name("transfer").expect("public transfer exists");
+    let transfer = artifact.entry("transfer").expect("public transfer exists");
     let expected_hash = blake3::hash(b"transfer({byte[1],int}[],byte[])");
-    assert_eq!(transfer.dispatch_tag, expected_hash.as_bytes()[..4]);
+    assert_eq!(transfer.dispatch_tag.as_bytes(), &expected_hash.as_bytes()[..4]);
 
-    let delegate_args = vec![Expr::dynamic_bytes(vec![7])];
-    let routed = compiled
-        .build_sig_script_for_covenant_decl("transferPolicy", delegate_args.clone(), Default::default())
+    let delegate_args = vec![vec![7u8].into()];
+    let routed = build_sig_script_for_covenant_decl(&compiled, "transferPolicy", delegate_args.clone(), Default::default())
         .expect("declaration helper resolves the overridden delegate name");
-    let direct = compiled.build_sig_script("transfer_delegator", delegate_args).expect("public delegate sigscript builds");
+    let direct = encode_entry_sig_script(&compiled, "transfer_delegator", &delegate_args).expect("public delegate sigscript builds");
     assert_eq!(routed, direct);
-    assert_eq!(compiled.cov_decl_to_abi.get("transferPolicy"), compiled.entry_by_name("transfer"));
-    assert_eq!(compiled.delegate_entry_abi.as_ref(), compiled.entry_by_name("transfer_delegator"));
-    assert_eq!(compiled.covenant_decl_entrypoint_name("transferPolicy", true), Some("transfer"));
-    assert_eq!(compiled.covenant_decl_entrypoint_name("transferPolicy", false), Some("transfer_delegator"));
+    assert_eq!(artifact.cov_binding_leader_decl_entry("transferPolicy"), artifact.entry("transfer"));
+    assert_eq!(artifact.delegate_entry_abi.as_ref(), artifact.entry("transfer_delegator"));
 }
 
 #[test]
@@ -801,15 +841,11 @@ fn supports_public_name_override_for_auth_bound_declaration() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("compile succeeds");
-    assert_eq!(compiled.abi[0].name, "spend");
-    assert_eq!(compiled.cov_decl_to_abi.get("spendPolicy"), compiled.entry_by_name("spend"));
-    assert_eq!(compiled.delegate_entry_abi, None);
-    assert_eq!(compiled.covenant_decl_entrypoint_name("spendPolicy", false), Some("spend"));
-
     let artifact = sil_abi_artifact(source, &[]).expect("portable auth ABI compiles");
     let contract = artifact.contract("Decls").expect("contract exists");
+    assert_eq!(contract.entries[0].name, "spend");
     assert_eq!(contract.auth_decl_entry("spendPolicy").expect("auth entry resolves").name, "spend");
+    assert_eq!(contract.delegate_entry_abi, None);
 }
 
 #[test]
@@ -827,7 +863,7 @@ fn rejects_duplicate_delegate_bodies() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("duplicate delegate bodies must fail");
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("duplicate delegate bodies must fail");
     assert!(err.to_string().contains("more than one #[covenant.delegate] body"), "unexpected error: {err}");
 }
 
@@ -840,7 +876,7 @@ fn rejects_delegate_body_without_cov_bound_declaration() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("unused delegate body must fail");
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("unused delegate body must fail");
     assert!(err.to_string().contains("requires at least one binding=cov"), "unexpected error: {err}");
 }
 
@@ -856,7 +892,8 @@ fn delegate_and_leader_internal_policy_names_use_disjoint_namespaces() {
         }
     "#;
 
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("internal policy names do not collide");
+    let compiled =
+        compile_contract(source, &[], CompileOptions::default()).expect("internal policy names do not collide");
     assert!(compiled.ast.functions.iter().any(|function| function.name == "__covenant_policy_delegate_authorize"));
     assert!(compiled.ast.functions.iter().any(|function| function.name == "__covenant_delegate_policy_authorize"));
 }
@@ -877,7 +914,7 @@ fn rejects_direct_calls_to_the_delegate_body() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("delegate bodies are compiler hooks");
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("delegate bodies are compiler hooks");
     let message = err.to_string();
     assert!(message.contains("covenant-annotated function 'authorizeDelegate' cannot be called directly"));
     assert!(message.contains("extract shared logic into an unannotated helper function"));
@@ -899,7 +936,7 @@ fn rejects_direct_calls_to_a_covenant_policy() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("covenant policies are compiler hooks");
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("covenant policies are compiler hooks");
     let message = err.to_string();
     assert!(message.contains("covenant-annotated function 'transferPolicy' cannot be called directly"));
     assert!(message.contains("extract shared logic into an unannotated helper function"));
@@ -917,7 +954,7 @@ fn rejects_conflicting_shared_delegate_names() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("delegate names must agree");
+    let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("delegate names must agree");
     assert!(err.to_string().contains("conflicting shared delegate entrypoint names"), "unexpected error: {err}");
 }
 
@@ -951,7 +988,8 @@ fn rejects_invalid_delegate_body_signatures() {
     ];
 
     for source in cases {
-        let err = compile_contract(source, &[], CompileOptions::default()).expect_err("invalid delegate signature must fail");
+        let err =
+            sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("invalid delegate signature must fail");
         assert!(err.to_string().contains("#[covenant.delegate]"), "unexpected error: {err}");
     }
 }
@@ -971,7 +1009,8 @@ fn rejects_generated_public_name_collision() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("generated public name collision must fail");
+    let err =
+        sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("generated public name collision must fail");
     assert!(err.to_string().contains("duplicate function name 'transfer'"), "unexpected error: {err}");
 }
 
@@ -997,7 +1036,7 @@ fn rejects_generated_public_name_collisions_with_helpers() {
     ];
 
     for source in cases {
-        let err = compile_contract(source, &[], CompileOptions::default())
+        let err = sil_abi_artifact_with_options(source, &[], CompileOptions::default())
             .expect_err("generated public names must not collide with helper functions");
         assert!(err.to_string().contains("duplicate function name 'spend'"), "unexpected error: {err}");
     }
@@ -1017,6 +1056,7 @@ fn rejects_per_leader_delegate_policy_selection() {
         }
     "#;
 
-    let err = compile_contract(source, &[], CompileOptions::default()).expect_err("leaders cannot select delegate policies");
+    let err =
+        sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("leaders cannot select delegate policies");
     assert!(err.to_string().contains("unknown covenant attribute argument 'delegate_policy'"), "unexpected error: {err}");
 }

--- a/silverscript-lang/tests/covenant_declaration_security_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_security_tests.rs
@@ -6,8 +6,8 @@ use kaspa_txscript_errors::TxScriptError;
 use silverscript_abi::ArtifactValue;
 use silverscript_lang::ast::Expr;
 use silverscript_lang::compiler::{
-    CompileOptions, CompiledContract, CovenantDeclCallOptions, compile_contract, generated_covenant_auth_entrypoint_name,
-    compile_to_sil_abi_artifact_with_options,
+    CompileOptions, CompiledContract, CovenantDeclCallOptions, compile_contract, compile_to_sil_abi_artifact_with_options,
+    generated_covenant_auth_entrypoint_name,
 };
 
 mod common;
@@ -156,7 +156,8 @@ const AUTH_VERIFICATION_CARDINALITY_SOURCE: &str = r#"
 "#;
 
 fn compile_state(source: &'static str, value: i64) -> silverscript_abi::SilAbiArtifact {
-    compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(value)], CompileOptions::default()).expect("compile succeeds")
+    compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(value)], CompileOptions::default())
+        .expect("compile succeeds")
 }
 
 fn function_param_type_names(compiled: &CompiledContract<'_>, function_name: &str) -> Vec<String> {

--- a/silverscript-lang/tests/covenant_declaration_security_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_security_tests.rs
@@ -7,7 +7,7 @@ use silverscript_abi::ArtifactValue;
 use silverscript_lang::ast::Expr;
 use silverscript_lang::compiler::{
     CompileOptions, CompiledContract, CovenantDeclCallOptions, compile_contract, generated_covenant_auth_entrypoint_name,
-    sil_abi_artifact_with_options,
+    compile_to_sil_abi_artifact_with_options,
 };
 
 mod common;
@@ -156,7 +156,7 @@ const AUTH_VERIFICATION_CARDINALITY_SOURCE: &str = r#"
 "#;
 
 fn compile_state(source: &'static str, value: i64) -> silverscript_abi::SilAbiArtifact {
-    sil_abi_artifact_with_options(source, &[ArtifactValue::Int(value)], CompileOptions::default()).expect("compile succeeds")
+    compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(value)], CompileOptions::default()).expect("compile succeeds")
 }
 
 fn function_param_type_names(compiled: &CompiledContract<'_>, function_name: &str) -> Vec<String> {
@@ -181,7 +181,7 @@ fn state_arg(value: i64) -> ArtifactValue {
 }
 
 fn compile_kcc20_state(owner: u8, amount: i64) -> silverscript_abi::SilAbiArtifact {
-    sil_abi_artifact_with_options(
+    compile_to_sil_abi_artifact_with_options(
         KCC20_SHAPED_SOURCE,
         &[ArtifactValue::Bytes(vec![owner]), ArtifactValue::Int(amount)],
         CompileOptions::default(),

--- a/silverscript-lang/tests/covenant_declaration_security_tests.rs
+++ b/silverscript-lang/tests/covenant_declaration_security_tests.rs
@@ -1,17 +1,20 @@
+use std::collections::BTreeMap;
+
 use kaspa_consensus_core::Hash;
 use kaspa_consensus_core::tx::{Transaction, TransactionOutput, UtxoEntry};
 use kaspa_txscript_errors::TxScriptError;
-use silverscript_lang::ast::{Expr, parse_type_ref};
+use silverscript_abi::ArtifactValue;
+use silverscript_lang::ast::Expr;
 use silverscript_lang::compiler::{
     CompileOptions, CompiledContract, CovenantDeclCallOptions, compile_contract, generated_covenant_auth_entrypoint_name,
-    struct_object,
+    sil_abi_artifact_with_options,
 };
 
 mod common;
 
 use common::{
-    assert_verify_like_error, covenant_decl_sigscript, covenant_output, covenant_utxo, execute_input_with_covenants,
-    plain_covenant_output, plain_utxo, push_redeem_script, tx_input,
+    assert_verify_like_error, build_sig_script_for_covenant_decl, bytecode, covenant_decl_sigscript, covenant_output, covenant_utxo,
+    execute_input_with_covenants, plain_covenant_output, plain_utxo, push_redeem_script, tx_input,
 };
 
 const COV_A: Hash = Hash::from_bytes(*b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
@@ -152,8 +155,8 @@ const AUTH_VERIFICATION_CARDINALITY_SOURCE: &str = r#"
     }
 "#;
 
-fn compile_state(source: &'static str, value: i64) -> CompiledContract<'static> {
-    compile_contract(source, &[Expr::int(value)], CompileOptions::default()).expect("compile succeeds")
+fn compile_state(source: &'static str, value: i64) -> silverscript_abi::SilAbiArtifact {
+    sil_abi_artifact_with_options(source, &[ArtifactValue::Int(value)], CompileOptions::default()).expect("compile succeeds")
 }
 
 fn function_param_type_names(compiled: &CompiledContract<'_>, function_name: &str) -> Vec<String> {
@@ -169,32 +172,33 @@ fn function_param_type_names(compiled: &CompiledContract<'_>, function_name: &st
         .collect()
 }
 
-fn state_array_arg(values: Vec<i64>) -> Expr<'static> {
-    Expr::array(
-        parse_type_ref("State[]").unwrap(),
-        values.into_iter().map(|value| struct_object("State", vec![("value", Expr::int(value))])).collect(),
+fn state_array_arg(values: Vec<i64>) -> ArtifactValue {
+    ArtifactValue::Array(values.into_iter().map(state_arg).collect())
+}
+
+fn state_arg(value: i64) -> ArtifactValue {
+    BTreeMap::from([("value".to_string(), value.into())]).into()
+}
+
+fn compile_kcc20_state(owner: u8, amount: i64) -> silverscript_abi::SilAbiArtifact {
+    sil_abi_artifact_with_options(
+        KCC20_SHAPED_SOURCE,
+        &[ArtifactValue::Bytes(vec![owner]), ArtifactValue::Int(amount)],
+        CompileOptions::default(),
     )
+    .expect("KCC20-shaped contract compiles")
 }
 
-fn state_arg(value: i64) -> Expr<'static> {
-    struct_object("State", vec![("value", Expr::int(value))])
+fn kcc20_state_arg(owner: u8, amount: i64) -> ArtifactValue {
+    BTreeMap::from([("owner".to_string(), vec![owner].into()), ("amount".to_string(), amount.into())]).into()
 }
 
-fn compile_kcc20_state(owner: u8, amount: i64) -> CompiledContract<'static> {
-    compile_contract(KCC20_SHAPED_SOURCE, &[Expr::bytes(vec![owner]), Expr::int(amount)], CompileOptions::default())
-        .expect("KCC20-shaped contract compiles")
-}
-
-fn kcc20_state_arg(owner: u8, amount: i64) -> Expr<'static> {
-    struct_object("State", vec![("owner", Expr::bytes(vec![owner])), ("amount", Expr::int(amount))])
-}
-
-fn cov_decl_nm_leader_sigscript(compiled: &CompiledContract<'_>, next_values: Vec<i64>) -> Vec<u8> {
+fn cov_decl_nm_leader_sigscript(compiled: &silverscript_abi::SilAbiArtifact, next_values: Vec<i64>) -> Vec<u8> {
     covenant_decl_sigscript(compiled, "rebalance", vec![state_array_arg(next_values)], true)
 }
 
-fn redeem_only_sigscript(compiled: &CompiledContract<'_>) -> Vec<u8> {
-    push_redeem_script(&compiled.bytecode)
+fn redeem_only_sigscript(compiled: &silverscript_abi::SilAbiArtifact) -> Vec<u8> {
+    push_redeem_script(&bytecode(compiled))
 }
 
 #[test]
@@ -231,7 +235,7 @@ fn singleton_transition_allows_correct_state_update() {
     let active = compile_state(AUTH_SINGLETON_TRANSITION_SOURCE, 10);
     let out = compile_state(AUTH_SINGLETON_TRANSITION_SOURCE, 13);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "bump", vec![Expr::int(3)], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "bump", vec![ArtifactValue::Int(3)], false));
     let outputs = vec![covenant_output(&out, 0, COV_A)];
     let tx = Transaction::new(1, vec![input0], outputs, 0, Default::default(), 0, vec![]);
     let entries = vec![covenant_utxo(&active, COV_A)];
@@ -245,7 +249,7 @@ fn singleton_transition_rejects_mismatched_output_state() {
     let active = compile_state(AUTH_SINGLETON_TRANSITION_SOURCE, 10);
     let wrong_out = compile_state(AUTH_SINGLETON_TRANSITION_SOURCE, 12);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "bump", vec![Expr::int(3)], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "bump", vec![ArtifactValue::Int(3)], false));
     let outputs = vec![covenant_output(&wrong_out, 0, COV_A)];
     let tx = Transaction::new(1, vec![input0], outputs, 0, Default::default(), 0, vec![]);
     let entries = vec![covenant_utxo(&active, COV_A)];
@@ -260,7 +264,7 @@ fn singleton_transition_rejects_two_authorized_outputs() {
     let out0 = compile_state(AUTH_SINGLETON_TRANSITION_SOURCE, 13);
     let out1 = compile_state(AUTH_SINGLETON_TRANSITION_SOURCE, 13);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "bump", vec![Expr::int(3)], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "bump", vec![ArtifactValue::Int(3)], false));
     let outputs = vec![covenant_output(&out0, 0, COV_A), covenant_output(&out1, 0, COV_A)];
     let tx = Transaction::new(1, vec![input0], outputs, 0, Default::default(), 0, vec![]);
     let entries = vec![covenant_utxo(&active, COV_A)];
@@ -273,7 +277,7 @@ fn singleton_transition_rejects_two_authorized_outputs() {
 fn singleton_transition_rejects_missing_authorized_output() {
     let active = compile_state(AUTH_SINGLETON_TRANSITION_SOURCE, 10);
 
-    let input0 = tx_input(0, covenant_decl_sigscript(&active, "bump", vec![Expr::int(3)], false));
+    let input0 = tx_input(0, covenant_decl_sigscript(&active, "bump", vec![ArtifactValue::Int(3)], false));
     let tx = Transaction::new(1, vec![input0], vec![], 0, Default::default(), 0, vec![]);
     let entries = vec![covenant_utxo(&active, COV_A)];
 
@@ -433,8 +437,8 @@ fn many_to_many_happy_path_succeeds() {
     let in1 = compile_state(COV_N_TO_M_SOURCE, 7);
     let out0 = compile_state(COV_N_TO_M_SOURCE, 10);
     let out1 = compile_state(COV_N_TO_M_SOURCE, 10);
-    assert_eq!(in0.bytecode, out0.bytecode, "leader input and output[0] script should match");
-    assert_eq!(in0.bytecode, out1.bytecode, "leader input and output[1] script should match");
+    assert_eq!(bytecode(&in0), bytecode(&out0), "leader input and output[0] script should match");
+    assert_eq!(bytecode(&in0), bytecode(&out1), "leader input and output[1] script should match");
 
     // Intended valid shape: two covenant inputs in the same id, two covenant outputs in the same id,
     // leader path on input 0 and delegate path on input 1.
@@ -453,11 +457,10 @@ fn shared_delegate_body_authenticates_each_inputs_local_state() {
     let in1 = compile_kcc20_state(2, 7);
     let out0 = compile_kcc20_state(3, 8);
     let out1 = compile_kcc20_state(4, 9);
-    let next_states =
-        Expr::array(parse_type_ref("State[]").expect("State[] parses"), vec![kcc20_state_arg(3, 8), kcc20_state_arg(4, 9)]);
+    let next_states = ArtifactValue::Array(vec![kcc20_state_arg(3, 8), kcc20_state_arg(4, 9)]);
 
-    let leader_sigscript = covenant_decl_sigscript(&in0, "transferPolicy", vec![next_states, Expr::dynamic_bytes(vec![1])], true);
-    let delegate_sigscript = covenant_decl_sigscript(&in1, "transferPolicy", vec![Expr::dynamic_bytes(vec![2])], false);
+    let leader_sigscript = covenant_decl_sigscript(&in0, "transferPolicy", vec![next_states, ArtifactValue::Bytes(vec![1])], true);
+    let delegate_sigscript = covenant_decl_sigscript(&in1, "transferPolicy", vec![ArtifactValue::Bytes(vec![2])], false);
     let outputs = vec![covenant_output(&out0, 0, COV_A), covenant_output(&out1, 1, COV_A)];
     let tx = Transaction::new(
         1,
@@ -473,7 +476,7 @@ fn shared_delegate_body_authenticates_each_inputs_local_state() {
     execute_input_with_covenants(tx.clone(), entries.clone(), 0).expect("leader authenticates its local owner");
     execute_input_with_covenants(tx, entries.clone(), 1).expect("delegate authenticates its own local owner");
 
-    let wrong_delegate_sigscript = covenant_decl_sigscript(&in1, "transferPolicy", vec![Expr::dynamic_bytes(vec![1])], false);
+    let wrong_delegate_sigscript = covenant_decl_sigscript(&in1, "transferPolicy", vec![ArtifactValue::Bytes(vec![1])], false);
     let wrong_tx = Transaction::new(
         1,
         vec![tx_input(0, redeem_only_sigscript(&in0)), tx_input(1, wrong_delegate_sigscript)],
@@ -561,18 +564,17 @@ fn many_to_many_leader_rejects_cov_output_with_different_script() {
 #[test]
 fn many_to_many_transition_leader_rejects_spoofed_prev_states() {
     let in0 = compile_state(COV_N_TO_M_TRANSITION_SOURCE, 10);
-    let honest = in0
-        .build_sig_script_for_covenant_decl("carry_forward", vec![], CovenantDeclCallOptions { is_leader: true })
+    let honest = build_sig_script_for_covenant_decl(&in0, "carry_forward", vec![], CovenantDeclCallOptions { is_leader: true })
         .expect("leader transition call should succeed without caller-supplied prev_states");
     assert!(!honest.is_empty(), "leader transition sigscript should not be empty");
 
-    let err = in0
-        .build_sig_script_for_covenant_decl(
-            "carry_forward",
-            vec![state_array_arg(vec![42, 43])],
-            CovenantDeclCallOptions { is_leader: true },
-        )
-        .expect_err("spoofed prev_states should no longer be accepted through the leader ABI");
+    let err = build_sig_script_for_covenant_decl(
+        &in0,
+        "carry_forward",
+        vec![state_array_arg(vec![42, 43])],
+        CovenantDeclCallOptions { is_leader: true },
+    )
+    .expect_err("spoofed prev_states should no longer be accepted through the leader ABI");
     assert!(matches!(err, silverscript_lang::compiler::CompilerError::Unsupported(_)), "unexpected error: {err:?}");
 }
 
@@ -610,12 +612,14 @@ fn runtime_accepts_state_entrypoint_argument_for_generated_wrapper() {
 fn runtime_passes_state_into_generated_policy_function() {
     let active = compile_state(AUTH_SINGLETON_ARRAY_RUNTIME_SOURCE, 10);
     let out = compile_state(AUTH_SINGLETON_ARRAY_RUNTIME_SOURCE, 11);
+    let lowered = compile_contract(AUTH_SINGLETON_ARRAY_RUNTIME_SOURCE, &[Expr::int(10)], CompileOptions::default())
+        .expect("lowered AST compiles");
 
     let wrapper_name = generated_covenant_auth_entrypoint_name("step");
-    let wrapper_param_types = function_param_type_names(&active, &wrapper_name);
+    let wrapper_param_types = function_param_type_names(&lowered, &wrapper_name);
     assert_eq!(wrapper_param_types, vec!["State".to_string()]);
 
-    let policy = active
+    let policy = lowered
         .ast
         .functions
         .iter()

--- a/silverscript-lang/tests/examples_tests.rs
+++ b/silverscript-lang/tests/examples_tests.rs
@@ -16,7 +16,7 @@ use kaspa_txscript::{EngineCtx, EngineFlags, TxScriptEngine, pay_to_script_hash_
 use rand::{RngCore, thread_rng};
 use secp256k1::{Keypair, Secp256k1, SecretKey};
 use silverscript_abi::ArtifactValue;
-use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
+use silverscript_lang::compiler::{CompileOptions, compile_to_sil_abi_artifact_with_options};
 use std::fs;
 
 use common::{bytecode, encode_entry_sig_script, encode_single_entry_sig_script};
@@ -175,7 +175,7 @@ fn r0_groth16_fixture() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
 fn compiles_announcement_example_and_verifies() {
     let source = load_example_source("announcement.sil");
 
-    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
     let message = "A contract may not injure a human being or, through inaction, allow a human being to come to harm.";
     let announcement_script = build_null_data_script(27906, message);
 
@@ -216,7 +216,7 @@ fn compiles_announcement_example_and_verifies() {
 fn compiles_constant_budget_example_and_verifies() {
     let source = load_example_source("constant_budget.sil");
 
-    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
     let recipient0 = [2u8; 32];
     let recipient1 = [3u8; 32];
     let output0_script = build_p2pk_script(&recipient0);
@@ -261,7 +261,7 @@ fn compiles_constant_budget_example_and_verifies() {
 fn compiles_for_loop_example_and_verifies() {
     let source = load_example_source("for_loop.sil");
 
-    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
     let recipient0 = [5u8; 32];
     let recipient1 = [6u8; 32];
     let recipient2 = [7u8; 32];
@@ -308,7 +308,7 @@ fn compiles_for_loop_ctor_example_with_constructor_bounds() {
     let source = load_example_source("for_loop_ctor.sil");
 
     let constructor_args = [(0).into(), (4).into()];
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
     let recipient0 = [5u8; 32];
     let recipient1 = [6u8; 32];
     let recipient2 = [7u8; 32];
@@ -335,7 +335,7 @@ fn compiles_return_basic_example_file_and_verifies() {
     let source = load_example_source("return_basic.sil");
 
     let options = CompileOptions { allow_entrypoint_return: true, ..CompileOptions::default() };
-    let compiled = sil_abi_artifact_with_options(&source, &[], options).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[], options).expect("compile succeeds");
     let script = bytecode_with_return_checks(bytecode(&compiled).clone(), &[12, 8]);
     let recipient0 = [9u8; 32];
     let recipient1 = [10u8; 32];
@@ -353,7 +353,7 @@ fn compiles_return_loop_example_file_and_verifies() {
     let source = load_example_source("return_loop.sil");
 
     let options = CompileOptions { allow_entrypoint_return: true, ..CompileOptions::default() };
-    let compiled = sil_abi_artifact_with_options(&source, &[], options).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[], options).expect("compile succeeds");
     let script = bytecode_with_return_checks(bytecode(&compiled).clone(), &[10]);
     let recipient0 = [11u8; 32];
     let recipient1 = [12u8; 32];
@@ -370,7 +370,7 @@ fn compiles_return_loop_example_file_and_verifies() {
 fn compiles_r0_g16_example_and_verifies() {
     let source = load_example_source("r0_g16.sil");
     let (journal_hash, proof, image_id) = r0_groth16_fixture();
-    let compiled = sil_abi_artifact_with_options(&source, &[image_id.into()], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[image_id.into()], CompileOptions::default()).expect("compile succeeds");
     let sigscript =
         encode_entry_sig_script(&compiled, "verify", &[journal_hash.into(), ArtifactValue::Bytes(proof)]).expect("sigscript builds");
 
@@ -391,7 +391,7 @@ fn compiles_r0_g16_example_and_verifies() {
 fn compiles_g16_verify_example_and_verifies() {
     let source = load_example_source("g16_verify.sil");
     let (verifying_key, proof, public_inputs) = kaspa_txscript::zk_precompiles::tests::helpers::load_groth_fields();
-    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
     let mut args = vec![ArtifactValue::Bytes(verifying_key), ArtifactValue::Bytes(proof)];
     args.extend(public_inputs.into_iter().map(Into::into));
     let sigscript = encode_entry_sig_script(&compiled, "verify", &args).expect("sigscript builds");
@@ -415,7 +415,7 @@ fn compiles_r0_succinct_example_and_verifies() {
     let (control_id, seal, claim, hashfn, control_index, control_digests, journal, image_id) =
         kaspa_txscript::zk_precompiles::tests::helpers::load_stark_fields();
     assert_eq!(hashfn, vec![1u8], "fixture should use Poseidon2 hash function id");
-    let compiled = sil_abi_artifact_with_options(&source, &[image_id.into(), control_id.into()], CompileOptions::default())
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[image_id.into(), control_id.into()], CompileOptions::default())
         .expect("compile succeeds");
     let sigscript = encode_entry_sig_script(
         &compiled,
@@ -443,7 +443,7 @@ fn r0_succinct_sha256_example_is_reserved_for_future_use() {
     let image_id = vec![0x11u8; 32];
     let control_id = vec![0x22u8; 32];
 
-    let err = sil_abi_artifact_with_options(&source, &[image_id.into(), control_id.into()], CompileOptions::default())
+    let err = compile_to_sil_abi_artifact_with_options(&source, &[image_id.into(), control_id.into()], CompileOptions::default())
         .expect_err("compile should fail");
     assert!(err.to_string().contains("only Poseidon2 R0 Succinct verification is currently supported"), "unexpected error: {err}");
 }
@@ -459,7 +459,7 @@ fn compiles_return_basic_example_and_verifies() {
     "#;
 
     let options = CompileOptions { allow_entrypoint_return: true, ..CompileOptions::default() };
-    let compiled = sil_abi_artifact_with_options(source, &[], options).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(source, &[], options).expect("compile succeeds");
     let script = bytecode_with_return_checks(bytecode(&compiled).clone(), &[2, 5]);
     let recipient0 = [13u8; 32];
     let recipient1 = [14u8; 32];
@@ -483,7 +483,7 @@ fn runs_everything_example_and_verifies() {
     let owner_pk = owner.x_only_public_key().0.serialize();
 
     let constructor_args = [7.into(), String::from("hello").into()];
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([23u8; 32]), index: 0 },
@@ -537,7 +537,7 @@ fn runs_sum_series_example_with_multiple_inputs() {
 
     for (max_iterations, n, should_pass) in cases {
         let constructor_args = [max_iterations.into()];
-        let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+        let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
         let sigscript = encode_single_entry_sig_script(&compiled, &[n.into()]).expect("sigscript builds");
         let result = run_contract_with_tx(
             bytecode(&compiled).clone(),
@@ -566,7 +566,7 @@ fn runs_complex_assignments_example_and_verifies() {
 
     for (limit, n) in cases {
         let constructor_args = [limit.into()];
-        let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+        let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
         let sigscript = encode_single_entry_sig_script(&compiled, &[n.into()]).expect("sigscript builds");
         let result = run_contract_with_tx(
             bytecode(&compiled).clone(),
@@ -601,7 +601,7 @@ fn compiles_hodl_vault_example_and_verifies() {
     let oracle_sig = oracle.sign_schnorr(oracle_signed).as_ref().to_vec();
 
     let constructor_args = vec![owner_pk.to_vec().into(), oracle_pk.to_vec().into(), min_block.into(), price_target.into()];
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([7u8; 32]), index: 0 },
@@ -664,7 +664,7 @@ fn compiles_mecenas_example_and_verifies() {
     let pledge = 2000i64;
     let constructor_args = vec![recipient.to_vec().into(), funder_hash.clone().into(), pledge.into()];
 
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     // Test receive() with changeValue > pledge + minerFee (else branch).
     let sigscript = encode_entry_sig_script(&compiled, "receive", &[]).expect("sigscript builds");
@@ -769,7 +769,7 @@ fn compiles_mecenas_locktime_example_and_verifies() {
         initial_block.to_le_bytes().to_vec().into(),
     ];
 
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
     let passed_blocks = lock_time - initial_block;
     let pledge = passed_blocks as i64 * pledge_per_block;
 
@@ -874,7 +874,7 @@ fn compiles_p2pkh_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([5u8; 32]), index: 0 },
@@ -932,7 +932,7 @@ fn compiles_p2pkh_ecdsa_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.into()];
 
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([5u8; 32]), index: 0 },
@@ -991,7 +991,7 @@ fn compiles_transfer_with_timeout_and_verifies() {
     let timeout = kaspa_txscript::LOCK_TIME_THRESHOLD as i64;
     let constructor_args = vec![sender_pk.to_vec().into(), recipient_pk.to_vec().into(), timeout.into()];
 
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([6u8; 32]), index: 0 },
@@ -1093,7 +1093,7 @@ fn compiles_covenant_escrow_example_and_verifies() {
     let seller = [11u8; 32];
     let constructor_args = vec![arbiter_hash.clone().into(), buyer.to_vec().into(), seller.to_vec().into()];
 
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input_value = 12_000u64;
     let output0_value = input_value - 1000;
@@ -1158,7 +1158,7 @@ fn compiles_covenant_last_will_and_verifies() {
     let hot_hash = blake2b_simd::Params::new().hash_length(32).to_state().update(hot_pk.as_slice()).finalize().as_bytes().to_vec();
 
     let constructor_args = vec![inheritor_hash.clone().into(), cold_hash.clone().into(), hot_hash.clone().into()];
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([12u8; 32]), index: 0 },
@@ -1309,7 +1309,7 @@ fn compiles_covenant_mecenas_example_and_verifies() {
     let period = 10i64;
     let constructor_args = vec![recipient.to_vec().into(), funder_hash.clone().into(), pledge.into(), period.into()];
 
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     // Test receive() with changeValue > pledge + minerFee (else branch).
     let sigscript = encode_entry_sig_script(&compiled, "receive", &[]).expect("sigscript builds");
@@ -1408,16 +1408,16 @@ fn compiles_covenant_id_example_and_verifies() {
 
     let execute_case = |out0_amount: i64, out1_amount: i64| {
         let active_compiled =
-            sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), 1_000i64.into()], CompileOptions::default())
+            compile_to_sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), 1_000i64.into()], CompileOptions::default())
                 .expect("compile succeeds");
         let input1_compiled =
-            sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), 600i64.into()], CompileOptions::default())
+            compile_to_sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), 600i64.into()], CompileOptions::default())
                 .expect("compile succeeds");
         let output0_compiled =
-            sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), out0_amount.into()], CompileOptions::default())
+            compile_to_sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), out0_amount.into()], CompileOptions::default())
                 .expect("compile succeeds");
         let output1_compiled =
-            sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), out1_amount.into()], CompileOptions::default())
+            compile_to_sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), out1_amount.into()], CompileOptions::default())
                 .expect("compile succeeds");
 
         let mut active_sigscript =
@@ -1511,7 +1511,7 @@ fn compiles_bar_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([18u8; 32]), index: 0 },
@@ -1566,7 +1566,7 @@ fn compiles_foo_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([19u8; 32]), index: 0 },
@@ -1616,7 +1616,7 @@ fn compiles_foo_example_and_verifies() {
 fn compiles_bounded_bytes_example_and_verifies() {
     let source = load_example_source("bounded_bytes.sil");
 
-    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
     let sigscript = encode_entry_sig_script(&compiled, "spend", &[vec![0u8; 4].into(), 0.into()]).expect("sigscript builds");
     let result = run_contract_with_tx(
         bytecode(&compiled).clone(),
@@ -1653,7 +1653,7 @@ fn compiles_p2pkh_invalid_example_and_fails() {
     let pkh = blake2b_simd::Params::new().hash_length(20).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([20u8; 32]), index: 0 },
@@ -1709,7 +1709,7 @@ fn compiles_sibling_introspection_example_and_verifies() {
     expected_locking_bytecode.extend_from_slice(&expected_script);
     let constructor_args = [expected_locking_bytecode.clone().into()];
 
-    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
     let sigscript = encode_entry_sig_script(&compiled, "spend", &[]).expect("sigscript builds");
     let input0 = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([21u8; 32]), index: 0 },
@@ -1773,7 +1773,7 @@ fn compiles_sibling_introspection_example_and_verifies() {
 fn compiles_many_assignments_example_under_500_bytes() {
     let source = load_example_source("many_assignments.sil");
 
-    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("long example should compile");
+    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("long example should compile");
 
     // This example chains many assignments like `a_n = a_(n-1) * a_(n-1)`.
     // We check the final bytecode stays small to prove the compiler is not

--- a/silverscript-lang/tests/examples_tests.rs
+++ b/silverscript-lang/tests/examples_tests.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
 use kaspa_consensus_core::hashing::sighash::{calc_ecdsa_signature_hash, calc_schnorr_signature_hash};
 use kaspa_consensus_core::hashing::sighash_type::SIG_HASH_ALL;
@@ -13,9 +15,11 @@ use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::{EngineCtx, EngineFlags, TxScriptEngine, pay_to_script_hash_script};
 use rand::{RngCore, thread_rng};
 use secp256k1::{Keypair, Secp256k1, SecretKey};
-use silverscript_lang::ast::Expr;
-use silverscript_lang::compiler::{CompileOptions, compile_contract};
+use silverscript_abi::ArtifactValue;
+use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
 use std::fs;
+
+use common::{bytecode, encode_entry_sig_script, encode_single_entry_sig_script};
 
 fn build_null_data_script(tag: i64, message: &str) -> Vec<u8> {
     ScriptBuilder::new().add_op(OpReturn).unwrap().add_i64(tag).unwrap().add_data(message.as_bytes()).unwrap().drain()
@@ -171,18 +175,18 @@ fn r0_groth16_fixture() -> (Vec<u8>, Vec<u8>, Vec<u8>) {
 fn compiles_announcement_example_and_verifies() {
     let source = load_example_source("announcement.sil");
 
-    let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
     let message = "A contract may not injure a human being or, through inaction, allow a human being to come to harm.";
     let announcement_script = build_null_data_script(27906, message);
 
     // Test announce() with changeAmount >= minerFee (else branch).
-    let sigscript = compiled.build_sig_script("announce", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "announce", &[]).expect("sigscript builds");
     let input_value = 3000u64;
     let output1_value = input_value - 1000;
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         announcement_script.clone(),
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         input_value,
         0,
         output1_value,
@@ -192,13 +196,13 @@ fn compiles_announcement_example_and_verifies() {
     assert!(result.is_ok(), "announcement example failed: {}", result.unwrap_err());
 
     // Test announce() with changeAmount < minerFee (if branch).
-    let sigscript = compiled.build_sig_script("announce", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "announce", &[]).expect("sigscript builds");
     let input_value = 1500u64;
     let output1_value = 1u64;
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         announcement_script,
-        compiled.bytecode,
+        bytecode(&compiled),
         input_value,
         0,
         output1_value,
@@ -212,19 +216,19 @@ fn compiles_announcement_example_and_verifies() {
 fn compiles_constant_budget_example_and_verifies() {
     let source = load_example_source("constant_budget.sil");
 
-    let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
     let recipient0 = [2u8; 32];
     let recipient1 = [3u8; 32];
     let output0_script = build_p2pk_script(&recipient0);
     let output1_script = build_p2pk_script(&recipient1);
 
     // Test spend() with output1 >= MIN_CHANGE (if branch).
-    let sigscript = compiled.build_sig_script("spend", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "spend", &[]).expect("sigscript builds");
     let input_value = 4000u64;
     let output0_value = 1500u64;
     let output1_value = 1200u64;
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         output0_script.clone(),
         output1_script.clone(),
         input_value,
@@ -236,12 +240,12 @@ fn compiles_constant_budget_example_and_verifies() {
     assert!(result.is_ok(), "constant_budget if branch failed: {}", result.unwrap_err());
 
     // Test spend() with output1 < MIN_CHANGE (else branch).
-    let sigscript = compiled.build_sig_script("spend", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "spend", &[]).expect("sigscript builds");
     let input_value = 3000u64;
     let output0_value = 1300u64;
     let output1_value = 500u64;
     let result = run_contract_with_tx(
-        compiled.bytecode,
+        bytecode(&compiled),
         output0_script,
         output1_script,
         input_value,
@@ -257,7 +261,7 @@ fn compiles_constant_budget_example_and_verifies() {
 fn compiles_for_loop_example_and_verifies() {
     let source = load_example_source("for_loop.sil");
 
-    let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
     let recipient0 = [5u8; 32];
     let recipient1 = [6u8; 32];
     let recipient2 = [7u8; 32];
@@ -268,7 +272,7 @@ fn compiles_for_loop_example_and_verifies() {
     let output3_script = build_p2pk_script(&recipient3);
 
     // Test check() with loop bounds START..END.
-    let sigscript = compiled.build_sig_script("check", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "check", &[]).expect("sigscript builds");
     let input_value = 10_000u64;
     let outputs = vec![
         (1000u64, output0_script.clone()),
@@ -276,11 +280,11 @@ fn compiles_for_loop_example_and_verifies() {
         (1002u64, output2_script.clone()),
         (1003u64, output3_script.clone()),
     ];
-    let result = run_contract_with_outputs(compiled.bytecode.clone(), outputs, input_value, sigscript, 0);
+    let result = run_contract_with_outputs(bytecode(&compiled).clone(), outputs, input_value, sigscript, 0);
     assert!(result.is_ok(), "for_loop example failed: {}", result.unwrap_err());
 
     // Test check() failure when require fails in the loop.
-    let sigscript = compiled.build_sig_script("check", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "check", &[]).expect("sigscript builds");
     let input_value = 10_000u64;
     let outputs = vec![
         (1000u64, output0_script.clone()),
@@ -288,14 +292,14 @@ fn compiles_for_loop_example_and_verifies() {
         (999u64, output2_script.clone()),
         (1003u64, output3_script.clone()),
     ];
-    let result = run_contract_with_outputs(compiled.bytecode.clone(), outputs, input_value, sigscript, 0);
+    let result = run_contract_with_outputs(bytecode(&compiled).clone(), outputs, input_value, sigscript, 0);
     assert!(result.is_err(), "for_loop require failure should error");
 
     // Test check() failure when there are fewer than 4 outputs.
-    let sigscript = compiled.build_sig_script("check", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "check", &[]).expect("sigscript builds");
     let input_value = 10_000u64;
     let outputs = vec![(1000u64, output0_script), (1001u64, output1_script), (1002u64, output2_script)];
-    let result = run_contract_with_outputs(compiled.bytecode, outputs, input_value, sigscript, 0);
+    let result = run_contract_with_outputs(bytecode(&compiled), outputs, input_value, sigscript, 0);
     assert!(result.is_err(), "for_loop with too few outputs should error");
 }
 
@@ -304,7 +308,7 @@ fn compiles_for_loop_ctor_example_with_constructor_bounds() {
     let source = load_example_source("for_loop_ctor.sil");
 
     let constructor_args = [(0).into(), (4).into()];
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
     let recipient0 = [5u8; 32];
     let recipient1 = [6u8; 32];
     let recipient2 = [7u8; 32];
@@ -314,7 +318,7 @@ fn compiles_for_loop_ctor_example_with_constructor_bounds() {
     let output2_script = build_p2pk_script(&recipient2);
     let output3_script = build_p2pk_script(&recipient3);
 
-    let sigscript = compiled.build_sig_script("check", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "check", &[]).expect("sigscript builds");
     let input_value = 10_000u64;
     let outputs = vec![
         (1000u64, output0_script.clone()),
@@ -322,7 +326,7 @@ fn compiles_for_loop_ctor_example_with_constructor_bounds() {
         (1002u64, output2_script.clone()),
         (1003u64, output3_script.clone()),
     ];
-    let result = run_contract_with_outputs(compiled.bytecode, outputs, input_value, sigscript, 0);
+    let result = run_contract_with_outputs(bytecode(&compiled), outputs, input_value, sigscript, 0);
     assert!(result.is_ok(), "for_loop_ctor example failed: {}", result.unwrap_err());
 }
 
@@ -331,15 +335,15 @@ fn compiles_return_basic_example_file_and_verifies() {
     let source = load_example_source("return_basic.sil");
 
     let options = CompileOptions { allow_entrypoint_return: true, ..CompileOptions::default() };
-    let compiled = compile_contract(&source, &[], options).expect("compile succeeds");
-    let script = bytecode_with_return_checks(compiled.bytecode.clone(), &[12, 8]);
+    let compiled = sil_abi_artifact_with_options(&source, &[], options).expect("compile succeeds");
+    let script = bytecode_with_return_checks(bytecode(&compiled).clone(), &[12, 8]);
     let recipient0 = [9u8; 32];
     let recipient1 = [10u8; 32];
     let output0_script = build_p2pk_script(&recipient0);
     let output1_script = build_p2pk_script(&recipient1);
 
     // Test main(b=8) returns [12, 8] on stack.
-    let sigscript = compiled.build_sig_script("main", vec![8.into()]).expect("sigscript builds");
+    let sigscript = encode_single_entry_sig_script(&compiled, &[8.into()]).expect("sigscript builds");
     let result = run_contract_with_tx(script, output0_script, output1_script, 2000, 500, 500, sigscript, 0);
     assert!(result.is_ok(), "return basic failed: {}", result.unwrap_err());
 }
@@ -349,15 +353,15 @@ fn compiles_return_loop_example_file_and_verifies() {
     let source = load_example_source("return_loop.sil");
 
     let options = CompileOptions { allow_entrypoint_return: true, ..CompileOptions::default() };
-    let compiled = compile_contract(&source, &[], options).expect("compile succeeds");
-    let script = bytecode_with_return_checks(compiled.bytecode.clone(), &[10]);
+    let compiled = sil_abi_artifact_with_options(&source, &[], options).expect("compile succeeds");
+    let script = bytecode_with_return_checks(bytecode(&compiled).clone(), &[10]);
     let recipient0 = [11u8; 32];
     let recipient1 = [12u8; 32];
     let output0_script = build_p2pk_script(&recipient0);
     let output1_script = build_p2pk_script(&recipient1);
 
     // Test main() returns the loop total on stack.
-    let sigscript = compiled.build_sig_script("main", vec![]).expect("sigscript builds");
+    let sigscript = encode_single_entry_sig_script(&compiled, &[]).expect("sigscript builds");
     let result = run_contract_with_tx(script, output0_script, output1_script, 2000, 500, 500, sigscript, 0);
     assert!(result.is_ok(), "return loop failed: {}", result.unwrap_err());
 }
@@ -366,14 +370,14 @@ fn compiles_return_loop_example_file_and_verifies() {
 fn compiles_r0_g16_example_and_verifies() {
     let source = load_example_source("r0_g16.sil");
     let (journal_hash, proof, image_id) = r0_groth16_fixture();
-    let compiled = compile_contract(&source, &[image_id.into()], CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &[image_id.into()], CompileOptions::default()).expect("compile succeeds");
     let sigscript =
-        compiled.build_sig_script("verify", vec![journal_hash.into(), Expr::dynamic_bytes(proof)]).expect("sigscript builds");
+        encode_entry_sig_script(&compiled, "verify", &[journal_hash.into(), ArtifactValue::Bytes(proof)]).expect("sigscript builds");
 
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
-        compiled.bytecode.clone(),
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
+        bytecode(&compiled).clone(),
+        bytecode(&compiled).clone(),
         2000,
         500,
         500,
@@ -387,15 +391,15 @@ fn compiles_r0_g16_example_and_verifies() {
 fn compiles_g16_verify_example_and_verifies() {
     let source = load_example_source("g16_verify.sil");
     let (verifying_key, proof, public_inputs) = kaspa_txscript::zk_precompiles::tests::helpers::load_groth_fields();
-    let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile succeeds");
-    let mut args: Vec<Expr<'static>> = vec![Expr::dynamic_bytes(verifying_key), Expr::dynamic_bytes(proof)];
+    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    let mut args = vec![ArtifactValue::Bytes(verifying_key), ArtifactValue::Bytes(proof)];
     args.extend(public_inputs.into_iter().map(Into::into));
-    let sigscript = compiled.build_sig_script("verify", args).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "verify", &args).expect("sigscript builds");
 
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
-        compiled.bytecode.clone(),
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
+        bytecode(&compiled).clone(),
+        bytecode(&compiled).clone(),
         2000,
         500,
         500,
@@ -411,19 +415,19 @@ fn compiles_r0_succinct_example_and_verifies() {
     let (control_id, seal, claim, hashfn, control_index, control_digests, journal, image_id) =
         kaspa_txscript::zk_precompiles::tests::helpers::load_stark_fields();
     assert_eq!(hashfn, vec![1u8], "fixture should use Poseidon2 hash function id");
-    let compiled =
-        compile_contract(&source, &[image_id.into(), control_id.into()], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled
-        .build_sig_script(
-            "verify",
-            vec![claim.into(), control_index.into(), Expr::dynamic_bytes(control_digests), Expr::dynamic_bytes(seal), journal.into()],
-        )
-        .expect("sigscript builds");
+    let compiled = sil_abi_artifact_with_options(&source, &[image_id.into(), control_id.into()], CompileOptions::default())
+        .expect("compile succeeds");
+    let sigscript = encode_entry_sig_script(
+        &compiled,
+        "verify",
+        &[claim.into(), control_index.into(), ArtifactValue::Bytes(control_digests), ArtifactValue::Bytes(seal), journal.into()],
+    )
+    .expect("sigscript builds");
 
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
-        compiled.bytecode.clone(),
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
+        bytecode(&compiled).clone(),
+        bytecode(&compiled).clone(),
         2000,
         500,
         500,
@@ -439,8 +443,8 @@ fn r0_succinct_sha256_example_is_reserved_for_future_use() {
     let image_id = vec![0x11u8; 32];
     let control_id = vec![0x22u8; 32];
 
-    let err =
-        compile_contract(&source, &[image_id.into(), control_id.into()], CompileOptions::default()).expect_err("compile should fail");
+    let err = sil_abi_artifact_with_options(&source, &[image_id.into(), control_id.into()], CompileOptions::default())
+        .expect_err("compile should fail");
     assert!(err.to_string().contains("only Poseidon2 R0 Succinct verification is currently supported"), "unexpected error: {err}");
 }
 
@@ -455,14 +459,14 @@ fn compiles_return_basic_example_and_verifies() {
     "#;
 
     let options = CompileOptions { allow_entrypoint_return: true, ..CompileOptions::default() };
-    let compiled = compile_contract(source, &[], options).expect("compile succeeds");
-    let script = bytecode_with_return_checks(compiled.bytecode.clone(), &[2, 5]);
+    let compiled = sil_abi_artifact_with_options(source, &[], options).expect("compile succeeds");
+    let script = bytecode_with_return_checks(bytecode(&compiled).clone(), &[2, 5]);
     let recipient0 = [13u8; 32];
     let recipient1 = [14u8; 32];
     let output0_script = build_p2pk_script(&recipient0);
     let output1_script = build_p2pk_script(&recipient1);
 
-    let sigscript = compiled.build_sig_script("main", vec![1.into(), 3.into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "main", &[1.into(), 3.into()]).expect("sigscript builds");
     let result = run_contract_with_tx(script, output0_script, output1_script, 2000, 500, 500, sigscript, 0);
     assert!(result.is_ok(), "return basic failed: {}", result.unwrap_err());
 }
@@ -479,7 +483,7 @@ fn runs_everything_example_and_verifies() {
     let owner_pk = owner.x_only_public_key().0.serialize();
 
     let constructor_args = [7.into(), String::from("hello").into()];
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([23u8; 32]), index: 0 },
@@ -489,13 +493,13 @@ fn runs_everything_example_and_verifies() {
     };
     let output = TransactionOutput {
         value: 5_000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -507,7 +511,7 @@ fn runs_everything_example_and_verifies() {
     signature.push(SIG_HASH_ALL.to_u8());
 
     let sigscript =
-        compiled.build_sig_script("hello", vec![owner_pk.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
+        encode_entry_sig_script(&compiled, "hello", &[owner_pk.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -533,12 +537,12 @@ fn runs_sum_series_example_with_multiple_inputs() {
 
     for (max_iterations, n, should_pass) in cases {
         let constructor_args = [max_iterations.into()];
-        let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-        let sigscript = compiled.build_sig_script("main", vec![n.into()]).expect("sigscript builds");
+        let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+        let sigscript = encode_single_entry_sig_script(&compiled, &[n.into()]).expect("sigscript builds");
         let result = run_contract_with_tx(
-            compiled.bytecode.clone(),
-            compiled.bytecode.clone(),
-            compiled.bytecode.clone(),
+            bytecode(&compiled).clone(),
+            bytecode(&compiled).clone(),
+            bytecode(&compiled).clone(),
             2000,
             500,
             500,
@@ -562,12 +566,12 @@ fn runs_complex_assignments_example_and_verifies() {
 
     for (limit, n) in cases {
         let constructor_args = [limit.into()];
-        let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-        let sigscript = compiled.build_sig_script("main", vec![n.into()]).expect("sigscript builds");
+        let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+        let sigscript = encode_single_entry_sig_script(&compiled, &[n.into()]).expect("sigscript builds");
         let result = run_contract_with_tx(
-            compiled.bytecode.clone(),
-            compiled.bytecode.clone(),
-            compiled.bytecode.clone(),
+            bytecode(&compiled).clone(),
+            bytecode(&compiled).clone(),
+            bytecode(&compiled).clone(),
             2000,
             500,
             500,
@@ -597,7 +601,7 @@ fn compiles_hodl_vault_example_and_verifies() {
     let oracle_sig = oracle.sign_schnorr(oracle_signed).as_ref().to_vec();
 
     let constructor_args = vec![owner_pk.to_vec().into(), oracle_pk.to_vec().into(), min_block.into(), price_target.into()];
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([7u8; 32]), index: 0 },
@@ -607,13 +611,13 @@ fn compiles_hodl_vault_example_and_verifies() {
     };
     let output = TransactionOutput {
         value: 5000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], block_height as u64, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -625,9 +629,12 @@ fn compiles_hodl_vault_example_and_verifies() {
     signature.push(SIG_HASH_ALL.to_u8());
 
     // Test spend() function call (build sigscript for spend()).
-    let sigscript = compiled
-        .build_sig_script("spend", vec![signature.clone().into(), oracle_sig.into(), Expr::dynamic_bytes(oracle_message.clone())])
-        .expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(
+        &compiled,
+        "spend",
+        &[signature.clone().into(), oracle_sig.into(), ArtifactValue::Bytes(oracle_message.clone())],
+    )
+    .expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -657,19 +664,19 @@ fn compiles_mecenas_example_and_verifies() {
     let pledge = 2000i64;
     let constructor_args = vec![recipient.to_vec().into(), funder_hash.clone().into(), pledge.into()];
 
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     // Test receive() with changeValue > pledge + minerFee (else branch).
-    let sigscript = compiled.build_sig_script("receive", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "receive", &[]).expect("sigscript builds");
     let input_value = 10000u64;
     let output0_value = pledge as u64;
     let output1_value = input_value - pledge as u64 - 1000;
     let output0_script = build_p2pk_script(&recipient);
 
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         output0_script,
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         input_value,
         output0_value,
         output1_value,
@@ -679,7 +686,7 @@ fn compiles_mecenas_example_and_verifies() {
     assert!(result.is_ok(), "mecenas example failed: {}", result.unwrap_err());
 
     // Test receive() with changeValue <= pledge + minerFee (if branch).
-    let sigscript = compiled.build_sig_script("receive", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "receive", &[]).expect("sigscript builds");
 
     let input_value = 6000u64;
     let output0_value = input_value - 1000;
@@ -687,9 +694,9 @@ fn compiles_mecenas_example_and_verifies() {
     let output0_script = build_p2pk_script(&recipient);
 
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         output0_script,
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         input_value,
         output0_value,
         output1_value,
@@ -706,13 +713,13 @@ fn compiles_mecenas_example_and_verifies() {
     };
     let output = TransactionOutput {
         value: 5000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -724,8 +731,8 @@ fn compiles_mecenas_example_and_verifies() {
     signature.push(SIG_HASH_ALL.to_u8());
 
     // Test reclaim() function call (build sigscript for reclaim()).
-    let sigscript =
-        compiled.build_sig_script("reclaim", vec![funder_pk.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "reclaim", &[funder_pk.to_vec().into(), signature.clone().into()])
+        .expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -762,14 +769,14 @@ fn compiles_mecenas_locktime_example_and_verifies() {
         initial_block.to_le_bytes().to_vec().into(),
     ];
 
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
     let passed_blocks = lock_time - initial_block;
     let pledge = passed_blocks as i64 * pledge_per_block;
 
     let output0_script = build_p2pk_script(&recipient);
-    let mut active_bytecode = Vec::with_capacity(2 + compiled.bytecode.len());
+    let mut active_bytecode = Vec::with_capacity(2 + bytecode(&compiled).len());
     active_bytecode.extend_from_slice(&0u16.to_be_bytes());
-    active_bytecode.extend_from_slice(&compiled.bytecode);
+    active_bytecode.extend_from_slice(&bytecode(&compiled));
     let mut bc_value = Vec::new();
     bc_value.push(8u8);
     bc_value.extend_from_slice(&lock_time.to_le_bytes());
@@ -777,13 +784,13 @@ fn compiles_mecenas_locktime_example_and_verifies() {
     let output1_script = pay_to_script_hash_script(&bc_value).script().to_vec();
 
     // Test receive() with changeValue > pledgePerBlock + minerFee (else branch).
-    let sigscript = compiled.build_sig_script("receive", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "receive", &[]).expect("sigscript builds");
     let input_value = 20000u64;
     let output0_value = pledge as u64;
     let output1_value = input_value - pledge as u64 - 1000;
 
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         output0_script.clone(),
         output1_script,
         input_value,
@@ -795,16 +802,16 @@ fn compiles_mecenas_locktime_example_and_verifies() {
     assert!(result.is_ok(), "mecenas_locktime example failed: {}", result.unwrap_err());
 
     // Test receive() with changeValue <= pledgePerBlock + minerFee (if branch).
-    let sigscript = compiled.build_sig_script("receive", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "receive", &[]).expect("sigscript builds");
 
     let input_value = 11000u64;
     let output0_value = input_value - 1000;
     let output1_value = 0u64;
 
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         output0_script,
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         input_value,
         output0_value,
         output1_value,
@@ -821,13 +828,13 @@ fn compiles_mecenas_locktime_example_and_verifies() {
     };
     let output = TransactionOutput {
         value: 6000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -839,8 +846,8 @@ fn compiles_mecenas_locktime_example_and_verifies() {
     signature.push(SIG_HASH_ALL.to_u8());
 
     // Test reclaim() function call (build sigscript for reclaim()).
-    let sigscript =
-        compiled.build_sig_script("reclaim", vec![funder_pk.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "reclaim", &[funder_pk.to_vec().into(), signature.clone().into()])
+        .expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -867,7 +874,7 @@ fn compiles_p2pkh_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([5u8; 32]), index: 0 },
@@ -877,13 +884,13 @@ fn compiles_p2pkh_example_and_verifies() {
     };
     let output = TransactionOutput {
         value: 7000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -896,7 +903,7 @@ fn compiles_p2pkh_example_and_verifies() {
 
     let mut run = |signature: Vec<u8>| {
         tx.tx.inputs[0].signature_script =
-            compiled.build_sig_script("spend", vec![pubkey_bytes.to_vec().into(), signature.into()]).expect("sigscript builds");
+            encode_entry_sig_script(&compiled, "spend", &[pubkey_bytes.to_vec().into(), signature.into()]).expect("sigscript builds");
 
         let verifiable_tx = tx.as_verifiable();
         let sig_cache = Cache::new(100);
@@ -925,7 +932,7 @@ fn compiles_p2pkh_ecdsa_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.into()];
 
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([5u8; 32]), index: 0 },
@@ -935,13 +942,13 @@ fn compiles_p2pkh_ecdsa_example_and_verifies() {
     };
     let output = TransactionOutput {
         value: 7000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -953,7 +960,7 @@ fn compiles_p2pkh_ecdsa_example_and_verifies() {
 
     let mut run = |signature: Vec<u8>| {
         tx.tx.inputs[0].signature_script =
-            compiled.build_sig_script("spend", vec![pubkey_bytes.to_vec().into(), signature.into()]).expect("sigscript builds");
+            encode_entry_sig_script(&compiled, "spend", &[pubkey_bytes.to_vec().into(), signature.into()]).expect("sigscript builds");
 
         let verifiable_tx = tx.as_verifiable();
         let sig_cache = Cache::new(100);
@@ -982,9 +989,9 @@ fn compiles_transfer_with_timeout_and_verifies() {
     let sender_pk = sender.x_only_public_key().0.serialize();
     let recipient_pk = recipient.x_only_public_key().0.serialize();
     let timeout = kaspa_txscript::LOCK_TIME_THRESHOLD as i64;
-    let constructor_args = vec![sender_pk.to_vec().into(), recipient_pk.to_vec().into(), Expr::temporal(timeout)];
+    let constructor_args = vec![sender_pk.to_vec().into(), recipient_pk.to_vec().into(), timeout.into()];
 
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([6u8; 32]), index: 0 },
@@ -994,13 +1001,13 @@ fn compiles_transfer_with_timeout_and_verifies() {
     };
     let output = TransactionOutput {
         value: 8_000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1012,7 +1019,7 @@ fn compiles_transfer_with_timeout_and_verifies() {
     signature.push(SIG_HASH_ALL.to_u8());
 
     // Test transfer() function call (build sigscript for transfer()).
-    let sigscript = compiled.build_sig_script("transfer", vec![signature.clone().into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "transfer", &[signature.clone().into()]).expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -1038,13 +1045,13 @@ fn compiles_transfer_with_timeout_and_verifies() {
     };
     let output = TransactionOutput {
         value: 9_000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], lock_time, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1056,7 +1063,7 @@ fn compiles_transfer_with_timeout_and_verifies() {
     signature.push(SIG_HASH_ALL.to_u8());
 
     // Test timeout() function call (build sigscript for timeout()).
-    let sigscript = compiled.build_sig_script("timeout", vec![signature.clone().into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "timeout", &[signature.clone().into()]).expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -1086,7 +1093,7 @@ fn compiles_covenant_escrow_example_and_verifies() {
     let seller = [11u8; 32];
     let constructor_args = vec![arbiter_hash.clone().into(), buyer.to_vec().into(), seller.to_vec().into()];
 
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input_value = 12_000u64;
     let output0_value = input_value - 1000;
@@ -1102,7 +1109,8 @@ fn compiles_covenant_escrow_example_and_verifies() {
         TransactionOutput { value: output0_value, script_public_key: ScriptPublicKey::new(0, output0_script.into()), covenant: None };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output0.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(input_value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1114,8 +1122,8 @@ fn compiles_covenant_escrow_example_and_verifies() {
     signature.push(SIG_HASH_ALL.to_u8());
 
     // Test spend() function call (build sigscript for spend()).
-    let sigscript =
-        compiled.build_sig_script("spend", vec![arbiter_pk.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "spend", &[arbiter_pk.to_vec().into(), signature.clone().into()])
+        .expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -1150,7 +1158,7 @@ fn compiles_covenant_last_will_and_verifies() {
     let hot_hash = blake2b_simd::Params::new().hash_length(32).to_state().update(hot_pk.as_slice()).finalize().as_bytes().to_vec();
 
     let constructor_args = vec![inheritor_hash.clone().into(), cold_hash.clone().into(), hot_hash.clone().into()];
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([12u8; 32]), index: 0 },
@@ -1160,13 +1168,13 @@ fn compiles_covenant_last_will_and_verifies() {
     };
     let output = TransactionOutput {
         value: 5_000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1178,8 +1186,8 @@ fn compiles_covenant_last_will_and_verifies() {
     signature.push(SIG_HASH_ALL.to_u8());
 
     // Test inherit() function call (build sigscript for inherit()).
-    let sigscript =
-        compiled.build_sig_script("inherit", vec![inheritor_pk.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "inherit", &[inheritor_pk.to_vec().into(), signature.clone().into()])
+        .expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -1204,13 +1212,13 @@ fn compiles_covenant_last_will_and_verifies() {
     };
     let output = TransactionOutput {
         value: 4_000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1223,7 +1231,7 @@ fn compiles_covenant_last_will_and_verifies() {
 
     // Test cold() function call (build sigscript for cold()).
     let sigscript =
-        compiled.build_sig_script("cold", vec![cold_pk.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
+        encode_entry_sig_script(&compiled, "cold", &[cold_pk.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -1251,12 +1259,13 @@ fn compiles_covenant_last_will_and_verifies() {
     };
     let output0 = TransactionOutput {
         value: output0_value,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output0.clone()], 0, Default::default(), 0, vec![]);
-    let utxo_entry = UtxoEntry::new(input_value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo_entry =
+        UtxoEntry::new(input_value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1269,7 +1278,7 @@ fn compiles_covenant_last_will_and_verifies() {
 
     // Test refresh() function call (build sigscript for refresh()).
     let sigscript =
-        compiled.build_sig_script("refresh", vec![hot_pk.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
+        encode_entry_sig_script(&compiled, "refresh", &[hot_pk.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -1300,10 +1309,10 @@ fn compiles_covenant_mecenas_example_and_verifies() {
     let period = 10i64;
     let constructor_args = vec![recipient.to_vec().into(), funder_hash.clone().into(), pledge.into(), period.into()];
 
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     // Test receive() with changeValue > pledge + minerFee (else branch).
-    let sigscript = compiled.build_sig_script("receive", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "receive", &[]).expect("sigscript builds");
 
     let input_value = 10000u64;
     let output0_value = pledge as u64;
@@ -1311,9 +1320,9 @@ fn compiles_covenant_mecenas_example_and_verifies() {
     let output0_script = build_p2pk_script(&recipient);
 
     let result = run_contract_with_tx_sequence(
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         output0_script,
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         input_value,
         output0_value,
         output1_value,
@@ -1323,7 +1332,7 @@ fn compiles_covenant_mecenas_example_and_verifies() {
     );
     assert!(result.is_ok(), "covenant mecenas example failed: {}", result.unwrap_err());
     // Test receive() with changeValue <= pledge + minerFee (if branch).
-    let sigscript = compiled.build_sig_script("receive", vec![]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "receive", &[]).expect("sigscript builds");
 
     let input_value = 6000u64;
     let output0_value = input_value - 1000;
@@ -1331,9 +1340,9 @@ fn compiles_covenant_mecenas_example_and_verifies() {
     let output0_script = build_p2pk_script(&recipient);
 
     let result = run_contract_with_tx_sequence(
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         output0_script,
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
         input_value,
         output0_value,
         output1_value,
@@ -1351,13 +1360,13 @@ fn compiles_covenant_mecenas_example_and_verifies() {
     };
     let output = TransactionOutput {
         value: 7_000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1369,8 +1378,8 @@ fn compiles_covenant_mecenas_example_and_verifies() {
     signature.push(SIG_HASH_ALL.to_u8());
 
     // Test reclaim() function call (build sigscript for reclaim()).
-    let sigscript =
-        compiled.build_sig_script("reclaim", vec![funder_pk.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "reclaim", &[funder_pk.to_vec().into(), signature.clone().into()])
+        .expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -1399,20 +1408,22 @@ fn compiles_covenant_id_example_and_verifies() {
 
     let execute_case = |out0_amount: i64, out1_amount: i64| {
         let active_compiled =
-            compile_contract(&source, &[max_ins.into(), max_outs.into(), 1_000i64.into()], CompileOptions::default())
+            sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), 1_000i64.into()], CompileOptions::default())
                 .expect("compile succeeds");
-        let input1_compiled = compile_contract(&source, &[max_ins.into(), max_outs.into(), 600i64.into()], CompileOptions::default())
-            .expect("compile succeeds");
+        let input1_compiled =
+            sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), 600i64.into()], CompileOptions::default())
+                .expect("compile succeeds");
         let output0_compiled =
-            compile_contract(&source, &[max_ins.into(), max_outs.into(), out0_amount.into()], CompileOptions::default())
+            sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), out0_amount.into()], CompileOptions::default())
                 .expect("compile succeeds");
         let output1_compiled =
-            compile_contract(&source, &[max_ins.into(), max_outs.into(), out1_amount.into()], CompileOptions::default())
+            sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), out1_amount.into()], CompileOptions::default())
                 .expect("compile succeeds");
 
         let mut active_sigscript =
-            active_compiled.build_sig_script("main", vec![vec![out0_amount, out1_amount].into()]).expect("sigscript builds");
-        active_sigscript.extend_from_slice(&sigscript_push_bytecode(&active_compiled.bytecode));
+            encode_entry_sig_script(&active_compiled, "main", &[ArtifactValue::Array(vec![out0_amount.into(), out1_amount.into()])])
+                .expect("sigscript builds");
+        active_sigscript.extend_from_slice(&sigscript_push_bytecode(&bytecode(&active_compiled)));
 
         let input0 = TransactionInput {
             previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([24u8; 32]), index: 0 },
@@ -1422,7 +1433,7 @@ fn compiles_covenant_id_example_and_verifies() {
         };
         let input1 = TransactionInput {
             previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([25u8; 32]), index: 1 },
-            signature_script: sigscript_push_bytecode(&input1_compiled.bytecode),
+            signature_script: sigscript_push_bytecode(&bytecode(&input1_compiled)),
             sequence: 0,
             compute_commit: SigopCount(0).into(),
         };
@@ -1435,7 +1446,7 @@ fn compiles_covenant_id_example_and_verifies() {
 
         let output0 = TransactionOutput {
             value: 1,
-            script_public_key: pay_to_script_hash_script(&output0_compiled.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(&output0_compiled)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id }),
         };
 
@@ -1447,7 +1458,7 @@ fn compiles_covenant_id_example_and_verifies() {
 
         let output2 = TransactionOutput {
             value: 1,
-            script_public_key: pay_to_script_hash_script(&output1_compiled.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(&output1_compiled)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id }),
         };
 
@@ -1462,8 +1473,9 @@ fn compiles_covenant_id_example_and_verifies() {
         );
 
         let utxo0 =
-            UtxoEntry::new(1_600, pay_to_script_hash_script(&active_compiled.bytecode), 0, tx.is_coinbase(), Some(covenant_id));
-        let utxo1 = UtxoEntry::new(700, pay_to_script_hash_script(&input1_compiled.bytecode), 0, tx.is_coinbase(), Some(covenant_id));
+            UtxoEntry::new(1_600, pay_to_script_hash_script(&bytecode(&active_compiled)), 0, tx.is_coinbase(), Some(covenant_id));
+        let utxo1 =
+            UtxoEntry::new(700, pay_to_script_hash_script(&bytecode(&input1_compiled)), 0, tx.is_coinbase(), Some(covenant_id));
         let utxo2 = UtxoEntry::new(300, ScriptPublicKey::new(0, vec![OpTrue].into()), 0, tx.is_coinbase(), Some(other_covenant_id));
 
         let reused_values = SigHashReusedValuesUnsync::new();
@@ -1499,7 +1511,7 @@ fn compiles_bar_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([18u8; 32]), index: 0 },
@@ -1509,13 +1521,13 @@ fn compiles_bar_example_and_verifies() {
     };
     let output = TransactionOutput {
         value: 7_000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1526,8 +1538,8 @@ fn compiles_bar_example_and_verifies() {
     signature.extend_from_slice(sig.as_ref().as_slice());
     signature.push(SIG_HASH_ALL.to_u8());
 
-    let sigscript =
-        compiled.build_sig_script("execute", vec![pubkey_bytes.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "execute", &[pubkey_bytes.to_vec().into(), signature.clone().into()])
+        .expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -1554,7 +1566,7 @@ fn compiles_foo_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([19u8; 32]), index: 0 },
@@ -1564,13 +1576,13 @@ fn compiles_foo_example_and_verifies() {
     };
     let output = TransactionOutput {
         value: 7_000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1581,8 +1593,8 @@ fn compiles_foo_example_and_verifies() {
     signature.extend_from_slice(sig.as_ref().as_slice());
     signature.push(SIG_HASH_ALL.to_u8());
 
-    let sigscript =
-        compiled.build_sig_script("execute", vec![pubkey_bytes.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "execute", &[pubkey_bytes.to_vec().into(), signature.clone().into()])
+        .expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -1604,12 +1616,12 @@ fn compiles_foo_example_and_verifies() {
 fn compiles_bounded_bytes_example_and_verifies() {
     let source = load_example_source("bounded_bytes.sil");
 
-    let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("spend", vec![vec![0u8; 4].into(), 0.into()]).expect("sigscript builds");
+    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("compile succeeds");
+    let sigscript = encode_entry_sig_script(&compiled, "spend", &[vec![0u8; 4].into(), 0.into()]).expect("sigscript builds");
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
-        compiled.bytecode.clone(),
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
+        bytecode(&compiled).clone(),
+        bytecode(&compiled).clone(),
         2000,
         500,
         500,
@@ -1618,11 +1630,11 @@ fn compiles_bounded_bytes_example_and_verifies() {
     );
     assert!(result.is_ok(), "bounded_bytes example failed: {}", result.unwrap_err());
 
-    let sigscript = compiled.build_sig_script("spend", vec![vec![0u8; 4].into(), 1.into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "spend", &[vec![0u8; 4].into(), 1.into()]).expect("sigscript builds");
     let result = run_contract_with_tx(
-        compiled.bytecode.clone(),
-        compiled.bytecode.clone(),
-        compiled.bytecode.clone(),
+        bytecode(&compiled).clone(),
+        bytecode(&compiled).clone(),
+        bytecode(&compiled).clone(),
         2000,
         500,
         500,
@@ -1641,7 +1653,7 @@ fn compiles_p2pkh_invalid_example_and_fails() {
     let pkh = blake2b_simd::Params::new().hash_length(20).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([20u8; 32]), index: 0 },
@@ -1651,13 +1663,13 @@ fn compiles_p2pkh_invalid_example_and_fails() {
     };
     let output = TransactionOutput {
         value: 7_000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
 
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo_entry =
-        UtxoEntry::new(output.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+        UtxoEntry::new(output.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let mut tx = MutableTransaction::with_entries(tx, vec![utxo_entry.clone()]);
 
     let reused_values = SigHashReusedValuesUnsync::new();
@@ -1668,8 +1680,8 @@ fn compiles_p2pkh_invalid_example_and_fails() {
     signature.extend_from_slice(sig.as_ref().as_slice());
     signature.push(SIG_HASH_ALL.to_u8());
 
-    let sigscript =
-        compiled.build_sig_script("spend", vec![pubkey_bytes.to_vec().into(), signature.clone().into()]).expect("sigscript builds");
+    let sigscript = encode_entry_sig_script(&compiled, "spend", &[pubkey_bytes.to_vec().into(), signature.clone().into()])
+        .expect("sigscript builds");
     tx.tx.inputs[0].signature_script = sigscript;
 
     let tx = tx.as_verifiable();
@@ -1695,10 +1707,10 @@ fn compiles_sibling_introspection_example_and_verifies() {
     let mut expected_locking_bytecode = Vec::new();
     expected_locking_bytecode.extend_from_slice(&0u16.to_be_bytes());
     expected_locking_bytecode.extend_from_slice(&expected_script);
-    let constructor_args = [Expr::dynamic_bytes(expected_locking_bytecode.clone())];
+    let constructor_args = [expected_locking_bytecode.clone().into()];
 
-    let compiled = compile_contract(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
-    let sigscript = compiled.build_sig_script("spend", vec![]).expect("sigscript builds");
+    let compiled = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let sigscript = encode_entry_sig_script(&compiled, "spend", &[]).expect("sigscript builds");
     let input0 = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([21u8; 32]), index: 0 },
         signature_script: sigscript,
@@ -1714,7 +1726,7 @@ fn compiles_sibling_introspection_example_and_verifies() {
 
     let output0 = TransactionOutput {
         value: 1_000,
-        script_public_key: ScriptPublicKey::new(0, compiled.bytecode.clone().into()),
+        script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).clone().into()),
         covenant: None,
     };
     let output1 = TransactionOutput {
@@ -1732,7 +1744,7 @@ fn compiles_sibling_introspection_example_and_verifies() {
         0,
         vec![],
     );
-    let utxo0 = UtxoEntry::new(output0.value, ScriptPublicKey::new(0, compiled.bytecode.clone().into()), 0, tx.is_coinbase(), None);
+    let utxo0 = UtxoEntry::new(output0.value, ScriptPublicKey::new(0, bytecode(&compiled).clone().into()), 0, tx.is_coinbase(), None);
     let utxo1 = UtxoEntry::new(
         output1.value,
         ScriptPublicKey::new(0, expected_locking_bytecode[2..].to_vec().into()),
@@ -1761,11 +1773,11 @@ fn compiles_sibling_introspection_example_and_verifies() {
 fn compiles_many_assignments_example_under_500_bytes() {
     let source = load_example_source("many_assignments.sil");
 
-    let compiled = compile_contract(&source, &[], CompileOptions::default()).expect("long example should compile");
+    let compiled = sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("long example should compile");
 
     // This example chains many assignments like `a_n = a_(n-1) * a_(n-1)`.
     // We check the final bytecode stays small to prove the compiler is not
     // re-expanding earlier expressions exponentially. Instead, each interim
     // variable should be stored on the stack once and reused by later steps.
-    assert!(compiled.bytecode.len() < 500, "long.sil should compile to less than 500 bytes, got {}", compiled.bytecode.len());
+    assert!(bytecode(&compiled).len() < 500, "long.sil should compile to less than 500 bytes, got {}", bytecode(&compiled).len());
 }

--- a/silverscript-lang/tests/examples_tests.rs
+++ b/silverscript-lang/tests/examples_tests.rs
@@ -308,7 +308,8 @@ fn compiles_for_loop_ctor_example_with_constructor_bounds() {
     let source = load_example_source("for_loop_ctor.sil");
 
     let constructor_args = [(0).into(), (4).into()];
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
     let recipient0 = [5u8; 32];
     let recipient1 = [6u8; 32];
     let recipient2 = [7u8; 32];
@@ -370,7 +371,8 @@ fn compiles_return_loop_example_file_and_verifies() {
 fn compiles_r0_g16_example_and_verifies() {
     let source = load_example_source("r0_g16.sil");
     let (journal_hash, proof, image_id) = r0_groth16_fixture();
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[image_id.into()], CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &[image_id.into()], CompileOptions::default()).expect("compile succeeds");
     let sigscript =
         encode_entry_sig_script(&compiled, "verify", &[journal_hash.into(), ArtifactValue::Bytes(proof)]).expect("sigscript builds");
 
@@ -483,7 +485,8 @@ fn runs_everything_example_and_verifies() {
     let owner_pk = owner.x_only_public_key().0.serialize();
 
     let constructor_args = [7.into(), String::from("hello").into()];
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([23u8; 32]), index: 0 },
@@ -537,7 +540,8 @@ fn runs_sum_series_example_with_multiple_inputs() {
 
     for (max_iterations, n, should_pass) in cases {
         let constructor_args = [max_iterations.into()];
-        let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+        let compiled =
+            compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
         let sigscript = encode_single_entry_sig_script(&compiled, &[n.into()]).expect("sigscript builds");
         let result = run_contract_with_tx(
             bytecode(&compiled).clone(),
@@ -566,7 +570,8 @@ fn runs_complex_assignments_example_and_verifies() {
 
     for (limit, n) in cases {
         let constructor_args = [limit.into()];
-        let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+        let compiled =
+            compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
         let sigscript = encode_single_entry_sig_script(&compiled, &[n.into()]).expect("sigscript builds");
         let result = run_contract_with_tx(
             bytecode(&compiled).clone(),
@@ -601,7 +606,8 @@ fn compiles_hodl_vault_example_and_verifies() {
     let oracle_sig = oracle.sign_schnorr(oracle_signed).as_ref().to_vec();
 
     let constructor_args = vec![owner_pk.to_vec().into(), oracle_pk.to_vec().into(), min_block.into(), price_target.into()];
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([7u8; 32]), index: 0 },
@@ -664,7 +670,8 @@ fn compiles_mecenas_example_and_verifies() {
     let pledge = 2000i64;
     let constructor_args = vec![recipient.to_vec().into(), funder_hash.clone().into(), pledge.into()];
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     // Test receive() with changeValue > pledge + minerFee (else branch).
     let sigscript = encode_entry_sig_script(&compiled, "receive", &[]).expect("sigscript builds");
@@ -769,7 +776,8 @@ fn compiles_mecenas_locktime_example_and_verifies() {
         initial_block.to_le_bytes().to_vec().into(),
     ];
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
     let passed_blocks = lock_time - initial_block;
     let pledge = passed_blocks as i64 * pledge_per_block;
 
@@ -874,7 +882,8 @@ fn compiles_p2pkh_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([5u8; 32]), index: 0 },
@@ -932,7 +941,8 @@ fn compiles_p2pkh_ecdsa_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.into()];
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([5u8; 32]), index: 0 },
@@ -991,7 +1001,8 @@ fn compiles_transfer_with_timeout_and_verifies() {
     let timeout = kaspa_txscript::LOCK_TIME_THRESHOLD as i64;
     let constructor_args = vec![sender_pk.to_vec().into(), recipient_pk.to_vec().into(), timeout.into()];
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([6u8; 32]), index: 0 },
@@ -1093,7 +1104,8 @@ fn compiles_covenant_escrow_example_and_verifies() {
     let seller = [11u8; 32];
     let constructor_args = vec![arbiter_hash.clone().into(), buyer.to_vec().into(), seller.to_vec().into()];
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input_value = 12_000u64;
     let output0_value = input_value - 1000;
@@ -1158,7 +1170,8 @@ fn compiles_covenant_last_will_and_verifies() {
     let hot_hash = blake2b_simd::Params::new().hash_length(32).to_state().update(hot_pk.as_slice()).finalize().as_bytes().to_vec();
 
     let constructor_args = vec![inheritor_hash.clone().into(), cold_hash.clone().into(), hot_hash.clone().into()];
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([12u8; 32]), index: 0 },
@@ -1309,7 +1322,8 @@ fn compiles_covenant_mecenas_example_and_verifies() {
     let period = 10i64;
     let constructor_args = vec![recipient.to_vec().into(), funder_hash.clone().into(), pledge.into(), period.into()];
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     // Test receive() with changeValue > pledge + minerFee (else branch).
     let sigscript = encode_entry_sig_script(&compiled, "receive", &[]).expect("sigscript builds");
@@ -1407,18 +1421,30 @@ fn compiles_covenant_id_example_and_verifies() {
     let other_covenant_id = kaspa_consensus_core::Hash::from_bytes(*b"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB");
 
     let execute_case = |out0_amount: i64, out1_amount: i64| {
-        let active_compiled =
-            compile_to_sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), 1_000i64.into()], CompileOptions::default())
-                .expect("compile succeeds");
-        let input1_compiled =
-            compile_to_sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), 600i64.into()], CompileOptions::default())
-                .expect("compile succeeds");
-        let output0_compiled =
-            compile_to_sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), out0_amount.into()], CompileOptions::default())
-                .expect("compile succeeds");
-        let output1_compiled =
-            compile_to_sil_abi_artifact_with_options(&source, &[max_ins.into(), max_outs.into(), out1_amount.into()], CompileOptions::default())
-                .expect("compile succeeds");
+        let active_compiled = compile_to_sil_abi_artifact_with_options(
+            &source,
+            &[max_ins.into(), max_outs.into(), 1_000i64.into()],
+            CompileOptions::default(),
+        )
+        .expect("compile succeeds");
+        let input1_compiled = compile_to_sil_abi_artifact_with_options(
+            &source,
+            &[max_ins.into(), max_outs.into(), 600i64.into()],
+            CompileOptions::default(),
+        )
+        .expect("compile succeeds");
+        let output0_compiled = compile_to_sil_abi_artifact_with_options(
+            &source,
+            &[max_ins.into(), max_outs.into(), out0_amount.into()],
+            CompileOptions::default(),
+        )
+        .expect("compile succeeds");
+        let output1_compiled = compile_to_sil_abi_artifact_with_options(
+            &source,
+            &[max_ins.into(), max_outs.into(), out1_amount.into()],
+            CompileOptions::default(),
+        )
+        .expect("compile succeeds");
 
         let mut active_sigscript =
             encode_entry_sig_script(&active_compiled, "main", &[ArtifactValue::Array(vec![out0_amount.into(), out1_amount.into()])])
@@ -1511,7 +1537,8 @@ fn compiles_bar_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([18u8; 32]), index: 0 },
@@ -1566,7 +1593,8 @@ fn compiles_foo_example_and_verifies() {
     let pkh = blake2b_simd::Params::new().hash_length(32).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([19u8; 32]), index: 0 },
@@ -1653,7 +1681,8 @@ fn compiles_p2pkh_invalid_example_and_fails() {
     let pkh = blake2b_simd::Params::new().hash_length(20).to_state().update(pubkey_bytes.as_slice()).finalize().as_bytes().to_vec();
     let constructor_args = [pkh.clone().into()];
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
 
     let input = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([20u8; 32]), index: 0 },
@@ -1709,7 +1738,8 @@ fn compiles_sibling_introspection_example_and_verifies() {
     expected_locking_bytecode.extend_from_slice(&expected_script);
     let constructor_args = [expected_locking_bytecode.clone().into()];
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()).expect("compile succeeds");
     let sigscript = encode_entry_sig_script(&compiled, "spend", &[]).expect("sigscript builds");
     let input0 = TransactionInput {
         previous_outpoint: TransactionOutpoint { transaction_id: TransactionId::from_bytes([21u8; 32]), index: 0 },
@@ -1773,7 +1803,8 @@ fn compiles_sibling_introspection_example_and_verifies() {
 fn compiles_many_assignments_example_under_500_bytes() {
     let source = load_example_source("many_assignments.sil");
 
-    let compiled = compile_to_sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("long example should compile");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(&source, &[], CompileOptions::default()).expect("long example should compile");
 
     // This example chains many assignments like `a_n = a_(n-1) * a_(n-1)`.
     // We check the final bytecode stays small to prove the compiler is not

--- a/silverscript-lang/tests/kcc20_tests.rs
+++ b/silverscript-lang/tests/kcc20_tests.rs
@@ -14,7 +14,7 @@ use kaspa_txscript::standard::multisig_redeem_script;
 use rand::{RngCore, thread_rng};
 use secp256k1::{Keypair, Secp256k1, SecretKey};
 use silverscript_abi::ArtifactValue;
-use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
+use silverscript_lang::compiler::{CompileOptions, compile_to_sil_abi_artifact_with_options};
 use std::collections::BTreeMap;
 use std::fs;
 
@@ -107,7 +107,7 @@ fn compile_kcc20_state_full(
     max_cov_ins: i64,
     max_cov_outs: i64,
 ) -> silverscript_abi::SilAbiArtifact {
-    sil_abi_artifact_with_options(
+    compile_to_sil_abi_artifact_with_options(
         source,
         &[
             ArtifactValue::Bytes(owner),
@@ -920,7 +920,7 @@ fn kcc20_covenant_minter() {
         compiled_template_parts_and_hash(&kcc20_template_probe)
     };
     let compile_minter = |kcc20_covid: Hash, amount: i64, initialized: bool| {
-        sil_abi_artifact_with_options(
+        compile_to_sil_abi_artifact_with_options(
             &kcc20_minter_source,
             &[
                 ArtifactValue::Bytes(owner_bytes.clone()),             // owner

--- a/silverscript-lang/tests/kcc20_tests.rs
+++ b/silverscript-lang/tests/kcc20_tests.rs
@@ -13,15 +13,16 @@ use kaspa_txscript::pay_to_script_hash_script;
 use kaspa_txscript::standard::multisig_redeem_script;
 use rand::{RngCore, thread_rng};
 use secp256k1::{Keypair, Secp256k1, SecretKey};
-use silverscript_lang::ast::{Expr, parse_type_ref};
-use silverscript_lang::compiler::{CompileOptions, CompiledContract, compile_contract, struct_object};
+use silverscript_abi::ArtifactValue;
+use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
+use std::collections::BTreeMap;
 use std::fs;
 
 mod common;
 
 use common::{
-    COV_A, COV_B, assert_verify_like_error, compiled_template_parts_and_hash, covenant_decl_sigscript, covenant_output, covenant_utxo,
-    execute_input_with_covenants,
+    COV_A, COV_B, assert_verify_like_error, bytecode, compiled_template_parts_and_hash, covenant_decl_sigscript, covenant_output,
+    covenant_utxo, execute_input_with_covenants,
 };
 
 fn load_example_source(name: &str) -> String {
@@ -41,91 +42,94 @@ fn random_keypair() -> Keypair {
     }
 }
 
-fn kcc20_state_array_arg<'i>(values: Vec<(Vec<u8>, i64)>) -> Expr<'i> {
+fn kcc20_state_array_arg(values: Vec<(Vec<u8>, i64)>) -> ArtifactValue {
     kcc20_state_array_arg_with_minter(values.into_iter().map(|(owner_identifier, amount)| (owner_identifier, amount, false)).collect())
 }
 
-fn kcc20_state_array_arg_full<'i>(values: Vec<(Vec<u8>, u8, i64, bool)>) -> Expr<'i> {
-    Expr::array(
-        parse_type_ref("State[]").unwrap(),
+fn kcc20_state_array_arg_full(values: Vec<(Vec<u8>, u8, i64, bool)>) -> ArtifactValue {
+    ArtifactValue::Array(
         values
             .into_iter()
             .map(|(owner_identifier, identifier_type, amount, is_minter)| {
-                struct_object(
-                    "State",
-                    vec![
-                        ("ownerIdentifier", Expr::bytes(owner_identifier)),
-                        ("identifierType", Expr::byte(identifier_type)),
-                        ("amount", Expr::int(amount)),
-                        ("isMinter", Expr::bool(is_minter)),
-                    ],
-                )
+                BTreeMap::from([
+                    ("ownerIdentifier".to_string(), owner_identifier.into()),
+                    ("identifierType".to_string(), identifier_type.into()),
+                    ("amount".to_string(), amount.into()),
+                    ("isMinter".to_string(), is_minter.into()),
+                ])
+                .into()
             })
             .collect(),
     )
 }
 
-fn kcc20_state_array_arg_with_minter<'i>(values: Vec<(Vec<u8>, i64, bool)>) -> Expr<'i> {
+fn kcc20_state_array_arg_with_minter(values: Vec<(Vec<u8>, i64, bool)>) -> ArtifactValue {
     kcc20_state_array_arg_full(
         values.into_iter().map(|(owner_identifier, amount, is_minter)| (owner_identifier, 0, amount, is_minter)).collect(),
     )
 }
 
-fn kcc20_state_arg<'i>(owner_identifier: Vec<u8>, identifier_type: u8, amount: i64, is_minter: bool) -> Expr<'i> {
-    struct_object(
-        "KCC20State",
-        vec![
-            ("ownerIdentifier", Expr::bytes(owner_identifier)),
-            ("identifierType", Expr::byte(identifier_type)),
-            ("amount", Expr::int(amount)),
-            ("isMinter", Expr::bool(is_minter)),
-        ],
-    )
+fn kcc20_state_arg(owner_identifier: Vec<u8>, identifier_type: u8, amount: i64, is_minter: bool) -> ArtifactValue {
+    BTreeMap::from([
+        ("ownerIdentifier".to_string(), owner_identifier.into()),
+        ("identifierType".to_string(), identifier_type.into()),
+        ("amount".to_string(), amount.into()),
+        ("isMinter".to_string(), is_minter.into()),
+    ])
+    .into()
 }
 
-fn kcc20_minter_state_arg<'i>(kcc20_covid: Vec<u8>, amount: i64, initialized: bool) -> Expr<'i> {
-    struct_object(
-        "State",
-        vec![("kcc20Covid", Expr::bytes(kcc20_covid)), ("amount", Expr::int(amount)), ("initialized", Expr::bool(initialized))],
-    )
+fn kcc20_minter_state_arg(kcc20_covid: Vec<u8>, amount: i64, initialized: bool) -> ArtifactValue {
+    BTreeMap::from([
+        ("kcc20Covid".to_string(), kcc20_covid.into()),
+        ("amount".to_string(), amount.into()),
+        ("initialized".to_string(), initialized.into()),
+    ])
+    .into()
 }
 
-fn compile_kcc20_state<'a>(source: &'a str, owner: Vec<u8>, amount: i64, max_cov_ins: i64, max_cov_outs: i64) -> CompiledContract<'a> {
+fn compile_kcc20_state(
+    source: &str,
+    owner: Vec<u8>,
+    amount: i64,
+    max_cov_ins: i64,
+    max_cov_outs: i64,
+) -> silverscript_abi::SilAbiArtifact {
     compile_kcc20_state_with_minter(source, owner, amount, false, max_cov_ins, max_cov_outs)
 }
 
-fn compile_kcc20_state_full<'a>(
-    source: &'a str,
+fn compile_kcc20_state_full(
+    source: &str,
     owner: Vec<u8>,
     amount: i64,
     identifier_type: u8,
     is_minter: bool,
     max_cov_ins: i64,
     max_cov_outs: i64,
-) -> CompiledContract<'a> {
-    compile_contract(
+) -> silverscript_abi::SilAbiArtifact {
+    sil_abi_artifact_with_options(
         source,
         &[
-            Expr::bytes(owner),
-            Expr::int(amount),
-            Expr::byte(identifier_type),
-            Expr::bool(is_minter),
-            Expr::int(max_cov_ins),
-            Expr::int(max_cov_outs),
+            ArtifactValue::Bytes(owner),
+            ArtifactValue::Int(amount),
+            ArtifactValue::Byte(identifier_type),
+            ArtifactValue::Bool(is_minter),
+            ArtifactValue::Int(max_cov_ins),
+            ArtifactValue::Int(max_cov_outs),
         ],
         CompileOptions::default(),
     )
     .expect("compile succeeds")
 }
 
-fn compile_kcc20_state_with_minter<'a>(
-    source: &'a str,
+fn compile_kcc20_state_with_minter(
+    source: &str,
     owner: Vec<u8>,
     amount: i64,
     is_minter: bool,
     max_cov_ins: i64,
     max_cov_outs: i64,
-) -> CompiledContract<'a> {
+) -> silverscript_abi::SilAbiArtifact {
     compile_kcc20_state_full(source, owner, amount, 0, is_minter, max_cov_ins, max_cov_outs)
 }
 
@@ -171,7 +175,7 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
 
     let handoff_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&handoff.bytecode),
+        script_public_key: pay_to_script_hash_script(&bytecode(&handoff)),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let handoff_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -188,7 +192,11 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
     let handoff_sigscript = covenant_decl_sigscript(
         &genesis,
         "transfer",
-        vec![kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]), Expr::bytes(handoff_sig), Expr::byte(0)],
+        vec![
+            kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]),
+            ArtifactValue::Bytes(handoff_sig),
+            ArtifactValue::Byte(0),
+        ],
         true,
     );
     let handoff_tx = Transaction::new(
@@ -209,12 +217,12 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
     let split_outputs = vec![
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_a.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(&split_a)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_b.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(&split_b)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -240,8 +248,8 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
         "transfer",
         vec![
             kcc20_state_array_arg(vec![(split_owner_a_bytes.clone(), 400), (split_owner_b_bytes.clone(), 600)]),
-            Expr::bytes(split_sig),
-            Expr::byte(0),
+            ArtifactValue::Bytes(split_sig),
+            ArtifactValue::Byte(0),
         ],
         true,
     );
@@ -260,12 +268,12 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
     let merged = compile_kcc20_state(&source, merged_owner_bytes.clone(), 1_000, 2, 2);
     let merge_outputs = vec![TransactionOutput {
         value: 2_000,
-        script_public_key: pay_to_script_hash_script(&merged.bytecode),
+        script_public_key: pay_to_script_hash_script(&bytecode(&merged)),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let merge_entries = vec![
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_a.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_b.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&bytecode(&split_a)), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&bytecode(&split_b)), 0, split_tx.is_coinbase(), Some(COV_A)),
     ];
     let merge_unsigned_tx = Transaction::new(
         1,
@@ -284,10 +292,11 @@ fn kcc20_can_split_then_merge_tokens_with_two_way_fanout() {
     let merge_leader_sigscript = covenant_decl_sigscript(
         &split_a,
         "transfer",
-        vec![kcc20_state_array_arg(vec![(merged_owner_bytes, 1_000)]), Expr::bytes(merge_sig_a), Expr::byte(0)],
+        vec![kcc20_state_array_arg(vec![(merged_owner_bytes, 1_000)]), ArtifactValue::Bytes(merge_sig_a), ArtifactValue::Byte(0)],
         true,
     );
-    let merge_delegate_sigscript = covenant_decl_sigscript(&split_b, "transfer", vec![Expr::bytes(merge_sig_b), Expr::byte(1)], false);
+    let merge_delegate_sigscript =
+        covenant_decl_sigscript(&split_b, "transfer", vec![ArtifactValue::Bytes(merge_sig_b), ArtifactValue::Byte(1)], false);
     let merge_tx = Transaction::new(
         1,
         vec![
@@ -330,7 +339,7 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
 
     let handoff_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&handoff.bytecode),
+        script_public_key: pay_to_script_hash_script(&bytecode(&handoff)),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let handoff_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -347,7 +356,11 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
     let handoff_sigscript = covenant_decl_sigscript(
         &genesis,
         "transfer",
-        vec![kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]), Expr::bytes(handoff_sig), Expr::byte(0)],
+        vec![
+            kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]),
+            ArtifactValue::Bytes(handoff_sig),
+            ArtifactValue::Byte(0),
+        ],
         true,
     );
     let handoff_tx = Transaction::new(
@@ -368,12 +381,12 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
     let split_outputs = vec![
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_a.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(&split_a)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_b.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(&split_b)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -399,8 +412,8 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
         "transfer",
         vec![
             kcc20_state_array_arg(vec![(split_owner_a_bytes.clone(), 400), (split_owner_b_bytes.clone(), 600)]),
-            Expr::bytes(split_sig),
-            Expr::byte(0),
+            ArtifactValue::Bytes(split_sig),
+            ArtifactValue::Byte(0),
         ],
         true,
     );
@@ -418,12 +431,12 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
 
     let merge_outputs = vec![TransactionOutput {
         value: 2_000,
-        script_public_key: pay_to_script_hash_script(&merged.bytecode),
+        script_public_key: pay_to_script_hash_script(&bytecode(&merged)),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let merge_entries = vec![
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_a.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
-        UtxoEntry::new(700, pay_to_script_hash_script(&split_b.bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&bytecode(&split_a)), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(700, pay_to_script_hash_script(&bytecode(&split_b)), 0, split_tx.is_coinbase(), Some(COV_A)),
     ];
     let merge_unsigned_tx = Transaction::new(
         1,
@@ -442,10 +455,11 @@ fn kcc20_rejects_merge_when_one_signature_is_wrong() {
     let merge_leader_sigscript = covenant_decl_sigscript(
         &split_a,
         "transfer",
-        vec![kcc20_state_array_arg(vec![(merged_owner_bytes, 1_000)]), Expr::bytes(merge_sig_a), Expr::byte(0)],
+        vec![kcc20_state_array_arg(vec![(merged_owner_bytes, 1_000)]), ArtifactValue::Bytes(merge_sig_a), ArtifactValue::Byte(0)],
         true,
     );
-    let merge_delegate_sigscript = covenant_decl_sigscript(&split_b, "transfer", vec![Expr::bytes(wrong_sig_b), Expr::byte(1)], false);
+    let merge_delegate_sigscript =
+        covenant_decl_sigscript(&split_b, "transfer", vec![ArtifactValue::Bytes(wrong_sig_b), ArtifactValue::Byte(1)], false);
     let merge_tx = Transaction::new(
         1,
         vec![
@@ -487,7 +501,7 @@ fn kcc20_rejects_split_when_amounts_do_not_match() {
 
     let handoff_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&handoff.bytecode),
+        script_public_key: pay_to_script_hash_script(&bytecode(&handoff)),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let handoff_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -504,7 +518,11 @@ fn kcc20_rejects_split_when_amounts_do_not_match() {
     let handoff_sigscript = covenant_decl_sigscript(
         &genesis,
         "transfer",
-        vec![kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]), Expr::bytes(handoff_sig), Expr::byte(0)],
+        vec![
+            kcc20_state_array_arg(vec![(handoff_owner_bytes.clone(), 1_000)]),
+            ArtifactValue::Bytes(handoff_sig),
+            ArtifactValue::Byte(0),
+        ],
         true,
     );
     let handoff_tx = Transaction::new(
@@ -525,12 +543,12 @@ fn kcc20_rejects_split_when_amounts_do_not_match() {
     let split_outputs = vec![
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_a.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(&split_a)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 700,
-            script_public_key: pay_to_script_hash_script(&split_b.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(&split_b)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -556,8 +574,8 @@ fn kcc20_rejects_split_when_amounts_do_not_match() {
         "transfer",
         vec![
             kcc20_state_array_arg(vec![(split_owner_a_bytes, 400), (split_owner_b_bytes, 500)]),
-            Expr::bytes(split_sig),
-            Expr::byte(0),
+            ArtifactValue::Bytes(split_sig),
+            ArtifactValue::Byte(0),
         ],
         true,
     );
@@ -597,12 +615,12 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let split_outputs = vec![
         TransactionOutput {
             value: 1_000,
-            script_public_key: pay_to_script_hash_script(&split_minter.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(&split_minter)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
         TransactionOutput {
             value: 1_000,
-            script_public_key: pay_to_script_hash_script(&split_other.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(&split_other)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         },
     ];
@@ -622,8 +640,8 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
         "transfer",
         vec![
             kcc20_state_array_arg_with_minter(vec![(minter_owner_bytes.clone(), 400, true), (other_owner_bytes.clone(), 600, false)]),
-            Expr::bytes(split_sig),
-            Expr::byte(0),
+            ArtifactValue::Bytes(split_sig),
+            ArtifactValue::Byte(0),
         ],
         true,
     );
@@ -645,11 +663,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let forged_other = compile_kcc20_state(&source, other_owner_bytes.clone(), 700, 2, 2);
     let forged_other_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&forged_other.bytecode),
+        script_public_key: pay_to_script_hash_script(&bytecode(&forged_other)),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let forged_other_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_other.bytecode), 0, split_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&bytecode(&split_other)), 0, split_tx.is_coinbase(), Some(COV_A))];
     let forged_other_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: split_tx.id(), index: 1 }, vec![])],
@@ -665,8 +683,8 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
         "transfer",
         vec![
             kcc20_state_array_arg_with_minter(vec![(other_owner_bytes.clone(), 700, false)]),
-            Expr::bytes(forged_other_sig),
-            Expr::byte(0),
+            ArtifactValue::Bytes(forged_other_sig),
+            ArtifactValue::Byte(0),
         ],
         true,
     );
@@ -687,11 +705,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let forged_other_minter = compile_kcc20_state_with_minter(&source, other_owner_bytes.clone(), 600, true, 2, 2);
     let forged_other_minter_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&forged_other_minter.bytecode),
+        script_public_key: pay_to_script_hash_script(&bytecode(&forged_other_minter)),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let forged_other_minter_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_other.bytecode), 0, split_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&bytecode(&split_other)), 0, split_tx.is_coinbase(), Some(COV_A))];
     let forged_other_minter_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: split_tx.id(), index: 1 }, vec![])],
@@ -707,8 +725,8 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
         "transfer",
         vec![
             kcc20_state_array_arg_with_minter(vec![(other_owner_bytes.clone(), 600, true)]),
-            Expr::bytes(forged_other_minter_sig),
-            Expr::byte(0),
+            ArtifactValue::Bytes(forged_other_minter_sig),
+            ArtifactValue::Byte(0),
         ],
         true,
     );
@@ -731,11 +749,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
 
     let mint_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&minted_minter.bytecode),
+        script_public_key: pay_to_script_hash_script(&bytecode(&minted_minter)),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let mint_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&split_minter.bytecode), 0, split_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&bytecode(&split_minter)), 0, split_tx.is_coinbase(), Some(COV_A))];
     let mint_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: split_tx.id(), index: 0 }, vec![])],
@@ -749,7 +767,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let mint_sigscript = covenant_decl_sigscript(
         &split_minter,
         "transfer",
-        vec![kcc20_state_array_arg_with_minter(vec![(minter_owner_bytes.clone(), 900, true)]), Expr::bytes(mint_sig), Expr::byte(0)],
+        vec![
+            kcc20_state_array_arg_with_minter(vec![(minter_owner_bytes.clone(), 900, true)]),
+            ArtifactValue::Bytes(mint_sig),
+            ArtifactValue::Byte(0),
+        ],
         true,
     );
     let mint_tx = Transaction::new(
@@ -766,11 +788,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
 
     let burn_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&burned_minter.bytecode),
+        script_public_key: pay_to_script_hash_script(&bytecode(&burned_minter)),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let burn_entries =
-        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&minted_minter.bytecode), 0, mint_tx.is_coinbase(), Some(COV_A))];
+        vec![UtxoEntry::new(1_000, pay_to_script_hash_script(&bytecode(&minted_minter)), 0, mint_tx.is_coinbase(), Some(COV_A))];
     let burn_unsigned_tx = Transaction::new(
         1,
         vec![tx_input_from_outpoint_v1(TransactionOutpoint { transaction_id: mint_tx.id(), index: 0 }, vec![])],
@@ -784,7 +806,11 @@ fn kcc20_minter_can_split_then_mint_then_burn() {
     let burn_sigscript = covenant_decl_sigscript(
         &minted_minter,
         "transfer",
-        vec![kcc20_state_array_arg_with_minter(vec![(minter_owner_bytes, 500, true)]), Expr::bytes(burn_sig), Expr::byte(0)],
+        vec![
+            kcc20_state_array_arg_with_minter(vec![(minter_owner_bytes, 500, true)]),
+            ArtifactValue::Bytes(burn_sig),
+            ArtifactValue::Byte(0),
+        ],
         true,
     );
     let burn_tx = Transaction::new(
@@ -812,7 +838,7 @@ fn kcc20_minter_can_mint_in_single_transaction() {
 
     let mint_outputs = vec![TransactionOutput {
         value: 1_000,
-        script_public_key: pay_to_script_hash_script(&minted.bytecode),
+        script_public_key: pay_to_script_hash_script(&bytecode(&minted)),
         covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
     }];
     let mint_entries = vec![covenant_utxo(&genesis, COV_A)];
@@ -829,7 +855,11 @@ fn kcc20_minter_can_mint_in_single_transaction() {
     let mint_sigscript = covenant_decl_sigscript(
         &genesis,
         "transfer",
-        vec![kcc20_state_array_arg_with_minter(vec![(genesis_owner_bytes, 1_500, true)]), Expr::bytes(mint_sig), Expr::byte(0)],
+        vec![
+            kcc20_state_array_arg_with_minter(vec![(genesis_owner_bytes, 1_500, true)]),
+            ArtifactValue::Bytes(mint_sig),
+            ArtifactValue::Byte(0),
+        ],
         true,
     );
     let mint_tx = Transaction::new(
@@ -890,16 +920,16 @@ fn kcc20_covenant_minter() {
         compiled_template_parts_and_hash(&kcc20_template_probe)
     };
     let compile_minter = |kcc20_covid: Hash, amount: i64, initialized: bool| {
-        compile_contract(
+        sil_abi_artifact_with_options(
             &kcc20_minter_source,
             &[
-                Expr::bytes(owner_bytes.clone()),             // owner
-                Expr::bytes(kcc20_covid.as_bytes().to_vec()), // initKCC20Covid
-                Expr::int(amount),                            // initAmount
-                Expr::bool(initialized),                      // initInitialized
-                Expr::int(template_prefix.len() as i64),      // templatePrefixLen
-                Expr::int(template_suffix.len() as i64),      // templateSuffixLen
-                Expr::bytes(expected_template_hash.clone()),  // expectedTemplateHash
+                ArtifactValue::Bytes(owner_bytes.clone()),             // owner
+                ArtifactValue::Bytes(kcc20_covid.as_bytes().to_vec()), // initKCC20Covid
+                ArtifactValue::Int(amount),                            // initAmount
+                ArtifactValue::Bool(initialized),                      // initInitialized
+                ArtifactValue::Int(template_prefix.len() as i64),      // templatePrefixLen
+                ArtifactValue::Int(template_suffix.len() as i64),      // templateSuffixLen
+                ArtifactValue::Bytes(expected_template_hash.clone()),  // expectedTemplateHash
             ],
             CompileOptions::default(),
         )
@@ -929,7 +959,7 @@ fn kcc20_covenant_minter() {
     let minter_genesis_input = tx_input_from_outpoint_v1(minter_genesis_outpoint, vec![]);
     let minter_genesis_utxo = UtxoEntry::new(1_500, funding_spk.clone(), 0, false, None);
     let minter_genesis_output_without_covenant =
-        TransactionOutput { value: 1_000, script_public_key: pay_to_script_hash_script(&pre_init.bytecode), covenant: None };
+        TransactionOutput { value: 1_000, script_public_key: pay_to_script_hash_script(&bytecode(&pre_init)), covenant: None };
     let minter_cov_id =
         hashing::covenant_id::covenant_id(minter_genesis_outpoint, std::iter::once((0, &minter_genesis_output_without_covenant)));
     let minter_genesis_outputs = vec![TransactionOutput {
@@ -972,11 +1002,11 @@ fn kcc20_covenant_minter() {
     // mint tx builder: spend A and C together
     // ============================================================
     let build_mint_tx = |prev_tx: &TestTx,
-                         prev_kcc20: &CompiledContract<'_>,
-                         prev_minter: &CompiledContract<'_>,
-                         next_minter_kcc20: &CompiledContract<'_>,
-                         next_recipient_kcc20: &CompiledContract<'_>,
-                         next_minter: &CompiledContract<'_>,
+                         prev_kcc20: &silverscript_abi::SilAbiArtifact,
+                         prev_minter: &silverscript_abi::SilAbiArtifact,
+                         next_minter_kcc20: &silverscript_abi::SilAbiArtifact,
+                         next_recipient_kcc20: &silverscript_abi::SilAbiArtifact,
+                         next_minter: &silverscript_abi::SilAbiArtifact,
                          minted_amount: i64,
                          next_minter_amount: i64| {
         let outputs = vec![
@@ -1005,8 +1035,8 @@ fn kcc20_covenant_minter() {
                     (minter_cov_id.as_bytes().to_vec(), IDENTIFIER_COVENANT_ID, 0, true),
                     (owner_bytes.clone(), 0, minted_amount, false),
                 ]),
-                Expr::bytes(vec![0; 65]),
-                Expr::byte(1),
+                ArtifactValue::Bytes(vec![0; 65]),
+                ArtifactValue::Byte(1),
             ],
             true,
         );
@@ -1015,7 +1045,7 @@ fn kcc20_covenant_minter() {
             "mint",
             vec![
                 kcc20_minter_state_arg(kcc20_covenant_id.as_bytes().to_vec(), next_minter_amount, true),
-                Expr::bytes(minter_sig),
+                ArtifactValue::Bytes(minter_sig),
                 kcc20_state_arg(minter_cov_id.as_bytes().to_vec(), IDENTIFIER_COVENANT_ID, 0, true),
                 kcc20_state_arg(owner_bytes.clone(), 0, minted_amount, false),
             ],
@@ -1049,7 +1079,7 @@ fn kcc20_covenant_minter() {
         "init",
         vec![
             kcc20_minter_state_arg(kcc20_covenant_id.as_bytes().to_vec(), MINTER_AMOUNT, true), // newState
-            Expr::bytes(asset_genesis_sig),                                                     // s
+            ArtifactValue::Bytes(asset_genesis_sig),                                            // s
         ],
         true,
     );
@@ -1104,8 +1134,8 @@ fn kcc20_covenant_minter() {
         "transfer",
         vec![
             kcc20_state_array_arg(vec![(alternate_owner_bytes.clone(), FIRST_MINTED_AMOUNT)]),
-            Expr::bytes(recipient_transfer_sig),
-            Expr::byte(0),
+            ArtifactValue::Bytes(recipient_transfer_sig),
+            ArtifactValue::Byte(0),
         ],
         true,
     );
@@ -1230,7 +1260,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
         .iter()
         .map(|state| TransactionOutput {
             value: 150,
-            script_public_key: pay_to_script_hash_script(&state.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(state)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         })
         .collect();
@@ -1253,8 +1283,8 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
                 (multisig_script_hash.clone(), IDENTIFIER_SCRIPT_HASH, 400, false),
                 (covenant_owner_bytes.clone(), IDENTIFIER_COVENANT_ID, 600, false),
             ]),
-            Expr::bytes(split_sig),
-            Expr::byte(0),
+            ArtifactValue::Bytes(split_sig),
+            ArtifactValue::Byte(0),
         ],
         true,
     );
@@ -1273,10 +1303,10 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
 
     execute_input_with_covenants(split_tx.clone(), split_entries, 0).expect("KCC20 non-minter split should succeed");
 
-    let build_single_output = |state: &CompiledContract<'_>| {
+    let build_single_output = |state: &silverscript_abi::SilAbiArtifact| {
         vec![TransactionOutput {
             value: 150,
-            script_public_key: pay_to_script_hash_script(&state.bytecode),
+            script_public_key: pay_to_script_hash_script(&bytecode(state)),
             covenant: Some(CovenantBinding { authorizing_input: 0, covenant_id: COV_A }),
         }]
     };
@@ -1289,11 +1319,15 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
             }
             Transaction::new(1, inputs, outputs, 0, Default::default(), 0, vec![])
         };
-    let build_kcc20_sigscript = |state: &CompiledContract<'_>, destination_owner: Vec<u8>, amount: i64, witness: u8| {
+    let build_kcc20_sigscript = |state: &silverscript_abi::SilAbiArtifact, destination_owner: Vec<u8>, amount: i64, witness: u8| {
         covenant_decl_sigscript(
             state,
             "transfer",
-            vec![kcc20_state_array_arg(vec![(destination_owner, amount)]), Expr::bytes(vec![0; 65]), Expr::byte(witness)],
+            vec![
+                kcc20_state_array_arg(vec![(destination_owner, amount)]),
+                ArtifactValue::Bytes(vec![0; 65]),
+                ArtifactValue::Byte(witness),
+            ],
             true,
         )
     };
@@ -1301,7 +1335,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
     let script_hash_spent = compile_kcc20_state(&source, multisig_spend_destination_owner_bytes.clone(), 400, 2, 2);
     let script_hash_spend_outputs = build_single_output(&script_hash_spent);
     let script_hash_spend_entries = vec![
-        UtxoEntry::new(150, pay_to_script_hash_script(&split_states[0].bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(150, pay_to_script_hash_script(&bytecode(&split_states[0])), 0, split_tx.is_coinbase(), Some(COV_A)),
         UtxoEntry::new(500, pay_to_script_hash_script(&multisig_redeem_script), 0, false, None),
     ];
     let script_hash_auxiliary_outpoint = TransactionOutpoint { transaction_id: TransactionId::from_bytes([2; 32]), index: 0 };
@@ -1364,7 +1398,7 @@ fn kcc20_non_minter_can_spend_script_hash_and_covenant_id_owned_outputs() {
     let covenant_id_spent = compile_kcc20_state(&source, covenant_spend_destination_owner_bytes.clone(), 600, 2, 2);
     let covenant_id_spend_outputs = build_single_output(&covenant_id_spent);
     let covenant_id_spend_entries = vec![
-        UtxoEntry::new(150, pay_to_script_hash_script(&split_states[1].bytecode), 0, split_tx.is_coinbase(), Some(COV_A)),
+        UtxoEntry::new(150, pay_to_script_hash_script(&bytecode(&split_states[1])), 0, split_tx.is_coinbase(), Some(COV_A)),
         UtxoEntry::new(500, pay_to_script_hash_script(&[0x51]), 0, false, Some(covenant_owner)),
     ];
     let covenant_id_auxiliary_outpoint = TransactionOutpoint { transaction_id: TransactionId::from_bytes([3; 32]), index: 0 };

--- a/silverscript-lang/tests/silverc-test-files/with_ctor_args.json
+++ b/silverscript-lang/tests/silverc-test-files/with_ctor_args.json
@@ -1,1 +1,1 @@
-[{"kind":"int","data":7}]
+[{"kind":"int","value":7}]

--- a/silverscript-lang/tests/silverc_tests.rs
+++ b/silverscript-lang/tests/silverc_tests.rs
@@ -127,6 +127,7 @@ fn silverc_accepts_constructor_args_and_output_flag() {
     let contract = artifact.contract("WithCtor").expect("contract resolved");
     let selector = contract.entry("main").expect("entrypoint resolved").dispatch_tag.into_bytes();
     let bytecode = decode_hex(&contract.compiled.script_hex).expect("compiled script decodes");
+    assert_eq!(contract.compiled.bytecode, bytecode);
     assert!(run_bytecode_with_selector(bytecode, selector).is_ok());
 }
 

--- a/silverscript-lang/tests/silverc_tests.rs
+++ b/silverscript-lang/tests/silverc_tests.rs
@@ -12,7 +12,7 @@ use kaspa_txscript::caches::Cache;
 use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::{EngineCtx, EngineFlags, TxScriptEngine};
 use rand::RngCore;
-use silverscript_abi::{SilAbiArtifact, decode_hex};
+use silverscript_abi::SilAbiArtifact;
 use silverscript_lang::ast::ContractAst;
 use silverscript_lang::compiler::DispatchTag;
 
@@ -84,7 +84,7 @@ fn silverc_defaults_output_path_and_empty_ctor_args() {
     let artifact: SilAbiArtifact = serde_json::from_str(&json).expect("parse portable ABI artifact");
     artifact.verify().expect("portable ABI verifies");
     assert_eq!(artifact.contracts.len(), 1);
-    assert_eq!(artifact.contracts[0].name, "Basic");
+    assert!(artifact.contracts.contains_key("Basic"));
 }
 
 #[test]
@@ -126,8 +126,7 @@ fn silverc_accepts_constructor_args_and_output_flag() {
     artifact.verify().expect("portable ABI verifies");
     let contract = artifact.contract("WithCtor").expect("contract resolved");
     let selector = contract.entry("main").expect("entrypoint resolved").dispatch_tag.into_bytes();
-    let bytecode = decode_hex(&contract.compiled.script_hex).expect("compiled script decodes");
-    assert_eq!(contract.compiled.bytecode, bytecode);
+    let bytecode = contract.compiled.bytecode.clone();
     assert!(run_bytecode_with_selector(bytecode, selector).is_ok());
 }
 

--- a/silverscript-lang/tests/silverc_tests.rs
+++ b/silverscript-lang/tests/silverc_tests.rs
@@ -12,8 +12,9 @@ use kaspa_txscript::caches::Cache;
 use kaspa_txscript::script_builder::ScriptBuilder;
 use kaspa_txscript::{EngineCtx, EngineFlags, TxScriptEngine};
 use rand::RngCore;
+use silverscript_abi::{SilAbiArtifact, decode_hex};
 use silverscript_lang::ast::ContractAst;
-use silverscript_lang::compiler::{COMPILER_VERSION, CompiledContract, DispatchTag};
+use silverscript_lang::compiler::DispatchTag;
 
 fn contract_fixture(name: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join("silverc-test-files").join(name)
@@ -80,13 +81,10 @@ fn silverc_defaults_output_path_and_empty_ctor_args() {
 
     let out_path = dir.join("basic.json");
     let json = fs::read_to_string(&out_path).expect("read output");
-    let artifact: serde_json::Value = serde_json::from_str(&json).expect("parse compiled artifact JSON");
-    assert!(artifact.get("cov_decl_to_abi").is_none());
-    assert!(artifact.get("delegate_entry_abi").is_none());
-    let compiled: CompiledContract = serde_json::from_str(&json).expect("parse compiled contract");
-    assert_eq!(compiled.contract_name, "Basic");
-    assert_eq!(compiled.compiler_version, COMPILER_VERSION);
-    assert_eq!(artifact["abi"][0]["dispatch_tag"], serde_json::json!(compiled.abi[0].dispatch_tag));
+    let artifact: SilAbiArtifact = serde_json::from_str(&json).expect("parse portable ABI artifact");
+    artifact.verify().expect("portable ABI verifies");
+    assert_eq!(artifact.contracts.len(), 1);
+    assert_eq!(artifact.contracts[0].name, "Basic");
 }
 
 #[test]
@@ -124,11 +122,12 @@ fn silverc_accepts_constructor_args_and_output_flag() {
     assert!(status.success());
 
     let json = fs::read_to_string(&out_path).expect("read output");
-    let compiled: CompiledContract = serde_json::from_str(&json).expect("parse compiled contract");
-    assert_eq!(compiled.contract_name, "WithCtor");
-    assert_eq!(compiled.compiler_version, COMPILER_VERSION);
-    let selector = compiled.entry_by_name("main").expect("entrypoint resolved").dispatch_tag;
-    assert!(run_bytecode_with_selector(compiled.bytecode, selector).is_ok());
+    let artifact: SilAbiArtifact = serde_json::from_str(&json).expect("parse portable ABI artifact");
+    artifact.verify().expect("portable ABI verifies");
+    let contract = artifact.contract("WithCtor").expect("contract resolved");
+    let selector = contract.entry("main").expect("entrypoint resolved").dispatch_tag.into_bytes();
+    let bytecode = decode_hex(&contract.compiled.script_hex).expect("compiled script decodes");
+    assert!(run_bytecode_with_selector(bytecode, selector).is_ok());
 }
 
 #[test]

--- a/silverscript-lang/tests/silverc_tests.rs
+++ b/silverscript-lang/tests/silverc_tests.rs
@@ -14,7 +14,7 @@ use kaspa_txscript::{EngineCtx, EngineFlags, TxScriptEngine};
 use rand::RngCore;
 use silverscript_abi::SilAbiArtifact;
 use silverscript_lang::ast::ContractAst;
-use silverscript_lang::compiler::DispatchTag;
+use silverscript_lang::compiler::{COMPILER_VERSION, DispatchTag};
 
 fn contract_fixture(name: &str) -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests").join("silverc-test-files").join(name)
@@ -81,10 +81,18 @@ fn silverc_defaults_output_path_and_empty_ctor_args() {
 
     let out_path = dir.join("basic.json");
     let json = fs::read_to_string(&out_path).expect("read output");
+    let json_value: serde_json::Value = serde_json::from_str(&json).expect("parse portable ABI artifact JSON");
     let artifact: SilAbiArtifact = serde_json::from_str(&json).expect("parse portable ABI artifact");
     artifact.verify().expect("portable ABI verifies");
     assert_eq!(artifact.contracts.len(), 1);
     assert!(artifact.contracts.contains_key("Basic"));
+    assert_eq!(json_value["compiler_version"], COMPILER_VERSION);
+    assert!(json_value["contracts"]["Basic"].get("cov_decl_to_abi").is_none());
+    assert!(json_value["contracts"]["Basic"].get("delegate_entry_abi").is_none());
+    assert_eq!(
+        json_value["contracts"]["Basic"]["entries"]["main"]["dispatch_tag"],
+        serde_json::json!(artifact.contract("Basic").unwrap().entry("main").unwrap().dispatch_tag)
+    );
 }
 
 #[test]

--- a/silverscript-lang/tests/temporal_type_tests.rs
+++ b/silverscript-lang/tests/temporal_type_tests.rs
@@ -55,7 +55,8 @@ fn temporal_supports_int_operations_with_temporal_operands() {
             }
         }
     "#;
-    let compiled = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal operations compile");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal operations compile");
     execute(compiled, &[20.into(), 3.into()]);
 }
 
@@ -71,7 +72,8 @@ fn int_and_temporal_conversions_are_runtime_no_ops() {
             }
         }
     "#;
-    let compiled = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("explicit conversions compile");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("explicit conversions compile");
     execute(compiled, &[1234.into(), 5678.into()]);
 }
 
@@ -105,7 +107,8 @@ fn temporal_array_entrypoint_arguments_round_trip() {
             }
         }
     "#;
-    let compiled = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal array argument compiles");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal array argument compiles");
     let points = ArtifactValue::Array(vec![1_000.into(), 2_000.into(), 62_000.into()]);
     execute(compiled, &[points]);
 }
@@ -127,7 +130,8 @@ fn temporal_array_size_inference_and_append_execute() {
             }
         }
     "#;
-    let compiled = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal array operations compile");
+    let compiled =
+        compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal array operations compile");
     execute(compiled, &[2_000.into()]);
 }
 
@@ -172,12 +176,13 @@ fn known_relative_age_must_fit_u32() {
             entry main() { require(this.ageDaa >= TOO_OLD); }
         }
     "#;
-    let error = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("known 2^32 value must be rejected");
+    let error = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default())
+        .expect_err("known 2^32 value must be rejected");
     assert!(error.to_string().contains("0 <= value < 2^32"), "unexpected error: {error}");
 
     let negative = "contract C() { entry main() { require(this.ageDaa >= -1); } }";
-    let error =
-        compile_to_sil_abi_artifact_with_options(negative, &[], CompileOptions::default()).expect_err("known negative age must be rejected");
+    let error = compile_to_sil_abi_artifact_with_options(negative, &[], CompileOptions::default())
+        .expect_err("known negative age must be rejected");
     assert!(error.to_string().contains("0 <= value < 2^32"), "unexpected error: {error}");
 
     let zero = "contract C() { entry main() { require(this.ageDaa >= 0); } }";
@@ -187,7 +192,8 @@ fn known_relative_age_must_fit_u32() {
     compile_to_sil_abi_artifact_with_options(max, &[], CompileOptions::default()).expect("2^32 - 1 remains valid");
 
     let constructor_known = "contract C(int age) { entry main() { require(this.ageDaa >= age); } }";
-    let error = compile_to_sil_abi_artifact_with_options(constructor_known, &[ArtifactValue::Int(1_i64 << 32)], CompileOptions::default())
-        .expect_err("known constructor age must be rejected");
+    let error =
+        compile_to_sil_abi_artifact_with_options(constructor_known, &[ArtifactValue::Int(1_i64 << 32)], CompileOptions::default())
+            .expect_err("known constructor age must be rejected");
     assert!(error.to_string().contains("0 <= value < 2^32"), "unexpected error: {error}");
 }

--- a/silverscript-lang/tests/temporal_type_tests.rs
+++ b/silverscript-lang/tests/temporal_type_tests.rs
@@ -8,7 +8,7 @@ use kaspa_consensus_core::tx::{
 use kaspa_txscript::caches::Cache;
 use kaspa_txscript::{EngineCtx, EngineFlags, TxScriptEngine};
 use silverscript_abi::ArtifactValue;
-use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
+use silverscript_lang::compiler::{CompileOptions, compile_to_sil_abi_artifact_with_options};
 
 use common::{bytecode, encode_single_entry_sig_script};
 
@@ -55,7 +55,7 @@ fn temporal_supports_int_operations_with_temporal_operands() {
             }
         }
     "#;
-    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal operations compile");
+    let compiled = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal operations compile");
     execute(compiled, &[20.into(), 3.into()]);
 }
 
@@ -71,7 +71,7 @@ fn int_and_temporal_conversions_are_runtime_no_ops() {
             }
         }
     "#;
-    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("explicit conversions compile");
+    let compiled = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("explicit conversions compile");
     execute(compiled, &[1234.into(), 5678.into()]);
 }
 
@@ -88,7 +88,7 @@ fn temporal_fields_arrays_and_millisecond_units_round_trip() {
             }
         }
     "#;
-    let compiled = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(1_000)], CompileOptions::default())
+    let compiled = compile_to_sil_abi_artifact_with_options(source, &[ArtifactValue::Int(1_000)], CompileOptions::default())
         .expect("temporal storage compiles");
     execute(compiled, &[3_000.into(), 3_000.into()]);
 }
@@ -105,7 +105,7 @@ fn temporal_array_entrypoint_arguments_round_trip() {
             }
         }
     "#;
-    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal array argument compiles");
+    let compiled = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal array argument compiles");
     let points = ArtifactValue::Array(vec![1_000.into(), 2_000.into(), 62_000.into()]);
     execute(compiled, &[points]);
 }
@@ -127,7 +127,7 @@ fn temporal_array_size_inference_and_append_execute() {
             }
         }
     "#;
-    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal array operations compile");
+    let compiled = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal array operations compile");
     execute(compiled, &[2_000.into()]);
 }
 
@@ -139,7 +139,7 @@ fn temporal_arrays_reject_int_elements_without_conversion() {
         "contract C() { entry main() { int[] values = temporal[]{temporal(1)}; } }",
     ] {
         assert!(
-            sil_abi_artifact_with_options(source, &[], CompileOptions::default()).is_err(),
+            compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).is_err(),
             "mixed int/temporal array must be rejected: {source}"
         );
     }
@@ -158,7 +158,7 @@ fn int_and_temporal_require_explicit_conversion() {
         "contract C() { entry main() { require(this.age >= 1); } }",
     ] {
         assert!(
-            sil_abi_artifact_with_options(source, &[], CompileOptions::default()).is_err(),
+            compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).is_err(),
             "mixed or obsolete temporal expression must be rejected: {source}"
         );
     }
@@ -172,22 +172,22 @@ fn known_relative_age_must_fit_u32() {
             entry main() { require(this.ageDaa >= TOO_OLD); }
         }
     "#;
-    let error = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("known 2^32 value must be rejected");
+    let error = compile_to_sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("known 2^32 value must be rejected");
     assert!(error.to_string().contains("0 <= value < 2^32"), "unexpected error: {error}");
 
     let negative = "contract C() { entry main() { require(this.ageDaa >= -1); } }";
     let error =
-        sil_abi_artifact_with_options(negative, &[], CompileOptions::default()).expect_err("known negative age must be rejected");
+        compile_to_sil_abi_artifact_with_options(negative, &[], CompileOptions::default()).expect_err("known negative age must be rejected");
     assert!(error.to_string().contains("0 <= value < 2^32"), "unexpected error: {error}");
 
     let zero = "contract C() { entry main() { require(this.ageDaa >= 0); } }";
-    sil_abi_artifact_with_options(zero, &[], CompileOptions::default()).expect("zero remains valid");
+    compile_to_sil_abi_artifact_with_options(zero, &[], CompileOptions::default()).expect("zero remains valid");
 
     let max = "contract C() { entry main() { require(this.ageDaa >= 4294967295); } }";
-    sil_abi_artifact_with_options(max, &[], CompileOptions::default()).expect("2^32 - 1 remains valid");
+    compile_to_sil_abi_artifact_with_options(max, &[], CompileOptions::default()).expect("2^32 - 1 remains valid");
 
     let constructor_known = "contract C(int age) { entry main() { require(this.ageDaa >= age); } }";
-    let error = sil_abi_artifact_with_options(constructor_known, &[ArtifactValue::Int(1_i64 << 32)], CompileOptions::default())
+    let error = compile_to_sil_abi_artifact_with_options(constructor_known, &[ArtifactValue::Int(1_i64 << 32)], CompileOptions::default())
         .expect_err("known constructor age must be rejected");
     assert!(error.to_string().contains("0 <= value < 2^32"), "unexpected error: {error}");
 }

--- a/silverscript-lang/tests/temporal_type_tests.rs
+++ b/silverscript-lang/tests/temporal_type_tests.rs
@@ -1,3 +1,5 @@
+mod common;
+
 use kaspa_consensus_core::hashing::sighash::SigHashReusedValuesUnsync;
 use kaspa_consensus_core::tx::{
     PopulatedTransaction, ScriptPublicKey, Transaction, TransactionId, TransactionInput, TransactionOutpoint, TransactionOutput,
@@ -5,11 +7,13 @@ use kaspa_consensus_core::tx::{
 };
 use kaspa_txscript::caches::Cache;
 use kaspa_txscript::{EngineCtx, EngineFlags, TxScriptEngine};
-use silverscript_lang::ast::{Expr, parse_type_ref};
-use silverscript_lang::compiler::{CompileOptions, CompiledContract, compile_contract};
+use silverscript_abi::ArtifactValue;
+use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
 
-fn execute(compiled: CompiledContract<'_>, args: Vec<Expr<'_>>) {
-    let signature_script = compiled.build_sig_script("main", args).expect("signature script builds");
+use common::{bytecode, encode_single_entry_sig_script};
+
+fn execute(compiled: silverscript_abi::SilAbiArtifact, args: &[ArtifactValue]) {
+    let signature_script = encode_single_entry_sig_script(&compiled, args).expect("signature script builds");
     let input = TransactionInput::new(
         TransactionOutpoint { transaction_id: TransactionId::from_bytes([9; 32]), index: 0 },
         signature_script,
@@ -17,7 +21,7 @@ fn execute(compiled: CompiledContract<'_>, args: Vec<Expr<'_>>) {
         0,
     );
     let output =
-        TransactionOutput { value: 1_000, script_public_key: ScriptPublicKey::new(0, compiled.bytecode.into()), covenant: None };
+        TransactionOutput { value: 1_000, script_public_key: ScriptPublicKey::new(0, bytecode(&compiled).into()), covenant: None };
     let tx = Transaction::new(1, vec![input.clone()], vec![output.clone()], 0, Default::default(), 0, vec![]);
     let utxo = UtxoEntry::new(output.value, output.script_public_key, 0, false, None);
     let populated = PopulatedTransaction::new(&tx, vec![utxo.clone()]);
@@ -51,8 +55,8 @@ fn temporal_supports_int_operations_with_temporal_operands() {
             }
         }
     "#;
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("temporal operations compile");
-    execute(compiled, vec![Expr::temporal(20), Expr::temporal(3)]);
+    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal operations compile");
+    execute(compiled, &[20.into(), 3.into()]);
 }
 
 #[test]
@@ -67,8 +71,8 @@ fn int_and_temporal_conversions_are_runtime_no_ops() {
             }
         }
     "#;
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("explicit conversions compile");
-    execute(compiled, vec![Expr::temporal(1234), Expr::int(5678)]);
+    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("explicit conversions compile");
+    execute(compiled, &[1234.into(), 5678.into()]);
 }
 
 #[test]
@@ -84,8 +88,9 @@ fn temporal_fields_arrays_and_millisecond_units_round_trip() {
             }
         }
     "#;
-    let compiled = compile_contract(source, &[Expr::temporal(1_000)], CompileOptions::default()).expect("temporal storage compiles");
-    execute(compiled, vec![Expr::temporal(3_000), Expr::temporal(3_000)]);
+    let compiled = sil_abi_artifact_with_options(source, &[ArtifactValue::Int(1_000)], CompileOptions::default())
+        .expect("temporal storage compiles");
+    execute(compiled, &[3_000.into(), 3_000.into()]);
 }
 
 #[test]
@@ -100,12 +105,9 @@ fn temporal_array_entrypoint_arguments_round_trip() {
             }
         }
     "#;
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("temporal array argument compiles");
-    let points = Expr::array(
-        parse_type_ref("temporal[3]").expect("temporal array type parses"),
-        vec![Expr::temporal(1_000), Expr::temporal(2_000), Expr::temporal(62_000)],
-    );
-    execute(compiled, vec![points]);
+    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal array argument compiles");
+    let points = ArtifactValue::Array(vec![1_000.into(), 2_000.into(), 62_000.into()]);
+    execute(compiled, &[points]);
 }
 
 #[test]
@@ -125,8 +127,8 @@ fn temporal_array_size_inference_and_append_execute() {
             }
         }
     "#;
-    let compiled = compile_contract(source, &[], CompileOptions::default()).expect("temporal array operations compile");
-    execute(compiled, vec![Expr::temporal(2_000)]);
+    let compiled = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect("temporal array operations compile");
+    execute(compiled, &[2_000.into()]);
 }
 
 #[test]
@@ -137,7 +139,7 @@ fn temporal_arrays_reject_int_elements_without_conversion() {
         "contract C() { entry main() { int[] values = temporal[]{temporal(1)}; } }",
     ] {
         assert!(
-            compile_contract(source, &[], CompileOptions::default()).is_err(),
+            sil_abi_artifact_with_options(source, &[], CompileOptions::default()).is_err(),
             "mixed int/temporal array must be rejected: {source}"
         );
     }
@@ -156,7 +158,7 @@ fn int_and_temporal_require_explicit_conversion() {
         "contract C() { entry main() { require(this.age >= 1); } }",
     ] {
         assert!(
-            compile_contract(source, &[], CompileOptions::default()).is_err(),
+            sil_abi_artifact_with_options(source, &[], CompileOptions::default()).is_err(),
             "mixed or obsolete temporal expression must be rejected: {source}"
         );
     }
@@ -170,21 +172,22 @@ fn known_relative_age_must_fit_u32() {
             entry main() { require(this.ageDaa >= TOO_OLD); }
         }
     "#;
-    let error = compile_contract(source, &[], CompileOptions::default()).expect_err("known 2^32 value must be rejected");
+    let error = sil_abi_artifact_with_options(source, &[], CompileOptions::default()).expect_err("known 2^32 value must be rejected");
     assert!(error.to_string().contains("0 <= value < 2^32"), "unexpected error: {error}");
 
     let negative = "contract C() { entry main() { require(this.ageDaa >= -1); } }";
-    let error = compile_contract(negative, &[], CompileOptions::default()).expect_err("known negative age must be rejected");
+    let error =
+        sil_abi_artifact_with_options(negative, &[], CompileOptions::default()).expect_err("known negative age must be rejected");
     assert!(error.to_string().contains("0 <= value < 2^32"), "unexpected error: {error}");
 
     let zero = "contract C() { entry main() { require(this.ageDaa >= 0); } }";
-    compile_contract(zero, &[], CompileOptions::default()).expect("zero remains valid");
+    sil_abi_artifact_with_options(zero, &[], CompileOptions::default()).expect("zero remains valid");
 
     let max = "contract C() { entry main() { require(this.ageDaa >= 4294967295); } }";
-    compile_contract(max, &[], CompileOptions::default()).expect("2^32 - 1 remains valid");
+    sil_abi_artifact_with_options(max, &[], CompileOptions::default()).expect("2^32 - 1 remains valid");
 
     let constructor_known = "contract C(int age) { entry main() { require(this.ageDaa >= age); } }";
-    let error = compile_contract(constructor_known, &[Expr::int(1_i64 << 32)], CompileOptions::default())
+    let error = sil_abi_artifact_with_options(constructor_known, &[ArtifactValue::Int(1_i64 << 32)], CompileOptions::default())
         .expect_err("known constructor age must be rejected");
     assert!(error.to_string().contains("0 <= value < 2^32"), "unexpected error: {error}");
 }

--- a/silverscript-lang/tests/tutorial_examples_tests.rs
+++ b/silverscript-lang/tests/tutorial_examples_tests.rs
@@ -1,6 +1,6 @@
 use silverscript_abi::ArtifactValue;
 use silverscript_lang::ast::{ArrayDim, TypeBase, TypeRef, parse_contract_ast};
-use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
+use silverscript_lang::compiler::{CompileOptions, compile_to_sil_abi_artifact_with_options};
 
 #[test]
 fn tutorial_contract_examples_parse() {
@@ -33,7 +33,7 @@ fn tutorial_examples_compile() {
             .map(|param| dummy_value(&param.type_ref))
             .collect::<Result<Vec<_>, _>>()
             .unwrap_or_else(|err| panic!("tutorial example #{index} constructor arguments could not be generated: {err}"));
-        if let Err(err) = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()) {
+        if let Err(err) = compile_to_sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()) {
             panic!("tutorial example #{index} failed to compile: {err}\n--- snippet ---\n{snippet}\n--- wrapped source ---\n{source}");
         }
     }

--- a/silverscript-lang/tests/tutorial_examples_tests.rs
+++ b/silverscript-lang/tests/tutorial_examples_tests.rs
@@ -1,5 +1,6 @@
-use silverscript_lang::ast::{ArrayDim, Expr, TypeBase, TypeRef, parse_contract_ast};
-use silverscript_lang::compiler::{CompileOptions, compile_contract};
+use silverscript_abi::ArtifactValue;
+use silverscript_lang::ast::{ArrayDim, TypeBase, TypeRef, parse_contract_ast};
+use silverscript_lang::compiler::{CompileOptions, sil_abi_artifact_with_options};
 
 #[test]
 fn tutorial_contract_examples_parse() {
@@ -32,13 +33,13 @@ fn tutorial_examples_compile() {
             .map(|param| dummy_value(&param.type_ref))
             .collect::<Result<Vec<_>, _>>()
             .unwrap_or_else(|err| panic!("tutorial example #{index} constructor arguments could not be generated: {err}"));
-        if let Err(err) = compile_contract(&source, &constructor_args, CompileOptions::default()) {
+        if let Err(err) = sil_abi_artifact_with_options(&source, &constructor_args, CompileOptions::default()) {
             panic!("tutorial example #{index} failed to compile: {err}\n--- snippet ---\n{snippet}\n--- wrapped source ---\n{source}");
         }
     }
 }
 
-fn dummy_value(type_ref: &TypeRef) -> Result<Expr<'static>, String> {
+fn dummy_value(type_ref: &TypeRef) -> Result<ArtifactValue, String> {
     if type_ref.is_array() {
         let length = match type_ref.array_size() {
             Some(ArrayDim::Fixed(length)) => *length,
@@ -46,20 +47,23 @@ fn dummy_value(type_ref: &TypeRef) -> Result<Expr<'static>, String> {
             Some(ArrayDim::Constant(name)) => return Err(format!("array size constant '{name}' is unsupported in tutorial tests")),
             Some(ArrayDim::Inferred) | None => return Err(format!("cannot generate a value for {}", type_ref.type_name())),
         };
+        if type_ref.base == TypeBase::Byte && type_ref.array_dims.len() == 1 {
+            return Ok(vec![0u8; length].into());
+        }
         let element_type = type_ref.array_element_type().ok_or_else(|| format!("invalid array type {}", type_ref.type_name()))?;
         let values = (0..length).map(|_| dummy_value(&element_type)).collect::<Result<Vec<_>, _>>()?;
-        return Ok(Expr::array(type_ref.clone(), values));
+        return Ok(values.into());
     }
 
     Ok(match &type_ref.base {
-        TypeBase::Int => Expr::int(0),
-        TypeBase::Temporal => Expr::temporal(kaspa_txscript::LOCK_TIME_THRESHOLD as i64),
-        TypeBase::Bool => Expr::bool(false),
-        TypeBase::Byte => Expr::byte(0),
-        TypeBase::String => Expr::string(String::new()),
-        TypeBase::Pubkey => Expr::bytes(vec![0; 32]),
-        TypeBase::Sig => Expr::bytes(vec![0; 65]),
-        TypeBase::Datasig => Expr::bytes(vec![0; 64]),
+        TypeBase::Int => 0.into(),
+        TypeBase::Temporal => (kaspa_txscript::LOCK_TIME_THRESHOLD as i64).into(),
+        TypeBase::Bool => false.into(),
+        TypeBase::Byte => 0u8.into(),
+        TypeBase::String => String::new().into(),
+        TypeBase::Pubkey => vec![0u8; 32].into(),
+        TypeBase::Sig => vec![0u8; 65].into(),
+        TypeBase::Datasig => vec![0u8; 64].into(),
         TypeBase::Tuple(_) | TypeBase::Custom(_) => return Err(format!("cannot generate a value for {}", type_ref.type_name())),
     })
 }
@@ -238,3 +242,4 @@ fn indent(text: &str, spaces: usize) -> String {
     let padding = " ".repeat(spaces);
     text.lines().map(|line| if line.is_empty() { line.to_string() } else { format!("{padding}{line}") }).collect::<Vec<_>>().join("\n")
 }
+mod common;

--- a/silverscript-lang/tests/tutorial_rust_examples_tests.rs
+++ b/silverscript-lang/tests/tutorial_rust_examples_tests.rs
@@ -21,7 +21,7 @@ fn tutorial_rust_programmatic_compilation_example() {
 
     assert!(!contract.compiled.bytecode.is_empty());
     assert_eq!(contract.entries.len(), 1);
-    assert_eq!(contract.entries[0].name, "spend");
+    assert!(contract.entries.contains_key("spend"));
 }
 
 #[test]

--- a/silverscript-lang/tests/tutorial_rust_examples_tests.rs
+++ b/silverscript-lang/tests/tutorial_rust_examples_tests.rs
@@ -1,5 +1,8 @@
-use silverscript_lang::ast::Expr;
-use silverscript_lang::compiler::{CompileOptions, compile_contract};
+mod common;
+
+use silverscript_lang::compiler::sil_abi_artifact;
+
+use common::encode_entry_sig_script;
 
 #[test]
 fn tutorial_rust_programmatic_compilation_example() {
@@ -13,14 +16,12 @@ fn tutorial_rust_programmatic_compilation_example() {
         }
     "#;
 
-    let constructor_args = vec![Expr::int(100)];
-    let compiled = compile_contract(source, &constructor_args, CompileOptions::default())
-        .expect("programmatic compilation example should compile");
+    let artifact = sil_abi_artifact(source, &[100.into()]).expect("programmatic compilation example should compile");
+    let contract = artifact.contract("MyContract").expect("contract exists");
 
-    assert_eq!(compiled.contract_name, "MyContract");
-    assert!(!compiled.bytecode.is_empty());
-    assert_eq!(compiled.abi.len(), 1);
-    assert_eq!(compiled.abi[0].name, "spend");
+    assert!(!contract.compiled.bytecode.is_empty());
+    assert_eq!(contract.entries.len(), 1);
+    assert_eq!(contract.entries[0].name, "spend");
 }
 
 #[test]
@@ -43,13 +44,13 @@ fn tutorial_rust_build_sigscript_multiple_entrypoints_example() {
     let sender_pk = vec![3u8; 32];
     let recipient_pk = vec![4u8; 32];
     let timeout = 1_640_000_000_000i64;
-    let compiled =
-        compile_contract(source, &[sender_pk.into(), recipient_pk.into(), Expr::temporal(timeout)], CompileOptions::default())
-            .expect("multi-entrypoint example should compile");
+    let artifact = sil_abi_artifact(source, &[sender_pk.into(), recipient_pk.into(), timeout.into()])
+        .expect("multi-entrypoint example should compile");
 
     let sig = vec![5u8; 65];
-    let transfer_sigscript = compiled.build_sig_script("transfer", vec![sig.clone().into()]).expect("transfer sigscript should build");
-    let reclaim_sigscript = compiled.build_sig_script("reclaim", vec![sig.into()]).expect("reclaim sigscript should build");
+    let transfer_sigscript =
+        encode_entry_sig_script(&artifact, "transfer", &[sig.clone().into()]).expect("transfer sigscript should build");
+    let reclaim_sigscript = encode_entry_sig_script(&artifact, "reclaim", &[sig.into()]).expect("reclaim sigscript should build");
 
     assert!(!transfer_sigscript.is_empty());
     assert!(!reclaim_sigscript.is_empty());

--- a/silverscript-lang/tests/tutorial_rust_examples_tests.rs
+++ b/silverscript-lang/tests/tutorial_rust_examples_tests.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use silverscript_lang::compiler::sil_abi_artifact;
+use silverscript_lang::compiler::compile_to_sil_abi_artifact;
 
 use common::encode_entry_sig_script;
 
@@ -16,7 +16,7 @@ fn tutorial_rust_programmatic_compilation_example() {
         }
     "#;
 
-    let artifact = sil_abi_artifact(source, &[100.into()]).expect("programmatic compilation example should compile");
+    let artifact = compile_to_sil_abi_artifact(source, &[100.into()]).expect("programmatic compilation example should compile");
     let contract = artifact.contract("MyContract").expect("contract exists");
 
     assert!(!contract.compiled.bytecode.is_empty());
@@ -44,7 +44,7 @@ fn tutorial_rust_build_sigscript_multiple_entrypoints_example() {
     let sender_pk = vec![3u8; 32];
     let recipient_pk = vec![4u8; 32];
     let timeout = 1_640_000_000_000i64;
-    let artifact = sil_abi_artifact(source, &[sender_pk.into(), recipient_pk.into(), timeout.into()])
+    let artifact = compile_to_sil_abi_artifact(source, &[sender_pk.into(), recipient_pk.into(), timeout.into()])
         .expect("multi-entrypoint example should compile");
 
     let sig = vec![5u8; 65];


### PR DESCRIPTION
 This PR introduces a portable, versioned ABI artifact shared by the compiler, debugger, and external tooling.

  There are no intentional SilverScript syntax, bytecode, or runtime-semantics changes. The practical change is that compiled contract metadata and signature-script encoding no longer depend on the compiler’s
  internal AST representation.

  ## Artifact and Tooling Changes

  - Add `SilAbiArtifact`, containing:

    - Compiler and schema versions
    - Struct definitions
    - Contracts and runtime-state layouts
    - Entrypoint parameters and dispatch tags
    - Covenant declaration entrypoint metadata
    - Compiled bytecode and script hex
    - Template hashes and state spans

  - Add `ArtifactValue` as the portable representation for constructor and entrypoint arguments.

  - Add typed encoders for:

    - Regular entrypoint signature scripts
    - Covenant declaration calls
    - Struct and struct-array arguments
    - Runtime-state scripts

  - Add artifact validation for schema versions, dispatch-tag collisions, bytecode encodings, runtime-state spans, and template hashes.

  - Preserve compiler-generated dispatch tags in `CompiledContract`, while moving the complete public ABI representation into `SilAbiArtifact`.

  - Add `SilDebugArtifact`, which combines a portable ABI artifact with per-contract debug information.

  - Migrate the debugger to use portable ABI types for argument parsing, entrypoint selection, signature-script generation, and covenant metadata.

  ## CLI Changes

  `silverc` now emits a `SilAbiArtifact` JSON document instead of serializing the compiler’s internal `CompiledContract`.

  Constructor argument files now use portable artifact values:

  ```json
  [
    {
      "kind": "bytes",
      "value": [1, 2, 3, 4]
    },
    {
      "kind": "int",
      "value": 12345
    }
  ]
  ```

  The generated artifact has the following general shape:

  ```json
  {
    "schema_version": 1,
    "compiler_version": "0.1.0",
    "structs": [],
    "contracts": [
      {
        "name": "Example",
        "runtime_state": {
          "source": "State",
          "fields": []
        },
        "entries": [
          {
            "name": "main",
            "dispatch_tag": "01234567",
            "params": [
              {
                "name": "amount",
                "type": {
                  "kind": "int"
                }
              }
            ]
          }
        ],
        "compiled": {
          "bytecode": [],
          "script_hex": "",
          "template_hash": [],
          "template_hash_hex": "",
          "state_span": {
            "offset": 0,
            "len": 0
          }
        }
      }
    ]
  }
  ```

  ## Programmatic Usage

  Contracts can be compiled directly into portable artifacts:

  ```rust
  use silverscript_lang::compiler::compile_to_sil_abi_artifact;

  let artifact = compile_to_sil_abi_artifact(
      source,
      &[100.into()],
  )?;

  let contract = artifact.contract("Example").expect("contract exists");
  ```

  Signature scripts are generated from the portable ABI:

  ```rust
  use silverscript_abi::encode_contract_entry_sig_script;

  let sigscript = encode_contract_entry_sig_script(
      &artifact,
      "Example",
      "main",
      &[100.into()],
  )?;
  ```
