### PR TITLE
Visit `as` cast targets as AST types

### DIFF
--- a/silverscript-lang/src/ast/visit.rs
+++ b/silverscript-lang/src/ast/visit.rs
@@ -1,6 +1,6 @@
 use super::{
     ConstantAst, ContractAst, ContractFieldAst, Expr, ExprKind, FunctionAst, FunctionAttributeArgAst, FunctionAttributeAst, ParamAst,
-    Statement, StructAst, StructBindingAst, StructFieldAst, TypeBase, TypeRef,
+    Statement, StructAst, StructBindingAst, StructFieldAst, TypeBase, TypeRef, as_cast_type,
 };
 use crate::span::Span;
 
@@ -391,7 +391,18 @@ pub fn walk_expr_mut<'i, V: AstVisitorMut<'i> + ?Sized>(visitor: &mut V, expr: &
                 visitor.visit_expr(item);
             }
         }
-        ExprKind::Call { name, args, name_span } | ExprKind::New { name, args, name_span } => {
+        ExprKind::Call { name, args, name_span } => {
+            if let Some(type_ref) = as_cast_type(name) {
+                visit_type_ref(visitor, &type_ref, *name_span);
+            } else {
+                visitor.visit_name(name, NameKind::CallTarget, *name_span);
+            }
+            visitor.visit_span(name_span);
+            for arg in args {
+                visitor.visit_expr(arg);
+            }
+        }
+        ExprKind::New { name, args, name_span } => {
             visitor.visit_name(name, NameKind::CallTarget, *name_span);
             visitor.visit_span(name_span);
             for arg in args {

--- a/silverscript-lang/tests/ast_spans_tests.rs
+++ b/silverscript-lang/tests/ast_spans_tests.rs
@@ -38,6 +38,11 @@ struct TypeOccurrenceCollector {
 }
 
 #[derive(Default)]
+struct TypeSourceCollector {
+    occurrences: Vec<(String, String)>,
+}
+
+#[derive(Default)]
 struct SyntheticMetadataCollector {
     type_names: Vec<(String, bool)>,
     attribute_path_segments: Vec<(String, bool)>,
@@ -147,6 +152,16 @@ impl<'i> AstVisitorMut<'i> for TypeOccurrenceCollector {
     }
 }
 
+impl<'i> AstVisitorMut<'i> for TypeSourceCollector {
+    fn visit_type(&mut self, type_ref: &silverscript_lang::ast::TypeRef, span: Span<'i>) {
+        self.occurrences.push((type_ref.type_name(), span.as_str().to_string()));
+    }
+
+    fn visit_span(&mut self, span: &mut Span<'i>) {
+        *span = Span::default();
+    }
+}
+
 impl<'i> AstVisitorMut<'i> for SyntheticMetadataCollector {
     fn visit_name(&mut self, name: &mut String, kind: NameKind, span: Span<'i>) {
         if kind == NameKind::AttributePathSegment {
@@ -195,6 +210,21 @@ fn composed_expression_spans_remain_syntactically_complete() {
         let expr = parse_expression_ast(source).unwrap_or_else(|err| panic!("`{source}` should parse: {err}"));
         assert_eq!(expr.span.as_str(), source, "composite expression span should be valid and complete");
     }
+}
+
+#[test]
+fn visits_as_cast_targets_as_types_before_mutating_their_spans() {
+    let source = "value as CounterState[]";
+    let mut expr = parse_expression_ast(source).expect("as-cast expression should parse");
+    let mut collector = TypeSourceCollector::default();
+
+    collector.visit_expr(&mut expr);
+
+    assert_eq!(collector.occurrences, vec![("CounterState[]".to_string(), "CounterState[]".to_string())]);
+    let ExprKind::Call { name_span, .. } = expr.kind else {
+        panic!("as cast should use the internal call representation");
+    };
+    assert!(name_span.as_str().is_empty(), "the stored cast type span must still be visited independently");
 }
 
 #[test]

--- a/silverscript-lang/tests/ast_spans_tests.rs
+++ b/silverscript-lang/tests/ast_spans_tests.rs
@@ -40,6 +40,7 @@ struct TypeOccurrenceCollector {
 #[derive(Default)]
 struct TypeSourceCollector {
     occurrences: Vec<(String, String)>,
+    call_targets: Vec<String>,
 }
 
 #[derive(Default)]
@@ -153,6 +154,12 @@ impl<'i> AstVisitorMut<'i> for TypeOccurrenceCollector {
 }
 
 impl<'i> AstVisitorMut<'i> for TypeSourceCollector {
+    fn visit_name(&mut self, name: &mut String, kind: NameKind, _span: Span<'i>) {
+        if kind == NameKind::CallTarget {
+            self.call_targets.push(name.clone());
+        }
+    }
+
     fn visit_type(&mut self, type_ref: &silverscript_lang::ast::TypeRef, span: Span<'i>) {
         self.occurrences.push((type_ref.type_name(), span.as_str().to_string()));
     }
@@ -221,6 +228,7 @@ fn visits_as_cast_targets_as_types_before_mutating_their_spans() {
     collector.visit_expr(&mut expr);
 
     assert_eq!(collector.occurrences, vec![("CounterState[]".to_string(), "CounterState[]".to_string())]);
+    assert!(collector.call_targets.is_empty(), "the internal cast name must not be exposed as a call target");
     let ExprKind::Call { name_span, .. } = expr.kind else {
         panic!("as cast should use the internal call representation");
     };


### PR DESCRIPTION
Classify the target of an `as` cast through `visit_type` instead of exposing its synthetic internal call name as a call target.

Preserve independent span traversal and add coverage for exact array-type spans and span mutation ordering.